### PR TITLE
fix: patch XML parser to handle large documents

### DIFF
--- a/app/DocxPostProcess.py
+++ b/app/DocxPostProcess.py
@@ -199,7 +199,8 @@ def _get_available_content_width_for_section(section: Section) -> int:
 def _resize_images_in_cell(cell: _Cell, max_image_width: float) -> None:
     cell_xml = cell._tc.xml
     # ruff: noqa: S320
-    tree = etree.fromstring(cell_xml)
+    # Use huge_tree parser to handle cells with large content (e.g., base64-encoded images > 10MB)
+    tree = etree.fromstring(cell_xml, docx_parser.oxml_parser)
 
     # Find all <wp:extent> elements that define image size
     extent_elements = tree.findall(


### PR DESCRIPTION
### Proposed changes

Enables `XML_PARSE_HUGE` to prevent buffer size errors when processing large embedded images in tables in DOCX files.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
