### PR TITLE
feat: add PPTX and template endpoint tests to container integration tests

### DIFF
--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -202,8 +202,8 @@ def wait_for_container_ready(container: Container, max_wait_time: int = 60) -> N
             if response.status_code == 200:
                 logging.info("Container is ready")
                 return
-        except requests.exceptions.RequestException:
-            pass
+        except requests.exceptions.RequestException as e:
+            logging.debug(f"Container not ready yet, retrying: {e}")
         time.sleep(1)
 
     # Timeout reached, print logs for debugging
@@ -528,10 +528,10 @@ def test_convert_markdown_to_pptx(test_parameters: TestParameters) -> None:
     )
     assert response.status_code == 200
 
-    # Verify it's a valid PPTX
+    # Verify it's a valid PPTX with expected slide count
     presentation = Presentation(io.BytesIO(response.content))
     assert presentation is not None
-    assert len(presentation.slides) >= 1
+    assert len(presentation.slides) == 2, "Expected 2 slides from markdown with slide separator"
 
     # Check response headers
     assert "Pandoc-Version" in response.headers


### PR DESCRIPTION
## Summary

- Add comprehensive PPTX endpoint tests to container integration tests
- Add template endpoint tests for both DOCX and PPTX
- Replace `time.sleep(5)` with `wait_for_container_ready()` that polls `/version` endpoint
- Add error handling tests for invalid formats

## New Tests

| Test | Description |
|------|-------------|
| `test_container_no_error_logs` | Verify no ERROR/CRITICAL logs during startup |
| `test_docx_template_endpoint` | Test `GET /docx-template` returns valid DOCX |
| `test_pptx_template_endpoint` | Test `GET /pptx-template` returns valid PPTX |
| `test_convert_markdown_to_pptx` | Test markdown → PPTX conversion |
| `test_convert_with_pptx_template` | Test PPTX conversion with custom template |
| `test_convert_invalid_source_format` | Test error handling for invalid source format |
| `test_convert_invalid_target_format` | Test error handling for invalid target format |

## Test plan

- [x] All 15 container tests pass locally
- [x] CI pipeline passes

Closes #109