### PR TITLE
fix: set max_part_size for form data requests

### DIFF
--- a/app/PandocController.py
+++ b/app/PandocController.py
@@ -307,7 +307,7 @@ def run_pandoc_conversion(source_data: str | bytes, source_format: str, target_f
 async def convert_docx_with_ref(request: Request, source_format: str, encoding: str | None = None, file_name: str = "converted-document.docx"):  # type: ignore
     temp_template_filename = None
     try:
-        form = await request.form()
+        form = await request.form(max_part_size=data_limit)
         source_content = form.get("source")
         source = await get_docx_source_data(source_content, encoding)
         if not source:
@@ -362,7 +362,7 @@ async def convert(request: Request, source_format: str, target_format: str, enco
             data = await request.body()
             source = data if not encoding else data.decode(encoding)
         else:
-            form = await request.form()
+            form = await request.form(max_part_size=data_limit)
             uploaded_file = form.get("source")
 
             try:


### PR DESCRIPTION
Refs: #64

### Proposed changes

This pull request introduces a minor but important update to the way form data is handled in the `PandocController`. The main change is the addition of a `max_part_size` parameter when parsing form data, which helps to control the maximum size of uploaded form parts and can prevent issues with excessively large uploads.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
