### PR TITLE
fix: sonar issues

### DIFF
--- a/.sonarlint/connectedMode.json
+++ b/.sonarlint/connectedMode.json
@@ -1,0 +1,5 @@
+{
+    "sonarCloudOrganization": "schweizerischebundesbahnen",
+    "projectKey": "SchweizerischeBundesbahnen_pandoc-service",
+    "region": "EU"
+}

--- a/app/PandocController.py
+++ b/app/PandocController.py
@@ -169,20 +169,18 @@ async def get_docx_template():  # type: ignore
     path = Path(CUSTOM_REFERENCE_DOCX)
     try:
         # ruff: noqa: S603
-        try:
-            subprocess.run(
-                [
-                    PANDOC_PATH,
-                    "-o",
-                    "custom-reference.docx",
-                    "--print-default-data-file",
-                    "reference.docx",
-                ],
-                check=True,
-                shell=False,
-            )
-        except subprocess.SubprocessError as e:
-            return process_error(e, "An internal error has occurred while generating the template", 500)
+        proc = await anyio.run_process(
+            [
+                PANDOC_PATH,
+                "-o",
+                "custom-reference.docx",
+                "--print-default-data-file",
+                "reference.docx",
+            ],
+            check=True,
+        )
+        if proc.returncode != 0:
+            return process_error(Exception(f"Process failed with return code {proc.returncode}"), "An internal error has occurred while generating the template", 500)
 
         with path.open("rb") as f:
             doc_content = f.read()

--- a/app/PandocController.py
+++ b/app/PandocController.py
@@ -8,6 +8,7 @@ import time
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 
+import anyio
 import starlette.datastructures
 import uvicorn
 from fastapi import FastAPI, Request, Response
@@ -322,8 +323,8 @@ async def convert_docx_with_ref(request: Request, source_format: str, encoding: 
 
         if docx_template_file:
             temp_template_filename = f"ref_{int(time.time())}.docx"
-            with Path(temp_template_filename).open("wb") as f:
-                f.write(await docx_template_file.read())
+            async with await anyio.open_file(temp_template_filename, "wb") as f:
+                await f.write(await docx_template_file.read())
 
         # Build conversion options including template if provided
         options = DEFAULT_CONVERSION_OPTIONS.copy()

--- a/renovate.json
+++ b/renovate.json
@@ -47,6 +47,21 @@
       "matchUpdateTypes": [
         "major"
       ]
+    },
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "github-releases"
+      ],
+      "matchDepNames": [
+        "jgm/pandoc"
+      ],
+      "semanticCommitType": "fix",
+      "matchUpdateTypes": [
+        "patch"
+      ]
     }
   ]
 }

--- a/tests/arguments_parser.py
+++ b/tests/arguments_parser.py
@@ -7,7 +7,7 @@ def get_cli_arguments():
     parser.add_argument("-l", "--app_url", type=str, help="Application URL")
     parser.add_argument("--tc_image_name", type=str, help="Docker image name")
     parser.add_argument("--flush_tmp_files", type=str, help="Write intermediate temporary files to disk")
-    args, unknown = parser.parse_known_args()
+    args, _ = parser.parse_known_args()
     return args
 
 

--- a/tests/test_docx_post_process.py
+++ b/tests/test_docx_post_process.py
@@ -378,7 +378,6 @@ def test_resize_images_in_cell_resizing_needed():
 
     # Find the wp:extent element to use with the real function
     extent_element = tree.find(".//wp:extent", {"wp": "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"})
-    assert extent_element is not None
     assert extent_element.get("cx") == str(large_image_width)
     assert extent_element.get("cy") == str(large_image_height)
 

--- a/tests/test_pandoc_controller.py
+++ b/tests/test_pandoc_controller.py
@@ -819,7 +819,7 @@ def test_run_pandoc_conversion_with_valid_reference_doc():
 
         # Ensure subprocess.run was called with the correct arguments
         mock_subprocess.assert_called_once()
-        args, kwargs = mock_subprocess.call_args
+        args, _ = mock_subprocess.call_args
         cmd = args[0]
         assert valid_option in cmd
 
@@ -912,12 +912,17 @@ def test_process_error_with_multiline_message():
 def test_get_docx_template_with_path_handling():
     """Test get_docx_template with path existence handling."""
     with (
-        patch("subprocess.run"),
+        patch("anyio.run_process") as mock_run_process,
         patch("pathlib.Path.exists", side_effect=[False, True]),  # False for initial check, True for finally
         patch("pathlib.Path.unlink"),
         patch("pathlib.Path.open", create=True) as mock_path_open,
         patch("fastapi.responses.StreamingResponse") as mock_send_file,
     ):
+        # Mock the anyio.run_process to avoid calling the real pandoc
+        process_mock = MagicMock()
+        process_mock.returncode = 0
+        mock_run_process.return_value = process_mock
+
         # Mock file content
         mock_file = MagicMock()
         mock_file.read.return_value = b"Mock DOCX template content"


### PR DESCRIPTION
This pull request introduces several updates, including migrating subprocess calls to `anyio` for asynchronous process handling, adding SonarLint configuration, updating Renovate rules, and making minor improvements to tests and code readability. Below is a breakdown of the most significant changes:

### Migration to `anyio` for Async Process Handling:
* Replaced `subprocess.run` with `anyio.run_process` in `get_docx_template` for better asynchronous process management. Updated error handling to check the return code of the process. (`app/PandocController.py`, [[1]](diffhunk://#diff-63d3e24fb87cc1a29d8f48d85273a868f35ebcdcc26f48e21e7f73729352a662L171-R172) [[2]](diffhunk://#diff-63d3e24fb87cc1a29d8f48d85273a868f35ebcdcc26f48e21e7f73729352a662L181-R183)
* Updated file writing in `convert_docx_with_ref` to use `anyio.open_file` for asynchronous file operations. (`app/PandocController.py`, [app/PandocController.pyL325-R325](diffhunk://#diff-63d3e24fb87cc1a29d8f48d85273a868f35ebcdcc26f48e21e7f73729352a662L325-R325))

### Configuration Updates:
* Added a new SonarLint configuration file (`.sonarlint/connectedMode.json`) to enable integration with SonarCloud for code quality analysis.
* Updated `renovate.json` to include a custom rule for managing `jgm/pandoc` GitHub releases with semantic commit types for patch updates.

### Test Updates:
* Updated tests to mock `anyio.run_process` instead of `subprocess.run` and added a mock process object for testing `get_docx_template`. (`tests/test_pandoc_controller.py`, [tests/test_pandoc_controller.pyL915-R925](diffhunk://#diff-2594dad53eeb874750746bcb2cdcc5e8fd6a43e2108413c9f23eb3fa09f190fdL915-R925))
* Simplified test assertions and variable handling in `test_run_pandoc_conversion_with_valid_reference_doc`. (`tests/test_pandoc_controller.py`, [tests/test_pandoc_controller.pyL822-R822](diffhunk://#diff-2594dad53eeb874750746bcb2cdcc5e8fd6a43e2108413c9f23eb3fa09f190fdL822-R822))

### Code Readability Improvements:
* Removed unused variables in argument parsing in `tests/arguments_parser.py`.
* Removed redundant assertion in `test_resize_images_in_cell_resizing_needed` for improved clarity. (`tests/test_docx_post_process.py`, [tests/test_docx_post_process.pyL381](diffhunk://#diff-247f67a6185af2b53be884c2ef18b3d675c789cd7b5809c1e792d38db2ceae7bL381))

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
