### PR TITLE
ci: add pull-requests:read to actionlint caller permissions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -13,3 +13,4 @@ jobs:
     permissions:
       checks: write
       contents: read
+      pull-requests: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,6 +11,7 @@ jobs:
   claude-review:
     uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-claude-code-review.yml@main  # zizmor: ignore[unpinned-uses]
     permissions:
+      actions: read
       contents: read
       pull-requests: write
       issues: write


### PR DESCRIPTION
## Summary
- Add `pull-requests: read` permission to the actionlint caller workflow, required by the upstream reusable workflow (`github-workflows-polarion#57`)

Closes #153

## Test plan
- [ ] Verify the actionlint workflow passes on this PR