### PR TITLE
fix(deps): update versioning template for pandoc in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,8 @@
       "depNameTemplate": "jgm/pandoc",
       "matchStrings": [
         "PANDOC_VERSION=(?<currentValue>.*)"
-      ]
+      ],
+      "versioningTemplate": "loose"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to include a versioning template for better control over dependency updates.

Configuration update:

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L16-R17): Added the `versioningTemplate` property with the value `"loose"` to the `depNameTemplate` rule for `jgm/pandoc`. This ensures more flexible version matching for the `PANDOC_VERSION` dependency.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
