### PR TITLE
fix: properly handle links during transformations of text formatting

### DIFF
--- a/filters/inline_styles.lua
+++ b/filters/inline_styles.lua
@@ -390,9 +390,16 @@ walk = function(inlines, props, vert_align)
       -- dropped here in favour of the inherited inline-CSS formatting.
       result[#result + 1] = emit_run(inline.text, props, vert_align)
     elseif t == "Link" then
-      -- Hyperlinks would need a relationship entry in word/_rels — we can't
-      -- create those from a Lua filter. Keep the link text and lose the URL.
-      append_all(result, walk(inline.content, props, vert_align))
+      -- Walk the link's content with the surrounding props so the styled
+      -- span's color/font/highlight apply to the link text too, then wrap
+      -- the walked runs back in a Link carrying the original target/title/
+      -- attr. Pandoc's DOCX writer turns that Link into <w:hyperlink> and
+      -- registers the relationship in word/_rels/document.xml.rels — we
+      -- get the relationship side-effect for free as long as we hand it a
+      -- Link node. Discarding the wrapper (the previous behaviour) kept
+      -- the visible text but dropped the click target entirely.
+      local walked = walk(inline.content, props, vert_align)
+      result[#result + 1] = pandoc.Link(walked, inline.target, inline.title, inline.attr)
     elseif t == "Image" then
       -- Images are embedded by Pandoc's DOCX writer as <w:drawing> with a
       -- relationship in word/_rels/document.xml.rels — that pipeline isn't

--- a/tests/test_inline_styles_filter_integration.py
+++ b/tests/test_inline_styles_filter_integration.py
@@ -1,0 +1,112 @@
+"""End-to-end integration tests for filters/inline_styles.lua.
+
+These tests invoke a real `pandoc` binary with the lua filter loaded, then
+inspect the resulting DOCX package. They skip cleanly when pandoc is not on
+PATH so unit-test runs on dev machines without pandoc are unaffected.
+
+Why an integration test (vs. mocked unit tests):
+    The other tests for this filter mock subprocess.run and only verify that
+    the right --lua-filter argument is added to the command line. They cannot
+    catch regressions where the filter still loads but produces AST that
+    pandoc's DOCX writer no longer renders correctly — for example, a future
+    pandoc version changing how RawInline children of a Link node propagate
+    into <w:hyperlink>, or a filter edit that drops the Link wrapper. This
+    file plugs that gap with a single, focused round-trip assertion.
+"""
+
+import shutil
+import subprocess
+import tempfile
+import zipfile
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+import pytest
+
+PANDOC = shutil.which("pandoc")
+FILTER_PATH = Path(__file__).resolve().parents[1] / "filters" / "inline_styles.lua"
+
+W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+R_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+PKG_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+
+pytestmark = pytest.mark.skipif(
+    PANDOC is None or not FILTER_PATH.exists(),
+    reason="pandoc binary or filters/inline_styles.lua not available",
+)
+
+
+def _convert_html_to_docx(html: str, output_path: Path) -> None:
+    """Run pandoc directly with the local filter file. Surfaces pandoc's
+    stderr verbatim if it fails, since lua errors land there."""
+    src_path = output_path.with_suffix(".html")
+    src_path.write_text(html, encoding="utf-8")
+    result = subprocess.run(
+        [
+            PANDOC,
+            "-f",
+            "html",
+            "-t",
+            "docx",
+            f"--lua-filter={FILTER_PATH}",
+            "-o",
+            str(output_path),
+            str(src_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"pandoc failed (exit {result.returncode}):\n{result.stderr}")
+
+
+def test_hyperlink_inside_styled_span_survives_filter():
+    """Regression: <a> inside a styled <span> must remain clickable.
+
+    Catches two failure modes:
+      1. Filter dropping the Link wrapper -> no <w:hyperlink> in document.xml,
+         no Relationship entry in word/_rels/document.xml.rels (the bug we
+         just fixed in filters/inline_styles.lua walk()'s Link branch).
+      2. Filter passing the Link through unchanged without re-walking its
+         content -> link works but inner runs lack the surrounding span's
+         color, defeating the walk-and-rewrap design.
+
+    A future pandoc version that changes how RawInline children inside a
+    Link node propagate into <w:hyperlink> would also surface here.
+    """
+    html = '<p><span style="color:#FF0000;"><a href="https://example.com/test">click here</a></span></p>'
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir) / "out.docx"
+        _convert_html_to_docx(html, out)
+        with zipfile.ZipFile(out) as zf:
+            doc_xml = zf.read("word/document.xml")
+            rels_xml = zf.read("word/_rels/document.xml.rels")
+
+    doc = ET.fromstring(doc_xml)
+    rels = ET.fromstring(rels_xml)
+
+    # 1. <w:hyperlink> exists at all (proves the Link wrapper was preserved).
+    hyperlink = doc.find(f".//{{{W_NS}}}hyperlink")
+    assert hyperlink is not None, f"no <w:hyperlink> in document.xml — filter dropped the Link node\ndocument.xml head: {doc_xml[:1500]!r}"
+
+    rid = hyperlink.get(f"{{{R_NS}}}id")
+    assert rid, "hyperlink element has no r:id"
+
+    # 2. The hyperlink's runs carry the surrounding span's color. This is the
+    #    walk-and-rewrap part: a naive pass-through Link would emit default
+    #    styling, but we want the outer span's red to apply to link text.
+    color_vals = [c.get(f"{{{W_NS}}}val") for c in hyperlink.findall(f".//{{{W_NS}}}color")]
+    assert "FF0000" in color_vals, f"hyperlink runs do not carry FF0000 (found colors: {color_vals}) — walk-and-rewrap regression in filters/inline_styles.lua Link branch"
+
+    # 3. Link text survived.
+    text = "".join(t.text or "" for t in hyperlink.iter(f"{{{W_NS}}}t"))
+    assert "click here" in text, f"link text missing from hyperlink runs: {text!r}"
+
+    # 4. The matching relationship targets the original href as External.
+    rel = rels.find(f".//{{{PKG_NS}}}Relationship[@Id='{rid}']")
+    assert rel is not None, f"no Relationship for {rid} in word/_rels/document.xml.rels — the relationship side-effect that pandoc creates from a Link node did not fire (Link AST node was probably dropped before the writer saw it)"
+    assert rel.get("Target") == "https://example.com/test", f"hyperlink relationship Target mismatch: {rel.get('Target')!r}"
+    assert rel.get("TargetMode") == "External", f"hyperlink relationship TargetMode mismatch: {rel.get('TargetMode')!r}"
+    assert rel.get("Type", "").endswith("/hyperlink"), f"unexpected Relationship Type: {rel.get('Type')!r}"


### PR DESCRIPTION
Fixes #158

### Proposed changes

Previously implementing a feature of migrating inlined styles from HTML to DOCX an issue was introduced that hyperlinks link were removed leaving only icons/text of them. This PR fixes this.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
