### PR TITLE
feat: migrate pyproject.toml to PEP 621/735 standard format

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1680,4 +1680,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<3.14"
-content-hash = "a976ea5f8c2ecbf7a323b6abf4c0ca5dc131e7f075e7e94695a232165fd98f59"
+content-hash = "fd9115e30bdd573c38507f0d7b9ee905912b9288e1faa2779cb009ed654161a3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,52 +7,37 @@ authors = [
 ]
 license = "Apache License 2.0"
 readme = "README.md"
-requires-python=">=3.13,<3.14"
-dynamic = ["dependencies"]
-# Dependencies moved back to [tool.poetry.dependencies] for Renovate compatibility
-# See: https://github.com/renovatebot/renovate/issues/33509
-# TODO: Migrate back to [project.dependencies] when Renovate adds Poetry v2 support
-# dependencies = [
-#     "python-docx (==1.2.0)",
-#     "defusedxml (==0.7.1)",
-#     "uvicorn (==0.34.3)",
-#     "asgiref (==3.8.1)",
-#     "python-multipart (==0.0.20)",
-#     "fastapi (==0.115.12)",
-#     "requests==2.32.4",
-# ]
+requires-python = ">=3.13,<3.14"
+dependencies = [
+    "python-docx==1.2.0",
+    "python-pptx==1.0.2",
+    "fastapi==0.128.0",
+    "uvicorn==0.40.0",
+    "python-multipart==0.0.21",
+    "defusedxml==0.7.1",
+    "asgiref==3.11.0",
+]
+
+[dependency-groups]
+dev = [
+    "pre-commit==4.5.1",
+    "ruff==0.14.11",
+    "mypy==1.19.1",
+    "anyio==4.12.1",  # Explicit for mypy type checking (transitive from starlette)
+]
+test = [
+    "tox==4.34.1",
+    "docker==7.1.0",  # for debug source code for pytest --> see tox.ini section [testenv]
+    "pytest==9.0.2",
+    "pytest-mock==3.15.1",
+    "pytest-cov==7.0.0",
+    "pytest-timeout==2.4.0",
+    "httpx==0.28.1",
+    "coverage==7.13.1",
+]
 
 [tool.poetry]
 packages = [{include = "app"}]
-
-# this duplication and legacy format must be kept until Renovate support is added for [project.dependencies] for poetry-lock updates
-# for more information check comments above
-[tool.poetry.dependencies]
-python-docx = "1.2.0"
-python-pptx = "1.0.2"
-fastapi = "0.128.0"
-uvicorn = "0.40.0"
-python-multipart = "0.0.21"
-defusedxml = "0.7.1"
-asgiref = "3.11.0"
-starlette = "0.50.0"
-
-[tool.poetry.group.dev.dependencies]
-pre-commit = "4.5.1"
-ruff = "0.14.11"
-mypy = "1.19.1"
-anyio = "4.12.1"  # Explicit for mypy type checking (transitive from starlette)
-
-[tool.poetry.group.test.dependencies]
-tox = "4.34.1"
-# for debug source code for pytest --> see tox.ini section [testenv]
-docker = "7.1.0"
-pytest = "9.0.2"
-pytest-mock = "3.15.1"
-pytest-cov = "7.0.0"
-pytest-timeout = "2.4.0"
-httpx = "0.28.1"
-coverage = "7.13.1"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary
- Convert `[tool.poetry.dependencies]` → `[project.dependencies]` (PEP 621)
- Convert `[tool.poetry.group.*.dependencies]` → `[dependency-groups]` (PEP 735)
- Remove `dynamic = ["dependencies"]` workaround
- Remove starlette as explicit dep (transitive via FastAPI)

## Why This Approach?
Poetry 2.0+ supports PEP 621, Poetry 2.2+ supports PEP 735. This enables:
- **Renovate compatibility** with standard PEP formats
- **Future uv migration** becomes trivial (just swap lock file)
- **Standard format** readable by multiple tools

## Test Plan
- [x] `poetry lock` regenerates successfully
- [x] `poetry install` works
- [x] All 106 tests pass
- [x] Pre-commit hooks pass
- [ ] Verify Renovate can update dependencies after merge

Closes #100