### PR TITLE
fix: add filter to preserve alignment of paragraphs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,8 @@ COPY filters/page_orientation.lua "/usr/local/share/pandoc/filters/page_orientat
 COPY filters/heading_levels.lua "/usr/local/share/pandoc/filters/heading_levels.lua"
 COPY filters/inline_styles.lua "/usr/local/share/pandoc/filters/inline_styles.lua"
 COPY filters/docx_colors_to_latex.lua "/usr/local/share/pandoc/filters/docx_colors_to_latex.lua"
+COPY filters/docx_paragraphs_to_latex.lua "/usr/local/share/pandoc/filters/docx_paragraphs_to_latex.lua"
+COPY filters/docx_lists_to_latex.lua "/usr/local/share/pandoc/filters/docx_lists_to_latex.lua"
 COPY filters/html_lists.lua "/usr/local/share/pandoc/filters/html_lists.lua"
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \

--- a/app/DocxColorPreProcess.py
+++ b/app/DocxColorPreProcess.py
@@ -29,84 +29,19 @@ Limitations
 
 from __future__ import annotations
 
-import io
 import logging
-import zipfile
-from typing import TYPE_CHECKING
 from xml.etree import ElementTree as ET
 
 from defusedxml import ElementTree as DefusedET
 
-if TYPE_CHECKING:
-    from collections.abc import Iterable
+from .docx_ooxml import STYLES_PART, W_NS, enumerate_body_parts, read_entries, repack
 
 logger = logging.getLogger(__name__)
 
-W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-
-# Well-known OOXML namespaces. ElementTree's default behavior on serialize
-# is to mint synthetic prefixes (ns0, ns1, ...) for every namespace it
-# wasn't told about — fine for round-tripping inside ET, but DOCX readers
-# (notably pandoc's docx reader) match drawing/relationship/etc. elements
-# on the canonical prefix rather than the URI. When wp:/a:/pic:/r: get
-# renamed to ns1:/ns2:/..., pandoc silently drops every <w:drawing> in
-# the file and images disappear from the output. Registering the
-# canonical prefixes globally tells ET to preserve them on serialize.
-_OOXML_NAMESPACES = {
-    "w": W_NS,
-    "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "m": "http://schemas.openxmlformats.org/officeDocument/2006/math",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "o": "urn:schemas-microsoft-com:office:office",
-    "v": "urn:schemas-microsoft-com:vml",
-    "w10": "urn:schemas-microsoft-com:office:word",
-    "wp": "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "a": "http://schemas.openxmlformats.org/drawingml/2006/main",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "pic": "http://schemas.openxmlformats.org/drawingml/2006/picture",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "mc": "http://schemas.openxmlformats.org/markup-compatibility/2006",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "w14": "http://schemas.microsoft.com/office/word/2010/wordml",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "w15": "http://schemas.microsoft.com/office/word/2012/wordml",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "w16se": "http://schemas.microsoft.com/office/word/2015/wordml/symex",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "wp14": "http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "wpc": "http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "wpg": "http://schemas.microsoft.com/office/word/2010/wordprocessingGroup",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "wpi": "http://schemas.microsoft.com/office/word/2010/wordprocessingInk",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "wps": "http://schemas.microsoft.com/office/word/2010/wordprocessingShape",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "wne": "http://schemas.microsoft.com/office/word/2006/wordml",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-}
-for _prefix, _uri in _OOXML_NAMESPACES.items():
-    ET.register_namespace(_prefix, _uri)
-
-STYLES_PART = "word/styles.xml"
 STYLE_PREFIX = "PandocColor"
 SEGMENT_SEPARATOR = "__"
 HEX_COLOR_LENGTH = 6
 _HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
-
-# Parts that can contain <w:r> runs we need to rewrite. Theme / numbering
-# / settings parts cannot carry runs and are skipped.
-_FIXED_BODY_PARTS = frozenset(
-    {
-        "word/document.xml",
-        "word/footnotes.xml",
-        "word/endnotes.xml",
-        "word/comments.xml",
-    }
-)
-
-
-def _enumerate_body_parts(names: Iterable[str]) -> list[str]:
-    """Return zip entry names that may contain runs to rewrite.
-
-    Headers and footers live in numbered parts (``word/header1.xml``,
-    ``word/footer2.xml``, ...) — the count and naming depend on how many
-    sections the document defines — so they can't be enumerated by a
-    fixed name list and have to be matched by prefix + ``.xml`` suffix.
-    """
-    result = []
-    for name in names:
-        if name in _FIXED_BODY_PARTS or (name.startswith(("word/header", "word/footer")) and name.endswith(".xml")):
-            result.append(name)
-    return result
 
 
 def preprocess(docx_bytes: bytes) -> bytes:
@@ -118,10 +53,8 @@ def preprocess(docx_bytes: bytes) -> bytes:
     # under the 200MB request cap and a full in-memory dict keeps the
     # rewrite loop simple — we mutate body parts in place and then
     # re-zip from the same dict at the end.
-    try:
-        with zipfile.ZipFile(io.BytesIO(docx_bytes), "r") as zin:
-            entries = {name: zin.read(name) for name in zin.namelist()}
-    except zipfile.BadZipFile:
+    entries = read_entries(docx_bytes)
+    if entries is None:
         logger.warning("Input is not a valid zip / DOCX; skipping color preprocess")
         return docx_bytes
 
@@ -131,16 +64,12 @@ def preprocess(docx_bytes: bytes) -> bytes:
         logger.debug("DOCX has no %s; skipping color preprocess", STYLES_PART)
         return docx_bytes
 
-    body_parts = _enumerate_body_parts(entries.keys())
-    if not body_parts:
-        return docx_bytes
-
     # Collected across all body parts and deduplicated by style_id so
     # styles.xml gets one <w:style> per unique fg/bg/highlight combo even
     # if many runs reference it.
     needed_styles: dict[str, _StyleSpec] = {}
 
-    for part in body_parts:
+    for part in enumerate_body_parts(entries.keys()):
         rewritten, part_styles = _rewrite_part(entries[part])
         if part_styles:
             entries[part] = rewritten
@@ -153,12 +82,7 @@ def preprocess(docx_bytes: bytes) -> bytes:
         return docx_bytes
 
     entries[STYLES_PART] = _augment_styles(entries[STYLES_PART], needed_styles)
-
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zout:
-        for name, data in entries.items():
-            zout.writestr(name, data)
-    return buf.getvalue()
+    return repack(entries)
 
 
 class _StyleSpec:

--- a/app/DocxColorPreProcess.py
+++ b/app/DocxColorPreProcess.py
@@ -32,9 +32,7 @@ from __future__ import annotations
 import logging
 from xml.etree import ElementTree as ET
 
-from defusedxml import ElementTree as DefusedET
-
-from .docx_ooxml import STYLES_PART, W_NS, enumerate_body_parts, read_entries, repack
+from .docx_ooxml import STYLES_PART, W_NS, augment_styles, enumerate_body_parts, parse_xml, read_entries, repack, serialize_tree
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +79,7 @@ def preprocess(docx_bytes: bytes) -> bytes:
     if not needed_styles:
         return docx_bytes
 
-    entries[STYLES_PART] = _augment_styles(entries[STYLES_PART], needed_styles)
+    entries[STYLES_PART] = augment_styles(entries[STYLES_PART], needed_styles, _build_style_element)
     return repack(entries)
 
 
@@ -183,11 +181,8 @@ def _replace_run_color_props(rpr: ET.Element, style_id: str) -> None:
 
 def _rewrite_part(xml_bytes: bytes) -> tuple[bytes, dict[str, _StyleSpec]]:
     """Rewrite one body part. Returns (new_bytes, styles_used)."""
-    # defusedxml's fromstring blocks XXE / billion-laughs; we still serialize
-    # with stdlib ET because defusedxml deliberately doesn't expose tostring.
-    try:
-        tree = DefusedET.fromstring(xml_bytes)
-    except ET.ParseError:
+    tree = parse_xml(xml_bytes)
+    if tree is None:
         logger.warning("Unparseable XML in DOCX part; skipping")
         return xml_bytes, {}
 
@@ -216,8 +211,7 @@ def _rewrite_part(xml_bytes: bytes) -> tuple[bytes, dict[str, _StyleSpec]]:
     if not styles_used:
         return xml_bytes, {}
 
-    new_xml = ET.tostring(tree, xml_declaration=True, encoding="UTF-8")
-    return new_xml, styles_used
+    return serialize_tree(tree), styles_used
 
 
 def _normalize_hex(value: str | None) -> str | None:
@@ -245,45 +239,6 @@ def _normalize_hex(value: str | None) -> str | None:
     if len(stripped) == HEX_COLOR_LENGTH and all(c in _HEX_DIGITS for c in stripped):
         return stripped.upper()
     return None
-
-
-def _augment_styles(styles_xml: bytes, specs: dict[str, _StyleSpec]) -> bytes:
-    """Insert <w:style> entries for each spec into word/styles.xml, idempotently.
-
-    The fragment we add looks like::
-
-        <w:style w:type="character" w:customStyle="1" w:styleId="PandocColor__FG_FF0000">
-            <w:name w:val="PandocColor__FG_FF0000"/>
-            <w:rPr>
-                <w:color w:val="FF0000"/>
-            </w:rPr>
-        </w:style>
-
-    Adding the matching ``<w:rPr>`` keeps the style usable when the
-    intermediate DOCX is inspected manually; pandoc only consumes the
-    ``w:styleId`` and ``w:name``.
-    """
-    try:
-        tree = DefusedET.fromstring(styles_xml)
-    except ET.ParseError:
-        logger.warning("Unparseable %s; skipping style augmentation", STYLES_PART)
-        return styles_xml
-
-    # Collect existing styleIds to make this idempotent: if the document
-    # has already been preprocessed (or genuinely defined a style with
-    # the same name) we must not append a duplicate <w:style> — Word
-    # rejects styles.xml with two entries sharing the same styleId.
-    existing_ids = {el.get(f"{{{W_NS}}}styleId") for el in tree.findall(f"{{{W_NS}}}style")}
-
-    for spec in specs.values():
-        if spec.style_id in existing_ids:
-            continue
-        # Appending to the root <w:styles> element is sufficient — style
-        # order in styles.xml has no semantic meaning, only the styleId
-        # link from runs matters.
-        tree.append(_build_style_element(spec))
-
-    return ET.tostring(tree, xml_declaration=True, encoding="UTF-8")
 
 
 def _build_style_element(spec: _StyleSpec) -> ET.Element:

--- a/app/DocxListLevelPreProcess.py
+++ b/app/DocxListLevelPreProcess.py
@@ -30,9 +30,7 @@ from __future__ import annotations
 import logging
 from xml.etree import ElementTree as ET
 
-from defusedxml import ElementTree as DefusedET
-
-from .docx_ooxml import W_NS, enumerate_body_parts, read_entries, repack
+from .docx_ooxml import W_NS, enumerate_body_parts, parse_xml, read_entries, repack, serialize_tree
 
 logger = logging.getLogger(__name__)
 
@@ -119,9 +117,8 @@ def _make_sentinel_run(level: int) -> ET.Element:
 
 def _rewrite_part(xml_bytes: bytes) -> tuple[bytes, bool]:
     """Tag every list paragraph in one body part. Returns (new_bytes, changed)."""
-    try:
-        tree = DefusedET.fromstring(xml_bytes)
-    except ET.ParseError:
+    tree = parse_xml(xml_bytes)
+    if tree is None:
         logger.warning("Unparseable XML in DOCX part; skipping")
         return xml_bytes, False
 
@@ -146,4 +143,4 @@ def _rewrite_part(xml_bytes: bytes) -> tuple[bytes, bool]:
     if not changed:
         return xml_bytes, False
 
-    return ET.tostring(tree, xml_declaration=True, encoding="UTF-8"), True
+    return serialize_tree(tree), True

--- a/app/DocxListLevelPreProcess.py
+++ b/app/DocxListLevelPreProcess.py
@@ -1,0 +1,210 @@
+"""Tag list-paragraph indent levels in a DOCX so they survive into LaTeX/PDF.
+
+Polarion allows malformed lists where a deeper level is nested directly inside
+a shallower one with no intermediate item (e.g. a level-3 ``<ol>`` straight
+inside a level-1 list). The DOCX is fine — each paragraph carries its absolute
+``<w:numPr>/<w:ilvl>`` and Word indents by level — but pandoc's DOCX reader
+**flattens skipped levels** when it reconstructs nested lists, so a level-3
+item with no level-2 item before it collapses to the same nesting depth (and
+therefore the same indentation) as level 2 in the PDF output.
+
+The true level lives only in ``<w:ilvl>`` and is gone once pandoc has read the
+file, so this preprocessor runs *before* pandoc and prepends a sentinel run to
+every list paragraph encoding its level::
+
+    <ilvl>
+
+The sentinel survives into the AST as a leading ``Str`` on the list item. The
+companion Lua filter (``filters/docx_lists_to_latex.lua``) reads the level,
+strips the sentinel, and pushes any under-nested sublist to its intended depth
+with marker-less wrapper levels. The Private-Use-Area delimiters never collide
+with real document text.
+
+This is the list-level companion to :mod:`app.DocxColorPreProcess` /
+:mod:`app.DocxParagraphPreProcess`; it runs on the same docx→latex path and is
+independent of them (list paragraphs carry ``<w:numPr>``, not colour/jc/ind).
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import zipfile
+from typing import TYPE_CHECKING
+from xml.etree import ElementTree as ET
+
+from defusedxml import ElementTree as DefusedET
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+logger = logging.getLogger(__name__)
+
+W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+
+# Canonical OOXML prefixes — see app/DocxColorPreProcess.py for why registering
+# these is required (otherwise ElementTree renames drawing namespaces on
+# serialize and pandoc drops every <w:drawing>, losing images).
+_OOXML_NAMESPACES = {
+    "w": W_NS,
+    "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "m": "http://schemas.openxmlformats.org/officeDocument/2006/math",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "o": "urn:schemas-microsoft-com:office:office",
+    "v": "urn:schemas-microsoft-com:vml",
+    "w10": "urn:schemas-microsoft-com:office:word",
+    "wp": "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "a": "http://schemas.openxmlformats.org/drawingml/2006/main",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "pic": "http://schemas.openxmlformats.org/drawingml/2006/picture",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "mc": "http://schemas.openxmlformats.org/markup-compatibility/2006",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "w14": "http://schemas.microsoft.com/office/word/2010/wordml",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "w15": "http://schemas.microsoft.com/office/word/2012/wordml",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "w16se": "http://schemas.microsoft.com/office/word/2015/wordml/symex",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "wp14": "http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "wpc": "http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "wpg": "http://schemas.microsoft.com/office/word/2010/wordprocessingGroup",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "wpi": "http://schemas.microsoft.com/office/word/2010/wordprocessingInk",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "wps": "http://schemas.microsoft.com/office/word/2010/wordprocessingShape",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "wne": "http://schemas.microsoft.com/office/word/2006/wordml",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+}
+for _prefix, _uri in _OOXML_NAMESPACES.items():
+    ET.register_namespace(_prefix, _uri)
+
+# Private-Use-Area delimiters wrapping the decimal level, e.g. "2".
+# The Lua filter matches the same shape. PUA code points never appear in real
+# document text, so the sentinel is unambiguous and safe to strip.
+SENTINEL_OPEN = ""
+SENTINEL_CLOSE = ""
+
+_FIXED_BODY_PARTS = frozenset(
+    {
+        "word/document.xml",
+        "word/footnotes.xml",
+        "word/endnotes.xml",
+        "word/comments.xml",
+    }
+)
+
+_P_TAG = f"{{{W_NS}}}p"
+_PPR_TAG = f"{{{W_NS}}}pPr"
+_NUMPR_TAG = f"{{{W_NS}}}numPr"
+_ILVL_TAG = f"{{{W_NS}}}ilvl"
+_R_TAG = f"{{{W_NS}}}r"
+_T_TAG = f"{{{W_NS}}}t"
+_VAL_ATTR = f"{{{W_NS}}}val"
+_SPACE_ATTR = "{http://www.w3.org/XML/1998/namespace}space"
+
+
+def _enumerate_body_parts(names: Iterable[str]) -> list[str]:
+    """Return zip entry names that may contain list paragraphs to tag."""
+    result = []
+    for name in names:
+        if name in _FIXED_BODY_PARTS or (name.startswith(("word/header", "word/footer")) and name.endswith(".xml")):
+            result.append(name)
+    return result
+
+
+def preprocess(docx_bytes: bytes) -> bytes:
+    """Return a DOCX with each list paragraph's ``<w:ilvl>`` prepended as a
+    sentinel run. Returns the input unchanged when there are no list paragraphs
+    or the package is not a recognizable DOCX.
+    """
+    try:
+        with zipfile.ZipFile(io.BytesIO(docx_bytes), "r") as zin:
+            entries = {name: zin.read(name) for name in zin.namelist()}
+    except zipfile.BadZipFile:
+        logger.warning("Input is not a valid zip / DOCX; skipping list-level preprocess")
+        return docx_bytes
+
+    body_parts = _enumerate_body_parts(entries.keys())
+    if not body_parts:
+        return docx_bytes
+
+    changed = False
+    for part in body_parts:
+        rewritten, part_changed = _rewrite_part(entries[part])
+        if part_changed:
+            entries[part] = rewritten
+            changed = True
+
+    if not changed:
+        return docx_bytes
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zout:
+        for name, data in entries.items():
+            zout.writestr(name, data)
+    return buf.getvalue()
+
+
+def _list_level(ppr: ET.Element) -> int | None:
+    """Return the ``<w:ilvl>`` value of a list paragraph, or None when the
+    paragraph is not a numbered/bulleted list item.
+    """
+    numpr = ppr.find(_NUMPR_TAG)
+    if numpr is None:
+        return None
+    ilvl = numpr.find(_ILVL_TAG)
+    # A list paragraph without an explicit <w:ilvl> defaults to level 0.
+    if ilvl is None:
+        return 0
+    raw = ilvl.get(_VAL_ATTR)
+    if raw is None:
+        return 0
+    try:
+        value = int(raw)
+    except ValueError:
+        return None
+    return value if value >= 0 else None
+
+
+def _already_tagged(para: ET.Element) -> bool:
+    """True if the paragraph's first run already carries a sentinel (so a second
+    preprocess pass is a no-op)."""
+    for child in para:
+        if child.tag == _R_TAG:
+            text_el = child.find(_T_TAG)
+            text = text_el.text if text_el is not None else None
+            return bool(text and text.startswith(SENTINEL_OPEN))
+        if child.tag != _PPR_TAG:
+            # Some other leading element (e.g. bookmark) — not our sentinel run.
+            return False
+    return False
+
+
+def _make_sentinel_run(level: int) -> ET.Element:
+    run = ET.Element(_R_TAG)
+    text = ET.SubElement(run, _T_TAG, {_SPACE_ATTR: "preserve"})
+    text.text = f"{SENTINEL_OPEN}{level}{SENTINEL_CLOSE}"
+    return run
+
+
+def _rewrite_part(xml_bytes: bytes) -> tuple[bytes, bool]:
+    """Tag every list paragraph in one body part. Returns (new_bytes, changed)."""
+    try:
+        tree = DefusedET.fromstring(xml_bytes)
+    except ET.ParseError:
+        logger.warning("Unparseable XML in DOCX part; skipping")
+        return xml_bytes, False
+
+    changed = False
+    for para in tree.iter(_P_TAG):
+        ppr = para.find(_PPR_TAG)
+        if ppr is None:
+            continue
+        level = _list_level(ppr)
+        if level is None:
+            continue
+        if _already_tagged(para):
+            # Idempotent: a previous pass already prepended a sentinel run.
+            continue
+        # Insert the sentinel run as the first run of the paragraph, after the
+        # <w:pPr> (which must stay the first child of <w:p>). list(para) keeps
+        # document order; pPr is index 0 when present.
+        insert_at = 1 if list(para)[0] is ppr else 0
+        para.insert(insert_at, _make_sentinel_run(level))
+        changed = True
+
+    if not changed:
+        return xml_bytes, False
+
+    return ET.tostring(tree, xml_declaration=True, encoding="UTF-8"), True

--- a/app/DocxListLevelPreProcess.py
+++ b/app/DocxListLevelPreProcess.py
@@ -134,9 +134,8 @@ def _rewrite_part(xml_bytes: bytes) -> tuple[bytes, bool]:
             # Idempotent: a previous pass already prepended a sentinel run.
             continue
         # Insert the sentinel run as the first run of the paragraph, after the
-        # <w:pPr> (which must stay the first child of <w:p>). list(para) keeps
-        # document order; pPr is index 0 when present.
-        insert_at = 1 if list(para)[0] is ppr else 0
+        # <w:pPr> (which must stay the first child of <w:p>) when present.
+        insert_at = 1 if next(iter(para)) is ppr else 0
         para.insert(insert_at, _make_sentinel_run(level))
         changed = True
 

--- a/app/DocxListLevelPreProcess.py
+++ b/app/DocxListLevelPreProcess.py
@@ -27,62 +27,20 @@ independent of them (list paragraphs carry ``<w:numPr>``, not colour/jc/ind).
 
 from __future__ import annotations
 
-import io
 import logging
-import zipfile
-from typing import TYPE_CHECKING
 from xml.etree import ElementTree as ET
 
 from defusedxml import ElementTree as DefusedET
 
-if TYPE_CHECKING:
-    from collections.abc import Iterable
+from .docx_ooxml import W_NS, enumerate_body_parts, read_entries, repack
 
 logger = logging.getLogger(__name__)
-
-W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-
-# Canonical OOXML prefixes — see app/DocxColorPreProcess.py for why registering
-# these is required (otherwise ElementTree renames drawing namespaces on
-# serialize and pandoc drops every <w:drawing>, losing images).
-_OOXML_NAMESPACES = {
-    "w": W_NS,
-    "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "m": "http://schemas.openxmlformats.org/officeDocument/2006/math",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "o": "urn:schemas-microsoft-com:office:office",
-    "v": "urn:schemas-microsoft-com:vml",
-    "w10": "urn:schemas-microsoft-com:office:word",
-    "wp": "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "a": "http://schemas.openxmlformats.org/drawingml/2006/main",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "pic": "http://schemas.openxmlformats.org/drawingml/2006/picture",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "mc": "http://schemas.openxmlformats.org/markup-compatibility/2006",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "w14": "http://schemas.microsoft.com/office/word/2010/wordml",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "w15": "http://schemas.microsoft.com/office/word/2012/wordml",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "w16se": "http://schemas.microsoft.com/office/word/2015/wordml/symex",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "wp14": "http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "wpc": "http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "wpg": "http://schemas.microsoft.com/office/word/2010/wordprocessingGroup",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "wpi": "http://schemas.microsoft.com/office/word/2010/wordprocessingInk",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "wps": "http://schemas.microsoft.com/office/word/2010/wordprocessingShape",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "wne": "http://schemas.microsoft.com/office/word/2006/wordml",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-}
-for _prefix, _uri in _OOXML_NAMESPACES.items():
-    ET.register_namespace(_prefix, _uri)
 
 # Private-Use-Area delimiters wrapping the decimal level, e.g. "2".
 # The Lua filter matches the same shape. PUA code points never appear in real
 # document text, so the sentinel is unambiguous and safe to strip.
 SENTINEL_OPEN = ""
 SENTINEL_CLOSE = ""
-
-_FIXED_BODY_PARTS = frozenset(
-    {
-        "word/document.xml",
-        "word/footnotes.xml",
-        "word/endnotes.xml",
-        "word/comments.xml",
-    }
-)
 
 _P_TAG = f"{{{W_NS}}}p"
 _PPR_TAG = f"{{{W_NS}}}pPr"
@@ -94,33 +52,18 @@ _VAL_ATTR = f"{{{W_NS}}}val"
 _SPACE_ATTR = "{http://www.w3.org/XML/1998/namespace}space"
 
 
-def _enumerate_body_parts(names: Iterable[str]) -> list[str]:
-    """Return zip entry names that may contain list paragraphs to tag."""
-    result = []
-    for name in names:
-        if name in _FIXED_BODY_PARTS or (name.startswith(("word/header", "word/footer")) and name.endswith(".xml")):
-            result.append(name)
-    return result
-
-
 def preprocess(docx_bytes: bytes) -> bytes:
     """Return a DOCX with each list paragraph's ``<w:ilvl>`` prepended as a
     sentinel run. Returns the input unchanged when there are no list paragraphs
     or the package is not a recognizable DOCX.
     """
-    try:
-        with zipfile.ZipFile(io.BytesIO(docx_bytes), "r") as zin:
-            entries = {name: zin.read(name) for name in zin.namelist()}
-    except zipfile.BadZipFile:
+    entries = read_entries(docx_bytes)
+    if entries is None:
         logger.warning("Input is not a valid zip / DOCX; skipping list-level preprocess")
         return docx_bytes
 
-    body_parts = _enumerate_body_parts(entries.keys())
-    if not body_parts:
-        return docx_bytes
-
     changed = False
-    for part in body_parts:
+    for part in enumerate_body_parts(entries.keys()):
         rewritten, part_changed = _rewrite_part(entries[part])
         if part_changed:
             entries[part] = rewritten
@@ -129,11 +72,7 @@ def preprocess(docx_bytes: bytes) -> bytes:
     if not changed:
         return docx_bytes
 
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zout:
-        for name, data in entries.items():
-            zout.writestr(name, data)
-    return buf.getvalue()
+    return repack(entries)
 
 
 def _list_level(ppr: ET.Element) -> int | None:

--- a/app/DocxParagraphPreProcess.py
+++ b/app/DocxParagraphPreProcess.py
@@ -35,50 +35,15 @@ Limitations
 
 from __future__ import annotations
 
-import io
 import logging
-import zipfile
-from typing import TYPE_CHECKING
 from xml.etree import ElementTree as ET
 
 from defusedxml import ElementTree as DefusedET
 
-if TYPE_CHECKING:
-    from collections.abc import Iterable
+from .docx_ooxml import STYLES_PART, W_NS, enumerate_body_parts, read_entries, repack
 
 logger = logging.getLogger(__name__)
 
-W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-
-# Canonical OOXML prefixes. ElementTree mints synthetic prefixes (ns0, ns1, …)
-# for namespaces it wasn't told about, which makes pandoc's docx reader drop
-# every <w:drawing> (images vanish). Registering the canonical prefixes keeps
-# them on serialize. See app/DocxColorPreProcess.py for the full rationale.
-_OOXML_NAMESPACES = {
-    "w": W_NS,
-    "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "m": "http://schemas.openxmlformats.org/officeDocument/2006/math",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "o": "urn:schemas-microsoft-com:office:office",
-    "v": "urn:schemas-microsoft-com:vml",
-    "w10": "urn:schemas-microsoft-com:office:word",
-    "wp": "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "a": "http://schemas.openxmlformats.org/drawingml/2006/main",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "pic": "http://schemas.openxmlformats.org/drawingml/2006/picture",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "mc": "http://schemas.openxmlformats.org/markup-compatibility/2006",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "w14": "http://schemas.microsoft.com/office/word/2010/wordml",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "w15": "http://schemas.microsoft.com/office/word/2012/wordml",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "w16se": "http://schemas.microsoft.com/office/word/2015/wordml/symex",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "wp14": "http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "wpc": "http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "wpg": "http://schemas.microsoft.com/office/word/2010/wordprocessingGroup",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "wpi": "http://schemas.microsoft.com/office/word/2010/wordprocessingInk",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "wps": "http://schemas.microsoft.com/office/word/2010/wordprocessingShape",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-    "wne": "http://schemas.microsoft.com/office/word/2006/wordml",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
-}
-for _prefix, _uri in _OOXML_NAMESPACES.items():
-    ET.register_namespace(_prefix, _uri)
-
-STYLES_PART = "word/styles.xml"
 STYLE_PREFIX = "PandocPara"
 SEGMENT_SEPARATOR = "__"
 
@@ -99,15 +64,6 @@ _ALIGN_MAP: dict[str, str | None] = {
     "distribute": None,
 }
 
-_FIXED_BODY_PARTS = frozenset(
-    {
-        "word/document.xml",
-        "word/footnotes.xml",
-        "word/endnotes.xml",
-        "word/comments.xml",
-    }
-)
-
 _P_TAG = f"{{{W_NS}}}p"
 _TC_TAG = f"{{{W_NS}}}tc"
 _PPR_TAG = f"{{{W_NS}}}pPr"
@@ -118,28 +74,13 @@ _VAL_ATTR = f"{{{W_NS}}}val"
 _LEFT_ATTR = f"{{{W_NS}}}left"
 
 
-def _enumerate_body_parts(names: Iterable[str]) -> list[str]:
-    """Return zip entry names that may contain paragraphs to rewrite.
-
-    Headers/footers live in numbered parts (``word/header1.xml`` …) whose count
-    depends on the section layout, so they're matched by prefix + ``.xml``.
-    """
-    result = []
-    for name in names:
-        if name in _FIXED_BODY_PARTS or (name.startswith(("word/header", "word/footer")) and name.endswith(".xml")):
-            result.append(name)
-    return result
-
-
 def preprocess(docx_bytes: bytes) -> bytes:
     """Return a DOCX with aligned/indented paragraphs rewritten to use synthetic
     paragraph styles. Returns the input unchanged when no such paragraphs are
     found or when the package is not a recognizable DOCX.
     """
-    try:
-        with zipfile.ZipFile(io.BytesIO(docx_bytes), "r") as zin:
-            entries = {name: zin.read(name) for name in zin.namelist()}
-    except zipfile.BadZipFile:
+    entries = read_entries(docx_bytes)
+    if entries is None:
         logger.warning("Input is not a valid zip / DOCX; skipping paragraph preprocess")
         return docx_bytes
 
@@ -147,15 +88,11 @@ def preprocess(docx_bytes: bytes) -> bytes:
         logger.debug("DOCX has no %s; skipping paragraph preprocess", STYLES_PART)
         return docx_bytes
 
-    body_parts = _enumerate_body_parts(entries.keys())
-    if not body_parts:
-        return docx_bytes
-
     # Deduplicated by style_id across all body parts so styles.xml gets one
     # <w:style> per unique align/indent combo even if many paragraphs use it.
     needed_styles: dict[str, _StyleSpec] = {}
 
-    for part in body_parts:
+    for part in enumerate_body_parts(entries.keys()):
         rewritten, part_styles = _rewrite_part(entries[part])
         if part_styles:
             entries[part] = rewritten
@@ -165,12 +102,7 @@ def preprocess(docx_bytes: bytes) -> bytes:
         return docx_bytes
 
     entries[STYLES_PART] = _augment_styles(entries[STYLES_PART], needed_styles)
-
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zout:
-        for name, data in entries.items():
-            zout.writestr(name, data)
-    return buf.getvalue()
+    return repack(entries)
 
 
 class _StyleSpec:
@@ -191,7 +123,7 @@ def _style_id(align: str | None, indent_twips: int | None) -> str:
     parts = [STYLE_PREFIX]
     if align:
         parts.append(f"ALIGN_{align}")
-    if indent_twips:
+    if indent_twips is not None:
         parts.append(f"IND_{indent_twips}")
     return SEGMENT_SEPARATOR.join(parts)
 
@@ -312,7 +244,7 @@ def _build_style_element(spec: _StyleSpec) -> ET.Element:
     )
     ET.SubElement(style, f"{{{W_NS}}}name", {f"{{{W_NS}}}val": spec.style_id})
     ppr = ET.SubElement(style, _PPR_TAG)
-    if spec.indent_twips:
+    if spec.indent_twips is not None:
         ET.SubElement(ppr, _IND_TAG, {_LEFT_ATTR: str(spec.indent_twips)})
     if spec.align:
         # Only center/right are ever encoded (see _ALIGN_MAP), and both map

--- a/app/DocxParagraphPreProcess.py
+++ b/app/DocxParagraphPreProcess.py
@@ -1,0 +1,321 @@
+"""Rewrite paragraph alignment / indentation in a DOCX as paragraph styles.
+
+Pandoc's DOCX reader drops paragraph alignment (``<w:jc>``) entirely and
+coerces left indentation (``<w:ind w:left>``) into a single ``BlockQuote``
+(merging distinct indent levels) before producing the AST, so no Lua filter
+can recover those properties for the LaTeX/PDF writer. This preprocessor runs
+*before* pandoc reads the DOCX and rewrites every paragraph that carries
+alignment and/or a left indent into a reference to a synthetic *paragraph*
+style named
+
+    PandocPara__ALIGN_<align>__IND_<twips>     (each segment optional)
+
+With ``-f docx+styles`` pandoc then surfaces those references as ``Div`` nodes
+carrying ``custom-style="PandocPara__..."``, which
+``filters/docx_paragraphs_to_latex.lua`` translates into a TeX group that sets
+``\\leftskip`` and the matching alignment primitive (``\\centering`` /
+``\\raggedleft`` / ``\\raggedright``).
+
+This is the paragraph-level companion to :mod:`app.DocxColorPreProcess` (which
+does the same trick for run-level colour via character styles); the two run
+independently on the same docx→latex path and compose — a coloured run inside
+an aligned paragraph yields ``Div[PandocPara] -> Para -> Span[PandocColor]``.
+
+Alignment encoding: ``<w:jc>`` values are normalised to left/center/right;
+``start``→left, ``end``→right; ``both``/``distribute`` (justified) are the
+LaTeX default and carry no alignment segment (only an indent, if present).
+
+Limitations
+-----------
+* Only ``<w:ind w:left>`` is carried; first-line / hanging indents are not.
+* The paragraph's existing ``<w:pStyle>`` is replaced; its own properties are
+  not preserved — pandoc would have dropped them anyway (only the style *name*
+  survives the reader).
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import zipfile
+from typing import TYPE_CHECKING
+from xml.etree import ElementTree as ET
+
+from defusedxml import ElementTree as DefusedET
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+logger = logging.getLogger(__name__)
+
+W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+
+# Canonical OOXML prefixes. ElementTree mints synthetic prefixes (ns0, ns1, …)
+# for namespaces it wasn't told about, which makes pandoc's docx reader drop
+# every <w:drawing> (images vanish). Registering the canonical prefixes keeps
+# them on serialize. See app/DocxColorPreProcess.py for the full rationale.
+_OOXML_NAMESPACES = {
+    "w": W_NS,
+    "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "m": "http://schemas.openxmlformats.org/officeDocument/2006/math",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "o": "urn:schemas-microsoft-com:office:office",
+    "v": "urn:schemas-microsoft-com:vml",
+    "w10": "urn:schemas-microsoft-com:office:word",
+    "wp": "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "a": "http://schemas.openxmlformats.org/drawingml/2006/main",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "pic": "http://schemas.openxmlformats.org/drawingml/2006/picture",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "mc": "http://schemas.openxmlformats.org/markup-compatibility/2006",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "w14": "http://schemas.microsoft.com/office/word/2010/wordml",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "w15": "http://schemas.microsoft.com/office/word/2012/wordml",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "w16se": "http://schemas.microsoft.com/office/word/2015/wordml/symex",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "wp14": "http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "wpc": "http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "wpg": "http://schemas.microsoft.com/office/word/2010/wordprocessingGroup",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "wpi": "http://schemas.microsoft.com/office/word/2010/wordprocessingInk",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "wps": "http://schemas.microsoft.com/office/word/2010/wordprocessingShape",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "wne": "http://schemas.microsoft.com/office/word/2006/wordml",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+}
+for _prefix, _uri in _OOXML_NAMESPACES.items():
+    ET.register_namespace(_prefix, _uri)
+
+STYLES_PART = "word/styles.xml"
+STYLE_PREFIX = "PandocPara"
+SEGMENT_SEPARATOR = "__"
+
+# OOXML <w:jc> value -> normalised alignment segment, or None when the value
+# needs no special handling. Only center and right are encoded:
+#   * left/start is the default reading direction — LaTeX already left-aligns
+#     where it matters, and encoding it wrapped every paragraph (notably the
+#     left-aligned table-cell paragraphs pandoc emits) in \raggedright, which
+#     needlessly perturbed rendering. Leave it to the default.
+#   * both/distribute is justified, which is LaTeX's default.
+_ALIGN_MAP: dict[str, str | None] = {
+    "left": None,
+    "start": None,
+    "center": "center",
+    "right": "right",
+    "end": "right",
+    "both": None,
+    "distribute": None,
+}
+
+_FIXED_BODY_PARTS = frozenset(
+    {
+        "word/document.xml",
+        "word/footnotes.xml",
+        "word/endnotes.xml",
+        "word/comments.xml",
+    }
+)
+
+_P_TAG = f"{{{W_NS}}}p"
+_TC_TAG = f"{{{W_NS}}}tc"
+_PPR_TAG = f"{{{W_NS}}}pPr"
+_PSTYLE_TAG = f"{{{W_NS}}}pStyle"
+_JC_TAG = f"{{{W_NS}}}jc"
+_IND_TAG = f"{{{W_NS}}}ind"
+_VAL_ATTR = f"{{{W_NS}}}val"
+_LEFT_ATTR = f"{{{W_NS}}}left"
+
+
+def _enumerate_body_parts(names: Iterable[str]) -> list[str]:
+    """Return zip entry names that may contain paragraphs to rewrite.
+
+    Headers/footers live in numbered parts (``word/header1.xml`` …) whose count
+    depends on the section layout, so they're matched by prefix + ``.xml``.
+    """
+    result = []
+    for name in names:
+        if name in _FIXED_BODY_PARTS or (name.startswith(("word/header", "word/footer")) and name.endswith(".xml")):
+            result.append(name)
+    return result
+
+
+def preprocess(docx_bytes: bytes) -> bytes:
+    """Return a DOCX with aligned/indented paragraphs rewritten to use synthetic
+    paragraph styles. Returns the input unchanged when no such paragraphs are
+    found or when the package is not a recognizable DOCX.
+    """
+    try:
+        with zipfile.ZipFile(io.BytesIO(docx_bytes), "r") as zin:
+            entries = {name: zin.read(name) for name in zin.namelist()}
+    except zipfile.BadZipFile:
+        logger.warning("Input is not a valid zip / DOCX; skipping paragraph preprocess")
+        return docx_bytes
+
+    if STYLES_PART not in entries:
+        logger.debug("DOCX has no %s; skipping paragraph preprocess", STYLES_PART)
+        return docx_bytes
+
+    body_parts = _enumerate_body_parts(entries.keys())
+    if not body_parts:
+        return docx_bytes
+
+    # Deduplicated by style_id across all body parts so styles.xml gets one
+    # <w:style> per unique align/indent combo even if many paragraphs use it.
+    needed_styles: dict[str, _StyleSpec] = {}
+
+    for part in body_parts:
+        rewritten, part_styles = _rewrite_part(entries[part])
+        if part_styles:
+            entries[part] = rewritten
+            needed_styles.update(part_styles)
+
+    if not needed_styles:
+        return docx_bytes
+
+    entries[STYLES_PART] = _augment_styles(entries[STYLES_PART], needed_styles)
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zout:
+        for name, data in entries.items():
+            zout.writestr(name, data)
+    return buf.getvalue()
+
+
+class _StyleSpec:
+    """Lightweight value object describing a synthetic paragraph style."""
+
+    __slots__ = ("align", "indent_twips", "style_id")
+
+    def __init__(self, style_id: str, align: str | None, indent_twips: int | None) -> None:
+        self.style_id = style_id
+        self.align = align
+        self.indent_twips = indent_twips
+
+
+def _style_id(align: str | None, indent_twips: int | None) -> str:
+    # Fixed ALIGN/IND ordering keeps the id deterministic: the same combination
+    # always produces the same id, which is what lets the Lua filter pattern-
+    # match the segments back out and what makes deduplication work.
+    parts = [STYLE_PREFIX]
+    if align:
+        parts.append(f"ALIGN_{align}")
+    if indent_twips:
+        parts.append(f"IND_{indent_twips}")
+    return SEGMENT_SEPARATOR.join(parts)
+
+
+def _extract_para_format(ppr: ET.Element) -> tuple[str | None, int | None]:
+    """Read (alignment segment, left-indent twips) from a <w:pPr>.
+
+    Returns (None, None) when there is nothing worth encoding (no alignment
+    that changes rendering, no positive left indent).
+    """
+    align: str | None = None
+    jc_el = ppr.find(_JC_TAG)
+    if jc_el is not None:
+        raw = jc_el.get(_VAL_ATTR)
+        if raw is not None:
+            align = _ALIGN_MAP.get(raw.strip().lower())
+
+    indent: int | None = None
+    ind_el = ppr.find(_IND_TAG)
+    if ind_el is not None:
+        left = ind_el.get(_LEFT_ATTR)
+        if left is not None:
+            try:
+                value = int(left)
+            except ValueError:
+                value = 0
+            if value > 0:
+                indent = value
+
+    return align, indent
+
+
+def _replace_para_props(ppr: ET.Element, style_id: str) -> None:
+    """Strip <w:pStyle>/<w:jc>/<w:ind> from <w:pPr> and insert a single
+    <w:pStyle> reference to the synthetic style as the first child.
+
+    Stripping <w:jc>/<w:ind> is what stops pandoc from dropping the alignment
+    and coercing the indent into a BlockQuote; the style reference carries the
+    information across the reader instead. <w:pStyle> must be the first child
+    of <w:pPr> per the OOXML schema (CT_PPr sequence).
+    """
+    for tag in (_PSTYLE_TAG, _JC_TAG, _IND_TAG):
+        for el in ppr.findall(tag):
+            ppr.remove(el)
+    ppr.insert(0, ET.Element(_PSTYLE_TAG, {_VAL_ATTR: style_id}))
+
+
+def _rewrite_part(xml_bytes: bytes) -> tuple[bytes, dict[str, _StyleSpec]]:
+    """Rewrite one body part. Returns (new_bytes, styles_used)."""
+    try:
+        tree = DefusedET.fromstring(xml_bytes)
+    except ET.ParseError:
+        logger.warning("Unparseable XML in DOCX part; skipping")
+        return xml_bytes, {}
+
+    styles_used: dict[str, _StyleSpec] = {}
+
+    # Paragraphs inside table cells are left alone: pandoc's docx reader already
+    # renders cell alignment/indent from the table structure (it emits
+    # >{\centering\arraybackslash}p{…} column types), so rewriting them is
+    # redundant and the per-cell wrapper changes row spacing. ElementTree has no
+    # parent pointers, so collect cell paragraphs up front and skip them below.
+    in_cell = {id(p) for tc in tree.iter(_TC_TAG) for p in tc.iter(_P_TAG)}
+
+    for para in tree.iter(_P_TAG):
+        if id(para) in in_cell:
+            continue
+        ppr = para.find(_PPR_TAG)
+        if ppr is None:
+            continue
+        align, indent = _extract_para_format(ppr)
+        if not align and not indent:
+            continue
+        style_id = _style_id(align, indent)
+        styles_used[style_id] = _StyleSpec(style_id, align, indent)
+        _replace_para_props(ppr, style_id)
+
+    if not styles_used:
+        return xml_bytes, {}
+
+    new_xml = ET.tostring(tree, xml_declaration=True, encoding="UTF-8")
+    return new_xml, styles_used
+
+
+def _augment_styles(styles_xml: bytes, specs: dict[str, _StyleSpec]) -> bytes:
+    """Insert a <w:style w:type="paragraph"> entry for each spec, idempotently."""
+    try:
+        tree = DefusedET.fromstring(styles_xml)
+    except ET.ParseError:
+        logger.warning("Unparseable %s; skipping style augmentation", STYLES_PART)
+        return styles_xml
+
+    # Idempotency: never append a second <w:style> with an existing styleId
+    # (Word rejects styles.xml with duplicate styleIds).
+    existing_ids = {el.get(f"{{{W_NS}}}styleId") for el in tree.findall(f"{{{W_NS}}}style")}
+
+    for spec in specs.values():
+        if spec.style_id in existing_ids:
+            continue
+        tree.append(_build_style_element(spec))
+
+    return ET.tostring(tree, xml_declaration=True, encoding="UTF-8")
+
+
+def _build_style_element(spec: _StyleSpec) -> ET.Element:
+    # w:type="paragraph" — a paragraph style (referenced by <w:pStyle>).
+    # Pandoc keys its custom-style attribute off <w:name w:val=...>, so name
+    # and styleId both carry the encoded segments. The <w:pPr> below keeps the
+    # style usable if the intermediate DOCX is inspected manually; pandoc only
+    # consumes the styleId + name.
+    style = ET.Element(
+        f"{{{W_NS}}}style",
+        {
+            f"{{{W_NS}}}type": "paragraph",
+            f"{{{W_NS}}}customStyle": "1",
+            f"{{{W_NS}}}styleId": spec.style_id,
+        },
+    )
+    ET.SubElement(style, f"{{{W_NS}}}name", {f"{{{W_NS}}}val": spec.style_id})
+    ppr = ET.SubElement(style, _PPR_TAG)
+    if spec.indent_twips:
+        ET.SubElement(ppr, _IND_TAG, {_LEFT_ATTR: str(spec.indent_twips)})
+    if spec.align:
+        # Only center/right are ever encoded (see _ALIGN_MAP), and both map
+        # straight back to the matching Word justification value.
+        ET.SubElement(ppr, _JC_TAG, {_VAL_ATTR: spec.align})
+    return style

--- a/app/DocxParagraphPreProcess.py
+++ b/app/DocxParagraphPreProcess.py
@@ -38,9 +38,7 @@ from __future__ import annotations
 import logging
 from xml.etree import ElementTree as ET
 
-from defusedxml import ElementTree as DefusedET
-
-from .docx_ooxml import STYLES_PART, W_NS, enumerate_body_parts, read_entries, repack
+from .docx_ooxml import STYLES_PART, W_NS, augment_styles, enumerate_body_parts, parse_xml, read_entries, repack, serialize_tree
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +99,7 @@ def preprocess(docx_bytes: bytes) -> bytes:
     if not needed_styles:
         return docx_bytes
 
-    entries[STYLES_PART] = _augment_styles(entries[STYLES_PART], needed_styles)
+    entries[STYLES_PART] = augment_styles(entries[STYLES_PART], needed_styles, _build_style_element)
     return repack(entries)
 
 
@@ -173,9 +171,8 @@ def _replace_para_props(ppr: ET.Element, style_id: str) -> None:
 
 def _rewrite_part(xml_bytes: bytes) -> tuple[bytes, dict[str, _StyleSpec]]:
     """Rewrite one body part. Returns (new_bytes, styles_used)."""
-    try:
-        tree = DefusedET.fromstring(xml_bytes)
-    except ET.ParseError:
+    tree = parse_xml(xml_bytes)
+    if tree is None:
         logger.warning("Unparseable XML in DOCX part; skipping")
         return xml_bytes, {}
 
@@ -204,28 +201,7 @@ def _rewrite_part(xml_bytes: bytes) -> tuple[bytes, dict[str, _StyleSpec]]:
     if not styles_used:
         return xml_bytes, {}
 
-    new_xml = ET.tostring(tree, xml_declaration=True, encoding="UTF-8")
-    return new_xml, styles_used
-
-
-def _augment_styles(styles_xml: bytes, specs: dict[str, _StyleSpec]) -> bytes:
-    """Insert a <w:style w:type="paragraph"> entry for each spec, idempotently."""
-    try:
-        tree = DefusedET.fromstring(styles_xml)
-    except ET.ParseError:
-        logger.warning("Unparseable %s; skipping style augmentation", STYLES_PART)
-        return styles_xml
-
-    # Idempotency: never append a second <w:style> with an existing styleId
-    # (Word rejects styles.xml with duplicate styleIds).
-    existing_ids = {el.get(f"{{{W_NS}}}styleId") for el in tree.findall(f"{{{W_NS}}}style")}
-
-    for spec in specs.values():
-        if spec.style_id in existing_ids:
-            continue
-        tree.append(_build_style_element(spec))
-
-    return ET.tostring(tree, xml_declaration=True, encoding="UTF-8")
+    return serialize_tree(tree), styles_used
 
 
 def _build_style_element(spec: _StyleSpec) -> ET.Element:

--- a/app/HtmlParagraphPreProcess.py
+++ b/app/HtmlParagraphPreProcess.py
@@ -1,26 +1,43 @@
-"""Preserve ``<p style="margin-left: ...">`` indentation for DOCX conversion.
+"""Preserve paragraph-level ``<p style="...">`` formatting for DOCX conversion.
 
 Pandoc's HTML reader drops the ``style`` attribute from ``<p>`` entirely, so
-any margin-left applied inline at the paragraph level is lost before any Lua
-filter can read it. This preprocessor finds each such ``<p>``, parses the
-margin-left value into twips (Word's native unit for ``<w:ind w:left=".."/>``),
-and wraps the paragraph in
+any paragraph-level CSS applied inline is lost before any Lua filter can read
+it. This preprocessor finds each such ``<p>``, extracts the formatting we
+support — ``margin-left`` (indent) and ``text-align`` (justification) — and
+wraps the paragraph in a marker ``<div>``:
 
-    <div class="pandoc-indent" data-indent-twips="N"><p ...>...</p></div>
+    <div class="pandoc-para" data-indent-twips="N" data-text-align="center"><p ...>...</p></div>
 
-Pandoc preserves both ``class`` and ``data-*`` attributes on ``<div>`` elements
-(they survive as the AST's ``Attr`` triple), so the indent value travels
-intact to the companion Lua filter (``filters/inline_styles.lua``), which
-emits a raw OOXML ``<w:p>`` carrying the matching paragraph properties.
+Each ``data-*`` attribute is emitted only when the corresponding property is
+present, so an indent-only, align-only, or combined paragraph all share the
+same wrapper. Pandoc preserves both ``class`` and ``data-*`` attributes on
+``<div>`` elements (they survive as the AST's ``Attr`` triple), so the values
+travel intact to the companion Lua filter (``filters/inline_styles.lua``),
+which emits a raw OOXML ``<w:p>`` carrying the matching paragraph properties
+(``<w:ind w:left="N"/>`` and/or ``<w:jc w:val="..."/>``). Pandoc strips the
+``data-`` prefix off these attributes when they aren't reserved HTML attribute
+names, so the filter sees ``indent-twips`` and ``text-align`` — note the align
+attribute is deliberately ``data-text-align`` (not ``data-align``) because
+``align`` *is* a reserved HTML attribute and pandoc would keep it prefixed,
+breaking the symmetry with ``indent-twips``.
 
-Unit conversion
----------------
+Indent unit conversion
+----------------------
 1 twip = 1/1440 inch. CSS reference DPI is 96, so 1 px = 1/96 inch = 15 twips.
 Absolute units (pt, in, cm, mm, pc) convert directly. em/rem are resolved
 against the standard 12pt body size (1 em = 240 twips). Percentages and
 unparseable values are skipped — the paragraph passes through with no indent
 rather than producing wrong output. Negative or zero indents are dropped for
 the same reason.
+
+Alignment
+---------
+The CSS ``text-align`` keyword is mapped to a canonical token
+(``left``/``center``/``right``/``justify``); ``start``/``end`` are folded onto
+``left``/``right``. The canonical token (not the OOXML value) is written into
+``data-align`` so the OOXML trust boundary stays in the Lua filter, mirroring
+how the twips value is handled. Anything else (``inherit``, ``initial``,
+vendor-prefixed, unknown) is skipped.
 """
 
 from __future__ import annotations
@@ -32,8 +49,14 @@ from lxml import etree, html  # type: ignore[import-untyped]
 
 logger = logging.getLogger(__name__)
 
-INDENT_CLASS = "pandoc-indent"
+PARA_CLASS = "pandoc-para"
 INDENT_ATTR = "data-indent-twips"
+# Deliberately "data-text-align", not "data-align": pandoc strips the "data-"
+# prefix only when the remainder isn't a reserved HTML attribute. "align" is
+# reserved (pandoc would keep "data-align"), but "text-align" is not, so it
+# de-prefixes to "text-align" just like "indent-twips" — keeping the Lua-side
+# attribute lookups symmetric. See the module docstring.
+ALIGN_ATTR = "data-text-align"
 
 # CSS unit -> twips conversion factor. 1 twip = 1/1440 inch.
 _UNIT_TO_TWIPS: dict[str, float] = {
@@ -47,6 +70,19 @@ _UNIT_TO_TWIPS: dict[str, float] = {
     # the default 12pt body size (1 em = 12pt = 240 twips).
     "em": 240.0,
     "rem": 240.0,
+}
+
+# CSS text-align keyword -> canonical token written into data-align. The
+# logical keywords start/end fold onto left/right (we have no bidi context, so
+# treat the document as left-to-right). Anything not listed here is skipped,
+# so inherit/initial/unset/vendor-prefixed values never produce a wrapper.
+_ALIGN_MAP: dict[str, str] = {
+    "left": "left",
+    "center": "center",
+    "right": "right",
+    "justify": "justify",
+    "start": "left",
+    "end": "right",
 }
 
 # A numeric value followed by an optional unit (letters or %). The unit is
@@ -70,20 +106,20 @@ _PARSE_FAILURES = (etree.ParseError, etree.ParserError, ValueError)
 
 
 def preprocess(source: bytes) -> bytes:
-    """Wrap each indented ``<p>`` in a marker ``<div>``. Idempotent on input
+    """Wrap each formatted ``<p>`` in a marker ``<div>``. Idempotent on input
     that has nothing to rewrite — returns the original bytes unchanged.
     """
     try:
         fragments = html.fragments_fromstring(source)
     except _PARSE_FAILURES:
-        logger.warning("HtmlIndentPreProcess: HTML parse failed; passing input through")
+        logger.warning("HtmlParagraphPreProcess: HTML parse failed; passing input through")
         return source
 
     # Top-level <p> fragments have no parent, so we couldn't reparent them
     # with their wrapping <div>. Hang every fragment off a synthetic root
     # while we walk so getparent()/insert() works uniformly — then drop the
     # root on the way out.
-    synthetic_root = etree.Element("__pandoc_indent_root__")
+    synthetic_root = etree.Element("__pandoc_para_root__")
     leading_text: str | None = None
     for frag in fragments:
         if hasattr(frag, "tag"):
@@ -94,7 +130,7 @@ def preprocess(source: bytes) -> bytes:
         else:
             leading_text += frag
 
-    rewrote = _wrap_indented_paragraphs(synthetic_root)
+    rewrote = _wrap_formatted_paragraphs(synthetic_root)
     if not rewrote:
         return source
 
@@ -106,7 +142,7 @@ def preprocess(source: bytes) -> bytes:
     return b"".join(parts)
 
 
-def _wrap_indented_paragraphs(root: html.HtmlElement) -> bool:
+def _wrap_formatted_paragraphs(root: html.HtmlElement) -> bool:
     rewrote = False
     # Materialize before mutating: parent.remove/insert invalidates the
     # iterator if we walk lazily.
@@ -115,21 +151,25 @@ def _wrap_indented_paragraphs(root: html.HtmlElement) -> bool:
         if not style:
             continue
         twips = _extract_margin_left_twips(style)
-        if twips is None:
+        align = _extract_text_align(style)
+        if twips is None and align is None:
             continue
         parent = p.getparent()
         if parent is None:
             continue
-        _wrap_paragraph(parent, p, twips)
+        _wrap_paragraph(parent, p, twips, align)
         rewrote = True
     return rewrote
 
 
-def _wrap_paragraph(parent: html.HtmlElement, p: html.HtmlElement, twips: int) -> None:
+def _wrap_paragraph(parent: html.HtmlElement, p: html.HtmlElement, twips: int | None, align: str | None) -> None:
     idx = parent.index(p)
     div = etree.Element("div")
-    div.set("class", INDENT_CLASS)
-    div.set(INDENT_ATTR, str(twips))
+    div.set("class", PARA_CLASS)
+    if twips is not None:
+        div.set(INDENT_ATTR, str(twips))
+    if align is not None:
+        div.set(ALIGN_ATTR, align)
     parent.remove(p)
     div.append(p)
     parent.insert(idx, div)
@@ -153,6 +193,22 @@ def _extract_margin_left_twips(style: str) -> int | None:
         prop, sep, value = declaration.partition(":")
         if sep and prop.strip().lower() == "margin-left":
             return _css_length_to_twips(value.strip())
+    return None
+
+
+def _extract_text_align(style: str) -> str | None:
+    """Return the first ``text-align`` value in a CSS style string as a
+    canonical token (``left``/``center``/``right``/``justify``), or None when
+    the property is absent or its value isn't one we map.
+
+    Parsing mirrors :func:`_extract_margin_left_twips` — plain
+    ``str.split``/``str.partition`` over the semicolon-separated declarations,
+    leftmost-wins — so the two extractors stay consistent.
+    """
+    for declaration in style.split(";"):
+        prop, sep, value = declaration.partition(":")
+        if sep and prop.strip().lower() == "text-align":
+            return _ALIGN_MAP.get(value.strip().lower())
     return None
 
 

--- a/app/PandocController.py
+++ b/app/PandocController.py
@@ -22,7 +22,7 @@ from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.schema import VersionSchema
 
-from . import DocxColorPreProcess, DocxPostProcess, HtmlIndentPreProcess, HtmlListsPreProcess, PptxPostProcess
+from . import DocxColorPreProcess, DocxListLevelPreProcess, DocxParagraphPreProcess, DocxPostProcess, HtmlListsPreProcess, HtmlParagraphPreProcess, PptxPostProcess
 from .metrics_server import MetricsServer, get_metrics_port, is_metrics_server_enabled
 from .pandoc_metrics import get_pandoc_metrics
 from .prometheus_metrics import (
@@ -51,6 +51,8 @@ FILTERS = {
     "heading_levels": f"{FILTER_BASE_PATH}/heading_levels.lua",
     "inline_styles": f"{FILTER_BASE_PATH}/inline_styles.lua",
     "docx_colors_to_latex": f"{FILTER_BASE_PATH}/docx_colors_to_latex.lua",
+    "docx_paragraphs_to_latex": f"{FILTER_BASE_PATH}/docx_paragraphs_to_latex.lua",
+    "docx_lists_to_latex": f"{FILTER_BASE_PATH}/docx_lists_to_latex.lua",
     "html_lists": f"{FILTER_BASE_PATH}/html_lists.lua",
 }
 
@@ -61,6 +63,8 @@ ALLOWED_PANDOC_OPTIONS = [
     f"--lua-filter={FILTERS['heading_levels']}",
     f"--lua-filter={FILTERS['inline_styles']}",
     f"--lua-filter={FILTERS['docx_colors_to_latex']}",
+    f"--lua-filter={FILTERS['docx_paragraphs_to_latex']}",
+    f"--lua-filter={FILTERS['docx_lists_to_latex']}",
     f"--lua-filter={FILTERS['html_lists']}",
     "--track-changes=all",
     "--reference-doc=",  # Prefix for reference-doc option
@@ -491,9 +495,14 @@ def _build_pandoc_command(  # noqa: PLR0913
         # for those synthetic list items.
         cmd.append(f"--lua-filter={FILTERS['html_lists']}")
 
-    # Companion filter to the DOCX color preprocessor.
+    # Companion filters to the DOCX color and paragraph-format preprocessors.
+    # Both only emit raw LaTeX, so they are gated on the docx->latex path. Div
+    # (paragraph) and Span (run color) scopes are independent, so order between
+    # them does not matter.
     if apply_docx_color_preprocess:
         cmd.append(f"--lua-filter={FILTERS['docx_colors_to_latex']}")
+        cmd.append(f"--lua-filter={FILTERS['docx_paragraphs_to_latex']}")
+        cmd.append(f"--lua-filter={FILTERS['docx_lists_to_latex']}")
 
     if validated_options:
         cmd.extend(validated_options)
@@ -547,19 +556,33 @@ def run_pandoc_conversion(source_data: str | bytes, source_format: str, target_f
     apply_docx_color_preprocess = source_format == "docx" and target_format in _LATEX_TARGET_FORMATS
     if apply_docx_color_preprocess:
         source_data = DocxColorPreProcess.preprocess(source_data)
+        # Same docx->latex gate: pandoc's docx reader drops paragraph alignment
+        # (<w:jc>) and collapses left indentation (<w:ind w:left>) into a single
+        # BlockQuote before the AST. Rewrite those paragraphs as references to
+        # synthetic paragraph styles that survive via docx+styles, and let the
+        # docx_paragraphs_to_latex Lua filter emit the matching \leftskip /
+        # \centering / \raggedleft. See app/DocxParagraphPreProcess.py.
+        source_data = DocxParagraphPreProcess.preprocess(source_data)
+        # Same gate: pandoc's docx reader flattens "irregular" lists (a deeper
+        # level nested directly inside a shallower one) so the deeper item loses
+        # its indentation. Tag each list paragraph's true <w:ilvl> so the
+        # docx_lists_to_latex Lua filter can restore the indentation. See
+        # app/DocxListLevelPreProcess.py.
+        source_data = DocxListLevelPreProcess.preprocess(source_data)
 
     # html -> docx: rewrite orphan <ol>/<ul> directly nested inside another
     # list so pandoc's HTML reader doesn't synthesize an implicit list item
     # that the DOCX writer would render as a stray marker (e.g. "a.") above
     # the deeper item. See app/HtmlListsPreProcess.py and
     # filters/html_lists.lua for the full pipeline.
-    # Also wrap each <p style="margin-left: ..."> in a marker <div> so the
-    # paragraph indent survives pandoc's HTML reader (which drops <p>'s style
-    # attribute outright). See app/HtmlIndentPreProcess.py and the Div
-    # handler in filters/inline_styles.lua for the full pipeline.
+    # Also wrap each <p style="margin-left: ...; text-align: ..."> in a marker
+    # <div> so the paragraph indent and/or alignment survive pandoc's HTML
+    # reader (which drops <p>'s style attribute outright). See
+    # app/HtmlParagraphPreProcess.py and the Div handler in
+    # filters/inline_styles.lua for the full pipeline.
     if source_format == "html" and target_format == "docx":
         source_data = HtmlListsPreProcess.preprocess(source_data)
-        source_data = HtmlIndentPreProcess.preprocess(source_data)
+        source_data = HtmlParagraphPreProcess.preprocess(source_data)
 
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as source_file, tempfile.NamedTemporaryFile(delete=False) as output_file:
         try:

--- a/app/PandocController.py
+++ b/app/PandocController.py
@@ -472,13 +472,14 @@ def _build_pandoc_command(  # noqa: PLR0913
     source_path: str,
     output_path: str,
     validated_options: list[str],
-    apply_docx_color_preprocess: bool,
+    apply_docx_latex_filters: bool,
 ) -> list[str]:
     """Build the pandoc CLI invocation for run_pandoc_conversion."""
-    # Source format gains the +styles extension when the color preprocessor
-    # ran, so the synthetic character styles it injected surface as
-    # custom-style Span attributes that docx_colors_to_latex.lua can pick up.
-    pandoc_source_format = f"{source_format}+styles" if apply_docx_color_preprocess else source_format
+    # Source format gains the +styles extension on the docx->latex path so the
+    # synthetic character/paragraph styles the preprocessors injected surface as
+    # custom-style attributes the docx_colors_to_latex / docx_paragraphs_to_latex
+    # filters can pick up.
+    pandoc_source_format = f"{source_format}+styles" if apply_docx_latex_filters else source_format
     cmd = [PANDOC_PATH, "-f", pandoc_source_format, "-t", target_format, "-o", output_path, source_path]
 
     # Convert inline CSS on HTML <span style="..."> into raw OOXML runs for
@@ -499,7 +500,7 @@ def _build_pandoc_command(  # noqa: PLR0913
     # Both only emit raw LaTeX, so they are gated on the docx->latex path. Div
     # (paragraph) and Span (run color) scopes are independent, so order between
     # them does not matter.
-    if apply_docx_color_preprocess:
+    if apply_docx_latex_filters:
         cmd.append(f"--lua-filter={FILTERS['docx_colors_to_latex']}")
         cmd.append(f"--lua-filter={FILTERS['docx_paragraphs_to_latex']}")
         cmd.append(f"--lua-filter={FILTERS['docx_lists_to_latex']}")
@@ -553,8 +554,8 @@ def run_pandoc_conversion(source_data: str | bytes, source_format: str, target_f
     # styles, then ask pandoc to surface those style references via
     # docx+styles, and let the docx_colors_to_latex Lua filter emit the
     # matching \textcolor / \colorbox raw LaTeX.
-    apply_docx_color_preprocess = source_format == "docx" and target_format in _LATEX_TARGET_FORMATS
-    if apply_docx_color_preprocess:
+    apply_docx_latex_filters = source_format == "docx" and target_format in _LATEX_TARGET_FORMATS
+    if apply_docx_latex_filters:
         source_data = DocxColorPreProcess.preprocess(source_data)
         # Same docx->latex gate: pandoc's docx reader drops paragraph alignment
         # (<w:jc>) and collapses left indentation (<w:ind w:left>) into a single
@@ -596,7 +597,7 @@ def run_pandoc_conversion(source_data: str | bytes, source_format: str, target_f
                 source_path=source_file.name,
                 output_path=output_file.name,
                 validated_options=validated_options,
-                apply_docx_color_preprocess=apply_docx_color_preprocess,
+                apply_docx_latex_filters=apply_docx_latex_filters,
             )
 
             # Run pandoc with validated parameters and measure duration

--- a/app/docx_ooxml.py
+++ b/app/docx_ooxml.py
@@ -1,0 +1,84 @@
+"""Shared OOXML/zip plumbing for the DOCX preprocessors.
+
+``DocxColorPreProcess``, ``DocxParagraphPreProcess`` and
+``DocxListLevelPreProcess`` all rewrite body parts of a DOCX package before
+pandoc reads it. This module factors out the boilerplate they share: the
+WordprocessingML namespace, the canonical-prefix registration, the set of parts
+that may contain runs/paragraphs, and reading/repacking the zip.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from typing import TYPE_CHECKING
+from xml.etree import ElementTree as ET
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+STYLES_PART = "word/styles.xml"
+
+# Canonical OOXML prefixes. ElementTree mints synthetic prefixes (ns0, ns1, …)
+# for namespaces it wasn't told about, which makes pandoc's docx reader drop
+# every <w:drawing> (images vanish). Registering the canonical prefixes keeps
+# them on serialize.
+_OOXML_NAMESPACES = {
+    "w": W_NS,
+    "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "m": "http://schemas.openxmlformats.org/officeDocument/2006/math",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "o": "urn:schemas-microsoft-com:office:office",
+    "v": "urn:schemas-microsoft-com:vml",
+    "w10": "urn:schemas-microsoft-com:office:word",
+    "wp": "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "a": "http://schemas.openxmlformats.org/drawingml/2006/main",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "pic": "http://schemas.openxmlformats.org/drawingml/2006/picture",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "mc": "http://schemas.openxmlformats.org/markup-compatibility/2006",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "w14": "http://schemas.microsoft.com/office/word/2010/wordml",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "w15": "http://schemas.microsoft.com/office/word/2012/wordml",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "w16se": "http://schemas.microsoft.com/office/word/2015/wordml/symex",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "wp14": "http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "wpc": "http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "wpg": "http://schemas.microsoft.com/office/word/2010/wordprocessingGroup",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "wpi": "http://schemas.microsoft.com/office/word/2010/wordprocessingInk",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "wps": "http://schemas.microsoft.com/office/word/2010/wordprocessingShape",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+    "wne": "http://schemas.microsoft.com/office/word/2006/wordml",  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
+}
+for _prefix, _uri in _OOXML_NAMESPACES.items():
+    ET.register_namespace(_prefix, _uri)
+
+# Parts that can contain <w:r> runs / <w:p> paragraphs to rewrite. Headers and
+# footers live in numbered parts (word/header1.xml, word/footer2.xml, …) whose
+# count depends on the section layout, so they're matched by prefix + suffix.
+_FIXED_BODY_PARTS = frozenset(
+    {
+        "word/document.xml",
+        "word/footnotes.xml",
+        "word/endnotes.xml",
+        "word/comments.xml",
+    }
+)
+
+
+def enumerate_body_parts(names: Iterable[str]) -> list[str]:
+    """Return zip entry names that may contain runs/paragraphs to rewrite."""
+    return [name for name in names if name in _FIXED_BODY_PARTS or (name.startswith(("word/header", "word/footer")) and name.endswith(".xml"))]
+
+
+def read_entries(docx_bytes: bytes) -> dict[str, bytes] | None:
+    """Read every zip entry into memory, or None if the bytes aren't a zip."""
+    try:
+        with zipfile.ZipFile(io.BytesIO(docx_bytes), "r") as zin:
+            return {name: zin.read(name) for name in zin.namelist()}
+    except zipfile.BadZipFile:
+        return None
+
+
+def repack(entries: dict[str, bytes]) -> bytes:
+    """Re-zip the (possibly mutated) entry dict back into a DOCX byte string."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zout:
+        for name, data in entries.items():
+            zout.writestr(name, data)
+    return buf.getvalue()

--- a/app/docx_ooxml.py
+++ b/app/docx_ooxml.py
@@ -10,12 +10,17 @@ that may contain runs/paragraphs, and reading/repacking the zip.
 from __future__ import annotations
 
 import io
+import logging
 import zipfile
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 from xml.etree import ElementTree as ET
 
+from defusedxml import ElementTree as DefusedET
+
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
+
+logger = logging.getLogger(__name__)
 
 W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"  # NOSONAR False positive - URI is OOXML namespace identifier (ECMA-376), it's never dereferenced
 STYLES_PART = "word/styles.xml"
@@ -82,3 +87,43 @@ def repack(entries: dict[str, bytes]) -> bytes:
         for name, data in entries.items():
             zout.writestr(name, data)
     return buf.getvalue()
+
+
+def parse_xml(xml_bytes: bytes) -> ET.Element | None:
+    """Parse a body/styles part with defusedxml (blocks XXE / billion-laughs),
+    returning None on malformed XML so callers can skip it. We serialize with
+    stdlib ET (:func:`serialize_tree`) since defusedxml has no tostring.
+    """
+    try:
+        return DefusedET.fromstring(xml_bytes)
+    except ET.ParseError:
+        return None
+
+
+def serialize_tree(tree: ET.Element) -> bytes:
+    return ET.tostring(tree, xml_declaration=True, encoding="UTF-8")
+
+
+class _StyleLike(Protocol):
+    style_id: str
+
+
+def augment_styles[S: _StyleLike](styles_xml: bytes, specs: dict[str, S], build_style_element: Callable[[S], ET.Element]) -> bytes:
+    """Append a ``<w:style>`` element (built by ``build_style_element``) for each
+    spec to ``word/styles.xml``, idempotently. Never appends a second style with
+    an existing ``w:styleId`` (Word rejects duplicate styleIds); style order in
+    styles.xml has no semantic meaning, so appending to the root is sufficient.
+    Returns the input unchanged when styles.xml is unparseable.
+    """
+    tree = parse_xml(styles_xml)
+    if tree is None:
+        logger.warning("Unparseable %s; skipping style augmentation", STYLES_PART)
+        return styles_xml
+
+    existing_ids = {el.get(f"{{{W_NS}}}styleId") for el in tree.findall(f"{{{W_NS}}}style")}
+    for spec in specs.values():
+        if spec.style_id in existing_ids:
+            continue
+        tree.append(build_style_element(spec))
+
+    return serialize_tree(tree)

--- a/filters/docx_colors_to_latex.lua
+++ b/filters/docx_colors_to_latex.lua
@@ -26,16 +26,22 @@
 -- color directive outside means \hl only sees plain text characters,
 -- which is the only input shape it reliably typesets.
 --
--- Why we still drop \hl for non-trivial inline content: even with the
--- color macro hoisted out, the Span may itself contain pandoc-emitted
--- macros (\textbf for Strong, \href for Link, \includegraphics for Image,
--- math delimiters, raw LaTeX, etc.). Any of those inside \hl produce
--- corrupt output: the link disappears, math is mis-typeset, the image
--- gets dropped or clipped. We therefore only apply the highlight wrapper
--- when the span's content is pure text (Str/Space/SoftBreak/LineBreak).
--- For anything richer we silently drop the highlight and rely on the
--- foreground color alone — which \textcolor preserves losslessly,
--- including around images.
+-- Bold/italic highlighted text: the same hoist-it-outside trick extends to
+-- the inline-formatting macros. When the whole span content is uniformly
+-- wrapped in Emph/Strong/Superscript/Subscript (the common case — a fully
+-- italic or bold highlighted phrase), we peel those wrappers and emit them
+-- as macros AROUND \hl (\emph{...\hl{plain}...}), so \hl still sees only
+-- plain text. hoist_for_hl() does this recursively, so bold-italic
+-- (Strong[Emph[...]]) hoists both. We deliberately do NOT hoist
+-- Underline/Strikeout: soul's own \ul/\st cannot nest inside \hl, and the
+-- core \underline is not line-breakable.
+--
+-- Why we still drop \hl for genuinely mixed content: if the highlight range
+-- only partially overlaps a formatting run (e.g. [Str "a", Emph "b"]) or
+-- contains a \href/\includegraphics/math, there is no single macro to hoist
+-- and soul cannot wrap it. hoist_for_hl() returns nil in that case and we
+-- fall back to dropping the highlight and keeping the foreground color
+-- alone — which \textcolor preserves losslessly, including around images.
 
 -- Word's 16 named highlight colors (ECMA-376 17.18.40) -> RGB hex.
 local HIGHLIGHT_HEX = {
@@ -77,6 +83,41 @@ local function content_is_soul_safe(content)
     end
   end
   return true
+end
+
+-- Inline-formatting nodes whose LaTeX macro uniformly wraps the node's whole
+-- content and is safe to place OUTSIDE soul's \hl. These are core LaTeX macros
+-- (not soul commands), so nesting them around \hl is fine. Underline/Strikeout
+-- are intentionally absent — see the header comment.
+local HOISTABLE = {
+  Emph        = { "\\emph{", "}" },
+  Strong      = { "\\textbf{", "}" },
+  Superscript = { "\\textsuperscript{", "}" },
+  Subscript   = { "\\textsubscript{", "}" },
+}
+
+-- Peel uniform formatting wrappers off `content` so soul's \hl can wrap the
+-- plain text inside. Returns (open, close, inner_inlines) where open/close are
+-- the hoisted macros to place around \hl, and inner_inlines is the soul-safe
+-- remainder to render inside it. Returns nil when the content is mixed/partial
+-- or contains something \hl can't handle (caller then drops the highlight).
+local function hoist_for_hl(content)
+  local open, close = "", ""
+  while true do
+    if content_is_soul_safe(content) then
+      return open, close, content
+    end
+    -- Only a single wrapper covering the entire content can be hoisted; a list
+    -- with siblings means the formatting is partial and soul can't wrap it.
+    if #content == 1 and HOISTABLE[content[1].t] then
+      local macro = HOISTABLE[content[1].t]
+      open = open .. macro[1]
+      close = macro[2] .. close
+      content = content[1].content
+    else
+      return nil
+    end
+  end
 end
 
 -- Parse the synthetic style name into a {fg, bg, hl} table, or return nil
@@ -138,8 +179,14 @@ function filter.Span(el)
     bg_color = HIGHLIGHT_HEX[props.hl]
   end
 
-  -- Highlight wrapper only when soul can handle the content shape.
-  local apply_bg = bg_color and content_is_soul_safe(el.content)
+  -- Highlight wrapper only when soul can handle the content shape. We peel
+  -- any uniform Emph/Strong/... wrappers out so \hl sees plain text; hl_inner
+  -- is what goes inside \hl (the original content minus the hoisted wrappers).
+  local hl_macros_open, hl_macros_close, hl_inner
+  if bg_color then
+    hl_macros_open, hl_macros_close, hl_inner = hoist_for_hl(el.content)
+  end
+  local apply_bg = hl_inner ~= nil
 
   if not props.fg and not apply_bg then
     return nil
@@ -149,23 +196,30 @@ function filter.Span(el)
 
   -- Outer: foreground color. \textcolor is a directive (no box, no
   -- padding, no line-break inhibition); applied first so it wraps the
-  -- entire span including any highlight wrapper inside.
+  -- entire span including any formatting/highlight wrappers inside.
   if props.fg then
     open = open .. "\\textcolor[HTML]{" .. props.fg .. "}{"
     close = "}" .. close
   end
 
-  -- Inner: highlight via soul \hl. The braces around \definecolor and
-  -- \sethlcolor make the color binding local so other highlighted spans
-  -- can redefine "pdc_hl" without interference. \hl sees only plain
-  -- text characters (the content-safety check above guarantees that).
+  -- Middle + inner: inline-formatting macros hoisted out of \hl (\emph,
+  -- \textbf, ...) followed by the highlight itself. The braces around
+  -- \definecolor and \sethlcolor make the color binding local so other
+  -- highlighted spans can redefine "pdc_hl" without interference. \hl sees
+  -- only plain text characters (hoist_for_hl guarantees that). All emitted
+  -- together so the macro strings are only referenced when apply_bg is true.
   if apply_bg then
-    open = open .. "{\\definecolor{pdc_hl}{HTML}{" .. bg_color .. "}\\sethlcolor{pdc_hl}\\hl{"
-    close = "}}" .. close
+    open = open .. hl_macros_open .. "{\\definecolor{pdc_hl}{HTML}{" .. bg_color .. "}\\sethlcolor{pdc_hl}\\hl{"
+    close = "}}" .. hl_macros_close .. close
   end
 
+  -- When highlighting we render the peeled-down inner inlines (the hoisted
+  -- Emph/Strong are now macros in `open`/`close`, so re-emitting them here
+  -- would double them up). Otherwise render the original content untouched.
+  local body = apply_bg and hl_inner or el.content
+
   local result = { pandoc.RawInline("latex", open) }
-  for _, inline in ipairs(el.content) do
+  for _, inline in ipairs(body) do
     result[#result + 1] = inline
   end
   result[#result + 1] = pandoc.RawInline("latex", close)

--- a/filters/docx_lists_to_latex.lua
+++ b/filters/docx_lists_to_latex.lua
@@ -1,0 +1,116 @@
+-- docx_lists_to_latex.lua
+--
+-- Companion to app/DocxListLevelPreProcess.py. Pandoc's docx reader flattens
+-- "irregular" lists — where a deeper level is nested directly inside a
+-- shallower one (Polarion allows this) — so a level-3 item with no level-2
+-- item before it collapses to the same nesting depth, and therefore the same
+-- indentation, as level 2 in the LaTeX/PDF output.
+--
+-- The preprocessor prepends each list paragraph's true <w:ilvl> as a sentinel
+-- that survives into the AST as a leading Str on the item:
+--
+--     Str "\u{E000}<level>\u{E001}<first word>"
+--
+-- This filter walks the lists while tracking the structural depth pandoc gave
+-- them, reads each list's true level from the sentinel, and pushes any list
+-- that is shallower than its true level into extra *marker-less* wrapper
+-- levels (\begin{enumerate}\item[] ... or \begin{itemize}\item[] ...). The
+-- empty \item[] adds one level of indentation without drawing a marker and
+-- without renumbering the sibling list, which reproduces Word's absolute-level
+-- indentation. Finally every residual sentinel is stripped from the text.
+--
+-- Why the markers still come out right: pandoc's depth-based ordered styles
+-- (decimal / lower-alpha / lower-roman) and LaTeX's enumerate defaults
+-- (arabic / alph / roman), and likewise the itemize bullet defaults, follow
+-- the same per-depth cycle. A pushed list lands at the runtime depth matching
+-- its style, so the default label for that depth is the intended one.
+
+local OPEN = "\u{E000}"
+local CLOSE = "\u{E001}"
+local SENTINEL_PATTERN = OPEN .. "(%d+)" .. CLOSE
+
+-- LaTeX's enumerate/itemize nest at most 4 deep; never wrap past that.
+local MAX_DEPTH = 4
+
+-- Read a list's true level (0-based) from the first sentinel-tagged Str in any
+-- of its items, or nil when none is tagged. One flattened sublist maps to one
+-- source numbering level, so any tagged item gives the list's level.
+local function read_level(list)
+  for _, item in ipairs(list.content) do
+    for _, blk in ipairs(item) do
+      if (blk.t == "Para" or blk.t == "Plain") and #blk.content >= 1 then
+        local first = blk.content[1]
+        if first.t == "Str" then
+          local n = first.text:match("^" .. SENTINEL_PATTERN)
+          if n then return tonumber(n) end
+        end
+      end
+    end
+  end
+  return nil
+end
+
+local process_blocks  -- forward declaration (mutual recursion with handle_list)
+
+local function handle_list(list, depth)
+  -- Fix nested lists first: each item's blocks live one structural level deeper.
+  for i, item in ipairs(list.content) do
+    list.content[i] = process_blocks(item, depth + 1)
+  end
+
+  local level = read_level(list)
+  local push = level and (level - (depth - 1)) or 0
+  if push < 0 then push = 0 end
+  if depth + push > MAX_DEPTH then push = MAX_DEPTH - depth end
+  if push <= 0 then
+    return { list }
+  end
+
+  local kind = (list.t == "OrderedList") and "enumerate" or "itemize"
+  local open, close = "", ""
+  for _ = 1, push do
+    open = open .. "\\begin{" .. kind .. "}\\item[] "
+    close = "\\end{" .. kind .. "}" .. close
+  end
+  return { pandoc.RawBlock("latex", open), list, pandoc.RawBlock("latex", close) }
+end
+
+-- Walk a block list at the given structural depth (1-based; a top-level list
+-- is depth 1). Lists are re-nested; container blocks are descended into so a
+-- list inside a Div/BlockQuote still starts a fresh depth-1 context.
+process_blocks = function(blocks, depth)
+  local out = {}
+  for _, block in ipairs(blocks) do
+    local t = block.t
+    if t == "OrderedList" or t == "BulletList" then
+      for _, b in ipairs(handle_list(block, depth)) do
+        out[#out + 1] = b
+      end
+    elseif t == "Div" or t == "BlockQuote" then
+      block.content = process_blocks(block.content, 1)
+      out[#out + 1] = block
+    else
+      out[#out + 1] = block
+    end
+  end
+  return out
+end
+
+function Pandoc(doc)
+  -- Only emit the raw-LaTeX re-nesting for LaTeX targets; the filter is gated
+  -- on docx->latex in the controller, so this is defensive.
+  if FORMAT:match("latex") then
+    doc = pandoc.Pandoc(process_blocks(doc.blocks, 1), doc.meta)
+  end
+  -- Strip every residual sentinel so it never leaks into the output, even from
+  -- a list the re-nesting walk did not reach.
+  return doc:walk({
+    Str = function(s)
+      local cleaned = s.text:gsub(SENTINEL_PATTERN, "")
+      if cleaned ~= s.text then
+        return pandoc.Str(cleaned)
+      end
+      return nil
+    end,
+  })
+end

--- a/filters/docx_paragraphs_to_latex.lua
+++ b/filters/docx_paragraphs_to_latex.lua
@@ -1,0 +1,94 @@
+-- docx_paragraphs_to_latex.lua
+--
+-- Companion to app/DocxParagraphPreProcess.py. The preprocessor rewrites every
+-- paragraph with alignment and/or a left indent in a DOCX as a reference to a
+-- synthetic *paragraph* style named
+--
+--   PandocPara__ALIGN_<align>__IND_<twips>      (each segment optional)
+--
+-- With `-f docx+styles`, pandoc surfaces those references as Div nodes carrying
+-- `custom-style="PandocPara__..."`. This filter rewrites each such Div into its
+-- inner blocks wrapped in a TeX group that sets the paragraph indent and
+-- alignment, so the formatting that pandoc's docx reader otherwise drops (it
+-- discards <w:jc> and collapses <w:ind> into a BlockQuote) survives into the
+-- PDF/LaTeX output:
+--
+--   IND_<twips>   -> \leftskip=<pt>pt   (twips/20 = points)
+--   ALIGN_center  -> \centering
+--   ALIGN_right   -> \raggedleft
+--   ALIGN_left    -> \raggedright
+--
+-- All are plain TeX primitives (no package needed) and are line-breakable. The
+-- group ends with \par so the alignment/indent applies to the wrapped
+-- paragraph and is scoped away from the surrounding text. Justified text is the
+-- LaTeX default, so the preprocessor never emits an ALIGN segment for it.
+
+local STYLE_PREFIX = "PandocPara"
+
+-- Normalised alignment segment -> LaTeX paragraph-alignment primitive. This is
+-- a trust boundary: only values present as a key here ever reach the output,
+-- and the emitted string is the table's literal value — attacker-controlled
+-- attribute text is never echoed into the LaTeX.
+local ALIGN_PRIMITIVE = {
+  left = "\\raggedright",
+  center = "\\centering",
+  right = "\\raggedleft",
+}
+
+-- Parse an IND segment value into a LaTeX length in points, or nil if it isn't
+-- a clean non-negative integer count of twips within a sane bound. Like the
+-- twips validation in inline_styles.lua, this keeps anything that isn't a
+-- bounded integer out of the emitted \leftskip length.
+local function twips_to_pt(raw)
+  local n = tonumber(raw)
+  if not n then return nil end
+  if n < 0 then return nil end
+  if n ~= math.floor(n) then return nil end
+  if n > 31680 then return nil end           -- ~200 inches; far beyond any real indent
+  -- 1pt = 20 twips. string.format emits only digits and a dot, so the value
+  -- cannot break out of the length argument.
+  return string.format("%.2f", n / 20)
+end
+
+local filter = {}
+
+function filter.Div(el)
+  -- The filter only emits LaTeX; for any other writer leave the Div untouched.
+  if not FORMAT:match("latex") then return nil end
+
+  local style = el.attributes and el.attributes["custom-style"]
+  if not style or style:sub(1, #STYLE_PREFIX) ~= STYLE_PREFIX then
+    return nil
+  end
+
+  local align_cmd, indent_pt
+  -- Segments are "__<KEY>_<value>"; KEY is letters, value has no underscore.
+  for key, value in style:gmatch("__(%a+)_([^_]+)") do
+    if key == "ALIGN" then
+      align_cmd = ALIGN_PRIMITIVE[value:lower()]
+    elseif key == "IND" then
+      indent_pt = twips_to_pt(value)
+    end
+  end
+
+  if not align_cmd and not indent_pt then
+    return nil
+  end
+
+  local open = "{"
+  if indent_pt then
+    open = open .. "\\leftskip=" .. indent_pt .. "pt "
+  end
+  if align_cmd then
+    open = open .. align_cmd .. " "
+  end
+
+  local result = { pandoc.RawBlock("latex", open) }
+  for _, block in ipairs(el.content) do
+    result[#result + 1] = block
+  end
+  result[#result + 1] = pandoc.RawBlock("latex", "\\par}")
+  return result
+end
+
+return filter

--- a/filters/inline_styles.lua
+++ b/filters/inline_styles.lua
@@ -444,23 +444,28 @@ function filter.Span(el)
   return walk(el.content, props, nil)
 end
 
--- Paragraph-level indent (margin-left). Pandoc's HTML reader drops the style
--- attribute from <p> outright, so the indent has to ride into the AST on a
--- wrapping Div that app/HtmlIndentPreProcess.py inserts. The contract:
+-- Paragraph-level formatting (margin-left indent + text-align). Pandoc's HTML
+-- reader drops the style attribute from <p> outright, so the formatting has to
+-- ride into the AST on a wrapping Div that app/HtmlParagraphPreProcess.py
+-- inserts. The contract:
 --
---     <div class="pandoc-indent" data-indent-twips="N"><p>...</p></div>
+--     <div class="pandoc-para" data-indent-twips="N" data-text-align="center"><p>...</p></div>
 --
--- becomes Div("", ["pandoc-indent"], [("indent-twips","N")]) [Para [...]].
--- We rewrite each inner Para into a raw OOXML <w:p> whose <w:pPr> carries
--- <w:ind w:left="N"/>. The Para's inlines are run through the same `walk()`
+-- becomes Div("", ["pandoc-para"], [("indent-twips","N"),("text-align","center")])
+-- [Para [...]] — pandoc strips the data- prefix off both attributes (the align
+-- attribute is data-text-align rather than data-align precisely so this
+-- stripping happens; "align" is a reserved HTML attribute pandoc would keep
+-- prefixed). Each data-* attribute is optional. We rewrite each inner Para
+-- into a raw OOXML <w:p> whose <w:pPr> carries <w:ind w:left="N"/> and/or
+-- <w:jc w:val="..."/>. The Para's inlines are run through the same `walk()`
 -- used by filter.Span, so nested <strong>/<em>/styled <span>s in the source
--- still render correctly inside the indented paragraph.
+-- still render correctly inside the formatted paragraph.
 --
 -- Graceful degradation: if walk() returns anything that can't be embedded as
 -- raw OOXML (a Link, Image, footnote, etc. — these need writer-level rels/
--- drawing handling that a raw <w:p> can't reproduce), we drop the indent for
--- that paragraph rather than corrupt its content. The Para passes through
--- with its semantics intact, just without the indent applied.
+-- drawing handling that a raw <w:p> can't reproduce), we drop the paragraph
+-- formatting rather than corrupt its content. The Para passes through with its
+-- semantics intact, just without the indent/alignment applied.
 
 -- Concatenate a list of inlines into a single OOXML string, or return nil
 -- if any element can't be safely flattened (Link, Image, Note, ...).
@@ -476,23 +481,39 @@ local function inlines_to_openxml(inlines)
   return table.concat(parts)
 end
 
--- Build the single OOXML <w:p> for an indented paragraph, or nil to signal
--- "fall back to the original Para". `twips` is trusted here: callers MUST
--- pass an already-validated non-negative integer (Lua number, not string).
--- See filter.Div below for the validation that establishes that trust.
-local function build_indented_w_p(inlines, twips)
+-- Build the single OOXML <w:p> for a formatted paragraph, or nil to signal
+-- "fall back to the original Para". Both `twips` and `jc` are trusted here:
+-- callers MUST pass an already-validated non-negative integer (Lua number, not
+-- string) and an allowlisted justification literal. See filter.Div below for
+-- the validation that establishes that trust. At least one of them must be
+-- set — an empty <w:pPr> would be pointless, so we return nil in that case and
+-- let the caller keep pandoc's native Para.
+local function build_para_w_p(inlines, twips, jc)
   local body = inlines_to_openxml(inlines)
   if not body then return nil end
+  -- <w:pPr> children must follow the CT_PPr schema sequence (ECMA-376 Part 1
+  -- §17.3.1.26): <w:ind> precedes <w:jc>. Word/LibreOffice are version-
+  -- dependent about out-of-order children (silent reorder, recovery warning,
+  -- or dropping the child), so we emit them in canonical order.
+  local ppr = {}
   -- string.format("%d", n) round-trips a validated integer through Lua's
   -- printf, which emits only decimal digits (and an optional leading '-' we
   -- already ruled out). Concatenating the raw attribute string here instead
-  -- — as the original version did — would have let HTML input like
-  --   <div class="pandoc-indent" data-indent-twips='1"/><w:r>...</w:r><w:p w:x="'>
+  -- — as an earlier version did — would have let HTML input like
+  --   <div class="pandoc-para" data-indent-twips='1"/><w:r>...</w:r><w:p w:x="'>
   -- close the <w:ind ...> early and splice arbitrary OOXML into the
   -- document. The validation in filter.Div + this %d format together close
-  -- that injection path.
+  -- that injection path. `jc` is one of a fixed set of literal strings (never
+  -- echoed input), so it carries no injection risk.
+  if twips then
+    ppr[#ppr + 1] = '<w:ind w:left="' .. string.format("%d", twips) .. '"/>'
+  end
+  if jc then
+    ppr[#ppr + 1] = '<w:jc w:val="' .. jc .. '"/>'
+  end
+  if #ppr == 0 then return nil end
   return pandoc.RawBlock("openxml",
-    '<w:p><w:pPr><w:ind w:left="' .. string.format("%d", twips) .. '"/></w:pPr>' .. body .. '</w:p>')
+    "<w:p><w:pPr>" .. table.concat(ppr) .. "</w:pPr>" .. body .. "</w:p>")
 end
 
 local function has_class(el, name)
@@ -522,20 +543,42 @@ local function parse_twips(raw)
   return math.floor(n)
 end
 
+-- Map the canonical text-align token (written by HtmlParagraphPreProcess) to
+-- the OOXML <w:jc w:val> value, or nil for anything unrecognized. This is a
+-- trust boundary: only values present as a *key* in this fixed table are ever
+-- emitted, and the emitted string is the table's literal *value* — attacker
+-- input is never echoed into the OOXML, so there is no attribute-injection
+-- path the way there is for the free-form twips attribute.
+local ALIGN_TO_JC = {
+  left = "left",
+  center = "center",
+  right = "right",
+  justify = "both",   -- CSS "justify" -> OOXML "both"
+  both = "both",      -- accept the OOXML spelling too, defensively
+}
+
+local function parse_align(raw)
+  if not raw then return nil end
+  return ALIGN_TO_JC[raw]
+end
+
 function filter.Div(el)
-  if not has_class(el, "pandoc-indent") then return nil end
+  if not has_class(el, "pandoc-para") then return nil end
   local twips = parse_twips(el.attributes["indent-twips"])
-  if not twips then return nil end
+  local jc = parse_align(el.attributes["text-align"])
+  -- Nothing valid to apply — leave the Div for pandoc's normal handling
+  -- rather than emit an empty/ malformed <w:pPr>.
+  if not twips and not jc then return nil end
 
   local result = {}
   for _, block in ipairs(el.content) do
     if block.t == "Para" or block.t == "Plain" then
-      local rb = build_indented_w_p(block.content, twips)
+      local rb = build_para_w_p(block.content, twips, jc)
       result[#result + 1] = rb or block
     else
       -- Anything else in the wrapper (nested lists, code blocks, ...) keeps
-      -- its normal writer treatment. Indent isn't applied to non-Para blocks
-      -- — they have their own pPr semantics we shouldn't trample.
+      -- its normal writer treatment. Indent/alignment aren't applied to
+      -- non-Para blocks — they have their own pPr semantics we shouldn't trample.
       result[#result + 1] = block
     end
   end

--- a/tests/test_docx_colors_to_latex_filter.py
+++ b/tests/test_docx_colors_to_latex_filter.py
@@ -165,3 +165,70 @@ def test_non_matching_custom_style_is_left_alone():
     assert "\\colorbox" not in result.stdout
     assert "\\hl{" not in result.stdout
     assert "hello" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Highlight on bold/italic text — formatting macros hoisted OUTSIDE \hl
+# ---------------------------------------------------------------------------
+#
+# Regression for the bug where a highlighted (background/shaded) run that is
+# also bold/italic lost its highlight entirely in DOCX->PDF: soul's \hl can't
+# wrap a span containing \emph/\textbf, so the old filter dropped the highlight.
+# The fix peels uniform formatting wrappers and emits them as macros AROUND
+# \hl, which only ever sees plain text. These build the exact AST shape pandoc
+# produces from `-f docx+styles` (Span[custom-style][Emph/Strong[...]]) via a
+# markdown bracketed span, so the test is pandoc-only (no tectonic needed).
+
+
+def _md_to_latex(md: str) -> str:
+    """Convert a markdown snippet to LaTeX through the filter, return stdout."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        src = Path(tmpdir) / "in.md"
+        src.write_text(md, encoding="utf-8")
+        result = subprocess.run(
+            [PANDOC, "-f", "markdown", "-t", "latex", f"--lua-filter={FILTER_PATH}", str(src)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    return _flatten_whitespace(result.stdout)
+
+
+def test_highlight_survives_italic_with_emph_hoisted_outside_hl():
+    """The "injected humour" case: italic + foreground color + background.
+
+    The highlight must NOT be dropped. \\emph is hoisted OUTSIDE \\hl (soul
+    can't wrap \\emph), \\textcolor stays outermost, and \\hl wraps plain text.
+    """
+    flat = _md_to_latex('[*injected humour*]{custom-style="PandocColor__FG_00B050__BG_FFFF00"}\n')
+    assert "\\hl{injected humour}" in flat, f"highlight dropped on italic text: {flat}"
+    assert "\\emph{" in flat, flat
+    assert "\\textcolor[HTML]{00B050}" in flat, flat
+    # Ordering: \textcolor outermost, then \emph, then \hl innermost.
+    assert flat.index("\\textcolor") < flat.index("\\emph{") < flat.index("\\hl{"), flat
+
+
+def test_highlight_survives_bold():
+    """Bold + background: \\textbf hoisted outside \\hl, highlight preserved."""
+    flat = _md_to_latex('[**loud**]{custom-style="PandocColor__BG_FFFF00"}\n')
+    assert "\\hl{loud}" in flat, f"highlight dropped on bold text: {flat}"
+    assert "\\textbf{" in flat and flat.index("\\textbf{") < flat.index("\\hl{"), flat
+
+
+def test_highlight_survives_bold_italic_nested():
+    """Bold-italic nests two wrappers; both must hoist out, \\hl innermost."""
+    flat = _md_to_latex('[***both***]{custom-style="PandocColor__BG_FFFF00"}\n')
+    assert "\\hl{both}" in flat, f"highlight dropped on bold-italic text: {flat}"
+    assert flat.index("\\textbf{") < flat.index("\\hl{"), flat
+    assert flat.index("\\emph{") < flat.index("\\hl{"), flat
+
+
+def test_partial_formatting_inside_highlight_drops_hl_but_keeps_color():
+    """When formatting only partially overlaps the highlighted span there is no
+    single macro to hoist, so soul can't wrap it. The highlight is gracefully
+    dropped (current limitation) while the foreground color and the text — bold
+    part included — are preserved."""
+    flat = _md_to_latex('[plain *and italic*]{custom-style="PandocColor__FG_00B050__BG_FFFF00"}\n')
+    assert "\\hl{" not in flat and "\\sethlcolor" not in flat, f"soul wrapped mixed content: {flat}"
+    assert "\\textcolor[HTML]{00B050}" in flat, flat
+    assert "\\emph{" in flat and "italic" in flat, flat

--- a/tests/test_docx_list_level_preprocess.py
+++ b/tests/test_docx_list_level_preprocess.py
@@ -1,0 +1,165 @@
+"""Unit tests for ``app.DocxListLevelPreProcess``.
+
+Each test builds a minimal DOCX zip in memory containing a single
+``word/document.xml`` and inspects the rewritten XML — same synthetic-fixture
+approach as ``test_docx_color_preprocess.py``.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from xml.etree import ElementTree as ET  # noqa: S405
+
+from app import DocxListLevelPreProcess
+from app.DocxListLevelPreProcess import SENTINEL_CLOSE, SENTINEL_OPEN
+
+W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+ET.register_namespace("w", W_NS)
+
+
+def _pack(parts: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, data in parts.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+def _doc(*paras_xml: str) -> bytes:
+    body = "".join(paras_xml)
+    return ('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>' + body + "</w:body></w:document>").encode("utf-8")
+
+
+def _list_para(ilvl: str | None, text: str = "item") -> str:
+    """A list <w:p> with a <w:numPr> at the given ilvl (None = numPr without ilvl)."""
+    ilvl_xml = f'<w:ilvl w:val="{ilvl}"/>' if ilvl is not None else ""
+    return f'<w:p><w:pPr><w:numPr>{ilvl_xml}<w:numId w:val="3"/></w:numPr></w:pPr><w:r><w:t>{text}</w:t></w:r></w:p>'
+
+
+def _plain_para(text: str = "para") -> str:
+    return f"<w:p><w:r><w:t>{text}</w:t></w:r></w:p>"
+
+
+def _body(blob: bytes) -> ET.Element:
+    with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+        return ET.fromstring(zf.read("word/document.xml"))  # noqa: S314
+
+
+def _first_run_text(para: ET.Element) -> str | None:
+    run = para.find(f"{{{W_NS}}}r")
+    if run is None:
+        return None
+    t = run.find(f"{{{W_NS}}}t")
+    return t.text if t is not None else None
+
+
+def _sentinel(level: int) -> str:
+    return f"{SENTINEL_OPEN}{level}{SENTINEL_CLOSE}"
+
+
+# --- tagging --------------------------------------------------------------
+
+
+def test_list_paragraph_gets_sentinel_for_its_ilvl():
+    blob = _pack({"word/document.xml": _doc(_list_para("2", "Level 3"))})
+    result = DocxListLevelPreProcess.preprocess(blob)
+    para = _body(result).find(f".//{{{W_NS}}}p")
+    # The first run is the sentinel encoding ilvl=2; the original text follows.
+    assert _first_run_text(para) == _sentinel(2)
+    texts = [t.text for t in para.iter(f"{{{W_NS}}}t")]
+    assert texts == [_sentinel(2), "Level 3"]
+
+
+def test_numpr_without_ilvl_defaults_to_level_zero():
+    blob = _pack({"word/document.xml": _doc(_list_para(None, "L1"))})
+    para = _body(DocxListLevelPreProcess.preprocess(blob)).find(f".//{{{W_NS}}}p")
+    assert _first_run_text(para) == _sentinel(0)
+
+
+def test_sentinel_is_inserted_after_ppr():
+    blob = _pack({"word/document.xml": _doc(_list_para("1"))})
+    para = _body(DocxListLevelPreProcess.preprocess(blob)).find(f".//{{{W_NS}}}p")
+    children = list(para)
+    assert children[0].tag == f"{{{W_NS}}}pPr"
+    assert children[1].tag == f"{{{W_NS}}}r"  # sentinel run right after pPr
+
+
+def test_multiple_levels_tagged_independently():
+    blob = _pack({"word/document.xml": _doc(_list_para("0", "a"), _list_para("2", "b"), _list_para("1", "c"))})
+    paras = _body(DocxListLevelPreProcess.preprocess(blob)).findall(f".//{{{W_NS}}}p")
+    assert [_first_run_text(p) for p in paras] == [_sentinel(0), _sentinel(2), _sentinel(1)]
+
+
+# --- pass-through ---------------------------------------------------------
+
+
+def test_non_list_paragraph_is_untouched():
+    blob = _pack({"word/document.xml": _doc(_plain_para("hello"))})
+    assert DocxListLevelPreProcess.preprocess(blob) == blob
+
+
+def test_document_without_lists_returned_unchanged():
+    blob = _pack({"word/document.xml": _doc(_plain_para("a"), _plain_para("b"))})
+    assert DocxListLevelPreProcess.preprocess(blob) == blob
+
+
+def test_mixed_doc_only_tags_list_paragraphs():
+    blob = _pack({"word/document.xml": _doc(_plain_para("intro"), _list_para("0", "item"))})
+    paras = _body(DocxListLevelPreProcess.preprocess(blob)).findall(f".//{{{W_NS}}}p")
+    assert _first_run_text(paras[0]) == "intro"  # plain paragraph untouched
+    assert _first_run_text(paras[1]) == _sentinel(0)
+
+
+# --- robustness -----------------------------------------------------------
+
+
+def test_preprocess_is_idempotent():
+    blob = _pack({"word/document.xml": _doc(_list_para("2", "x"))})
+    once = DocxListLevelPreProcess.preprocess(blob)
+    # A second pass must not prepend a second sentinel.
+    assert DocxListLevelPreProcess.preprocess(once) == once
+    para = _body(once).find(f".//{{{W_NS}}}p")
+    assert [t.text for t in para.iter(f"{{{W_NS}}}t")] == [_sentinel(2), "x"]
+
+
+def test_non_docx_input_is_returned_unchanged():
+    assert DocxListLevelPreProcess.preprocess(b"not a zip") == b"not a zip"
+
+
+def test_zip_without_body_parts_returned_unchanged():
+    """A package with no document/header/footer parts has nothing to tag."""
+    blob = _pack({"word/styles.xml": b"<x/>", "docProps/core.xml": b"<x/>"})
+    assert DocxListLevelPreProcess.preprocess(blob) == blob
+
+
+def test_ilvl_element_without_val_defaults_to_zero():
+    para = '<w:p><w:pPr><w:numPr><w:ilvl/><w:numId w:val="3"/></w:numPr></w:pPr><w:r><w:t>x</w:t></w:r></w:p>'
+    para_el = _body(DocxListLevelPreProcess.preprocess(_pack({"word/document.xml": _doc(para)}))).find(f".//{{{W_NS}}}p")
+    assert _first_run_text(para_el) == _sentinel(0)
+
+
+def test_non_integer_ilvl_is_not_tagged():
+    blob = _pack({"word/document.xml": _doc(_list_para("abc", "x"))})
+    assert DocxListLevelPreProcess.preprocess(blob) == blob
+
+
+def test_negative_ilvl_is_not_tagged():
+    blob = _pack({"word/document.xml": _doc(_list_para("-1", "x"))})
+    assert DocxListLevelPreProcess.preprocess(blob) == blob
+
+
+def test_malformed_document_xml_returned_unchanged():
+    blob = _pack({"word/document.xml": b"<w:document><unclosed>"})
+    assert DocxListLevelPreProcess.preprocess(blob) == blob
+
+
+def test_list_paragraph_with_leading_bookmark_is_still_tagged():
+    """A list paragraph whose first child after pPr is not a run (e.g. a
+    bookmark) is still tagged — the sentinel goes right after pPr."""
+    para = '<w:p><w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="3"/></w:numPr></w:pPr><w:bookmarkStart w:id="0" w:name="b"/><w:r><w:t>x</w:t></w:r></w:p>'
+    para_el = _body(DocxListLevelPreProcess.preprocess(_pack({"word/document.xml": _doc(para)}))).find(f".//{{{W_NS}}}p")
+    children = list(para_el)
+    assert children[0].tag == f"{{{W_NS}}}pPr"
+    assert children[1].tag == f"{{{W_NS}}}r"
+    assert _first_run_text(para_el) == _sentinel(1)

--- a/tests/test_docx_lists_to_latex_filter.py
+++ b/tests/test_docx_lists_to_latex_filter.py
@@ -1,0 +1,105 @@
+"""Integration tests for ``filters/docx_lists_to_latex.lua``.
+
+Runs the real ``pandoc`` binary with the filter on a native AST that mimics what
+the docx reader produces for a Polarion "irregular" list once
+``DocxListLevelPreProcess`` has tagged each item with its true ``<w:ilvl>``
+(a leading ``\\uE000<level>\\uE001`` sentinel ``Str``). Pandoc-only — no DOCX
+fixture or tectonic needed.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+PANDOC = shutil.which("pandoc")
+FILTER_PATH = Path(__file__).resolve().parents[1] / "filters" / "docx_lists_to_latex.lua"
+
+OPEN = ""
+CLOSE = ""
+
+pytestmark = pytest.mark.skipif(
+    PANDOC is None or not FILTER_PATH.exists(),
+    reason="pandoc binary or filters/docx_lists_to_latex.lua not available",
+)
+
+
+def _tag(level: int) -> str:
+    return f"{OPEN}{level}{CLOSE}"
+
+
+def _native_to_latex(native: str) -> str:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        src = Path(tmpdir) / "in.native"
+        src.write_text(native, encoding="utf-8")
+        result = subprocess.run(
+            [PANDOC, "-f", "native", "-t", "latex", f"--lua-filter={FILTER_PATH}", str(src)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    return result.stdout
+
+
+# The flattened AST pandoc produces for the irregular ordered list, with the
+# preprocessor's level sentinels prepended: Level 1 (lvl0), then a LowerRoman
+# sublist holding "Level 3" (lvl2), then a LowerAlpha sublist holding
+# "Level 2" (lvl1) — all as depth-2 siblings under Level 1's item.
+def _ordered_irregular() -> str:
+    return (
+        "[ OrderedList (1, Decimal, Period)\n"
+        f'  [ [ Plain [Str "{_tag(0)}Level", Space, Str "1"]\n'
+        f'    , OrderedList (1, LowerRoman, Period) [ [ Plain [Str "{_tag(2)}Level", Space, Str "3"] ] ]\n'
+        f'    , OrderedList (1, LowerAlpha, Period) [ [ Plain [Str "{_tag(1)}Level", Space, Str "2"] ] ]\n'
+        "    ] ] ]\n"
+    )
+
+
+def _bulleted_irregular() -> str:
+    return f'[ BulletList\n  [ [ Plain [Str "{_tag(0)}B1"]\n    , BulletList [ [ Plain [Str "{_tag(2)}B3"] ] ]\n    , BulletList [ [ Plain [Str "{_tag(1)}B2"] ] ]\n    ] ] ]\n'
+
+
+def test_ordered_irregular_pushes_only_the_deeper_sublist():
+    latex = _native_to_latex(_ordered_irregular())
+    # Exactly one marker-less wrapper level — for "Level 3" (lvl2 at depth2).
+    assert latex.count("\\begin{enumerate}\\item[]") == 1, latex
+    # "Level 2" (lvl1 at depth2) is NOT wrapped.
+    assert "\\begin{itemize}" not in latex
+    # Sentinels are gone and content is intact.
+    assert OPEN not in latex and CLOSE not in latex, "sentinel leaked into output"
+    assert "Level 3" in latex and "Level 2" in latex and "Level 1" in latex
+
+
+def test_bulleted_irregular_uses_itemize_wrapper():
+    latex = _native_to_latex(_bulleted_irregular())
+    assert latex.count("\\begin{itemize}\\item[]") == 1, latex
+    assert OPEN not in latex and CLOSE not in latex
+    assert "B3" in latex and "B2" in latex
+
+
+def test_wellformed_contiguous_list_is_not_wrapped():
+    """A properly nested 0->1->2 list needs no push; only the sentinels are stripped."""
+    native = (
+        "[ OrderedList (1, Decimal, Period)\n"
+        f'  [ [ Plain [Str "{_tag(0)}L1"]\n'
+        "    , OrderedList (1, LowerAlpha, Period)\n"
+        f'      [ [ Plain [Str "{_tag(1)}L2"]\n'
+        f'        , OrderedList (1, LowerRoman, Period) [ [ Plain [Str "{_tag(2)}L3"] ] ]\n'
+        "        ] ] ] ] ]\n"
+    )
+    latex = _native_to_latex(native)
+    assert "\\item[]" not in latex, latex
+    assert OPEN not in latex and CLOSE not in latex
+    assert "L1" in latex and "L2" in latex and "L3" in latex
+
+
+def test_untagged_list_is_left_alone():
+    """A plain list with no sentinels must pass through unchanged (no wrapper)."""
+    native = '[ OrderedList (1, Decimal, Period) [ [ Plain [Str "plain"] ] ] ]\n'
+    latex = _native_to_latex(native)
+    assert "\\item[]" not in latex
+    assert "plain" in latex

--- a/tests/test_docx_paragraph_preprocess.py
+++ b/tests/test_docx_paragraph_preprocess.py
@@ -1,0 +1,222 @@
+"""Unit tests for ``app.DocxParagraphPreProcess``.
+
+Each test builds a minimal DOCX zip in memory containing a single
+``word/document.xml`` plus the bare ``word/styles.xml`` skeleton, runs the
+preprocessor, and inspects the rewritten XML — the same synthetic-fixture
+approach as ``test_docx_color_preprocess.py``.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from xml.etree import ElementTree as ET  # noqa: S405
+
+from app import DocxParagraphPreProcess
+
+W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+ET.register_namespace("w", W_NS)
+
+EMPTY_STYLES_XML = b'<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"/>'
+
+
+def _pack(parts: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, data in parts.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+def _unpack(blob: bytes) -> dict[str, bytes]:
+    with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+        return {name: zf.read(name) for name in zf.namelist()}
+
+
+def _doc(*paras_xml: str) -> bytes:
+    body = "".join(paras_xml)
+    return ('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>' + body + "</w:body></w:document>").encode("utf-8")
+
+
+def _para(ppr_inner: str, text: str = "x") -> str:
+    """A <w:p> with the given <w:pPr> inner XML and a single text run."""
+    return f"<w:p><w:pPr>{ppr_inner}</w:pPr><w:r><w:t>{text}</w:t></w:r></w:p>"
+
+
+def _styles(blob: bytes) -> ET.Element:
+    return ET.fromstring(_unpack(blob)["word/styles.xml"])  # noqa: S314
+
+
+def _body(blob: bytes) -> ET.Element:
+    return ET.fromstring(_unpack(blob)["word/document.xml"])  # noqa: S314
+
+
+def _style_ids(styles_root: ET.Element) -> list[str]:
+    return [el.get(f"{{{W_NS}}}styleId") or "" for el in styles_root.findall(f"{{{W_NS}}}style")]
+
+
+def _pstyle_vals(body_root: ET.Element) -> list[str]:
+    return [el.get(f"{{{W_NS}}}val") or "" for el in body_root.iter(f"{{{W_NS}}}pStyle")]
+
+
+def _first_pppr(body_root: ET.Element) -> ET.Element:
+    return body_root.find(f".//{{{W_NS}}}pPr")  # type: ignore[return-value]
+
+
+# --- pass-through ---------------------------------------------------------
+
+
+def test_plain_paragraph_returns_input_unchanged():
+    """No jc / ind anywhere -> bytes are returned untouched (no rezip)."""
+    blob = _pack({"word/document.xml": _doc(_para("")), "word/styles.xml": EMPTY_STYLES_XML})
+    assert DocxParagraphPreProcess.preprocess(blob) == blob
+
+
+def test_paragraph_without_ppr_is_ignored():
+    doc = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>x</w:t></w:r></w:p></w:body></w:document>'.encode()
+    blob = _pack({"word/document.xml": doc, "word/styles.xml": EMPTY_STYLES_XML})
+    assert DocxParagraphPreProcess.preprocess(blob) == blob
+
+
+# --- alignment ------------------------------------------------------------
+
+
+def test_center_alignment_becomes_pstyle_and_jc_stripped():
+    blob = _pack({"word/document.xml": _doc(_para('<w:jc w:val="center"/>')), "word/styles.xml": EMPTY_STYLES_XML})
+    result = DocxParagraphPreProcess.preprocess(blob)
+    body = _body(result)
+    assert body.find(f".//{{{W_NS}}}jc") is None, "w:jc must be stripped"
+    assert _pstyle_vals(body) == ["PandocPara__ALIGN_center"]
+    assert "PandocPara__ALIGN_center" in _style_ids(_styles(result))
+
+
+def test_right_alignment():
+    blob = _pack({"word/document.xml": _doc(_para('<w:jc w:val="right"/>')), "word/styles.xml": EMPTY_STYLES_XML})
+    body = _body(DocxParagraphPreProcess.preprocess(blob))
+    assert _pstyle_vals(body) == ["PandocPara__ALIGN_right"]
+
+
+def test_left_alignment_is_not_encoded():
+    """left is the default reading direction; encoding it wrapped every
+    (notably table-cell) paragraph in \\raggedright for no benefit, so it is
+    deliberately left untouched."""
+    blob = _pack({"word/document.xml": _doc(_para('<w:jc w:val="left"/>')), "word/styles.xml": EMPTY_STYLES_XML})
+    assert DocxParagraphPreProcess.preprocess(blob) == blob
+
+
+def test_end_folds_to_right_and_start_is_not_encoded():
+    blob = _pack({"word/document.xml": _doc(_para('<w:jc w:val="start"/>'), _para('<w:jc w:val="end"/>')), "word/styles.xml": EMPTY_STYLES_XML})
+    body = _body(DocxParagraphPreProcess.preprocess(blob))
+    # start (= left) is not encoded; only the end (= right) paragraph is tagged.
+    assert _pstyle_vals(body) == ["PandocPara__ALIGN_right"]
+
+
+def test_justified_and_left_without_indent_are_not_encoded():
+    """left/start and both/distribute all map to the default; nothing to emit."""
+    blob = _pack({"word/document.xml": _doc(_para('<w:jc w:val="both"/>'), _para('<w:jc w:val="distribute"/>'), _para('<w:jc w:val="left"/>')), "word/styles.xml": EMPTY_STYLES_XML})
+    assert DocxParagraphPreProcess.preprocess(blob) == blob
+
+
+def test_paragraphs_inside_table_cells_are_not_rewritten():
+    """Pandoc renders table-cell alignment/indent from the table structure
+    itself, so cell paragraphs must be left alone — rewriting them is redundant
+    and the per-cell LaTeX wrapper changes table row spacing (regression)."""
+    cell = "<w:tc>" + _para('<w:jc w:val="center"/>', "in-cell") + "</w:tc>"
+    doc = ('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr>' + cell + "</w:tr></w:tbl></w:body></w:document>").encode()
+    blob = _pack({"word/document.xml": doc, "word/styles.xml": EMPTY_STYLES_XML})
+    # No paragraph rewritten -> bytes returned unchanged.
+    assert DocxParagraphPreProcess.preprocess(blob) == blob
+
+
+def test_body_paragraph_still_rewritten_alongside_table_cells():
+    """A centered body paragraph outside any cell is still tagged even when the
+    document also contains a (skipped) table cell."""
+    cell = "<w:tbl><w:tr><w:tc>" + _para('<w:jc w:val="center"/>', "cell") + "</w:tc></w:tr></w:tbl>"
+    body_para = _para('<w:jc w:val="center"/>', "body")
+    doc = ('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>' + cell + body_para + "</w:body></w:document>").encode()
+    blob = _pack({"word/document.xml": doc, "word/styles.xml": EMPTY_STYLES_XML})
+    result = DocxParagraphPreProcess.preprocess(blob)
+    # Exactly one pStyle added — for the body paragraph, not the cell paragraph.
+    assert _pstyle_vals(_body(result)) == ["PandocPara__ALIGN_center"]
+
+
+# --- indentation ----------------------------------------------------------
+
+
+def test_left_indent_becomes_pstyle_and_ind_stripped():
+    blob = _pack({"word/document.xml": _doc(_para('<w:ind w:left="600"/>')), "word/styles.xml": EMPTY_STYLES_XML})
+    result = DocxParagraphPreProcess.preprocess(blob)
+    body = _body(result)
+    assert body.find(f".//{{{W_NS}}}ind") is None, "w:ind must be stripped so pandoc doesn't make a BlockQuote"
+    assert _pstyle_vals(body) == ["PandocPara__IND_600"]
+    assert "PandocPara__IND_600" in _style_ids(_styles(result))
+
+
+def test_distinct_indent_levels_get_distinct_styles():
+    """The bug being fixed: 40px (600) and 80px (1200) must stay distinct,
+    not collapse into one BlockQuote level."""
+    blob = _pack({"word/document.xml": _doc(_para('<w:ind w:left="600"/>'), _para('<w:ind w:left="1200"/>')), "word/styles.xml": EMPTY_STYLES_XML})
+    result = DocxParagraphPreProcess.preprocess(blob)
+    assert _pstyle_vals(_body(result)) == ["PandocPara__IND_600", "PandocPara__IND_1200"]
+    ids = _style_ids(_styles(result))
+    assert "PandocPara__IND_600" in ids and "PandocPara__IND_1200" in ids
+
+
+def test_zero_and_negative_indent_are_not_encoded():
+    blob = _pack({"word/document.xml": _doc(_para('<w:ind w:left="0"/>'), _para('<w:ind w:left="-200"/>')), "word/styles.xml": EMPTY_STYLES_XML})
+    assert DocxParagraphPreProcess.preprocess(blob) == blob
+
+
+def test_non_integer_indent_is_ignored():
+    blob = _pack({"word/document.xml": _doc(_para('<w:ind w:left="abc"/>')), "word/styles.xml": EMPTY_STYLES_XML})
+    assert DocxParagraphPreProcess.preprocess(blob) == blob
+
+
+# --- combined -------------------------------------------------------------
+
+
+def test_alignment_and_indent_share_one_pstyle():
+    blob = _pack({"word/document.xml": _doc(_para('<w:jc w:val="right"/><w:ind w:left="600"/>')), "word/styles.xml": EMPTY_STYLES_XML})
+    result = DocxParagraphPreProcess.preprocess(blob)
+    assert _pstyle_vals(_body(result)) == ["PandocPara__ALIGN_right__IND_600"]
+    assert "PandocPara__ALIGN_right__IND_600" in _style_ids(_styles(result))
+
+
+def test_existing_pstyle_is_replaced_and_pstyle_is_first_child():
+    blob = _pack({"word/document.xml": _doc(_para('<w:pStyle w:val="BodyText"/><w:jc w:val="center"/>')), "word/styles.xml": EMPTY_STYLES_XML})
+    body = _body(DocxParagraphPreProcess.preprocess(blob))
+    # The old pStyle is gone, replaced by ours.
+    assert _pstyle_vals(body) == ["PandocPara__ALIGN_center"]
+    # And <w:pStyle> is the first child of <w:pPr> (OOXML CT_PPr schema order).
+    ppr = _first_pppr(body)
+    assert list(ppr)[0].tag == f"{{{W_NS}}}pStyle"
+
+
+# --- dedup / idempotency --------------------------------------------------
+
+
+def test_duplicate_combination_registers_one_style():
+    blob = _pack({"word/document.xml": _doc(_para('<w:jc w:val="center"/>', "a"), _para('<w:jc w:val="center"/>', "b")), "word/styles.xml": EMPTY_STYLES_XML})
+    result = DocxParagraphPreProcess.preprocess(blob)
+    assert _pstyle_vals(_body(result)) == ["PandocPara__ALIGN_center", "PandocPara__ALIGN_center"]
+    # styles.xml has exactly one entry for the shared style.
+    assert _style_ids(_styles(result)).count("PandocPara__ALIGN_center") == 1
+
+
+def test_preprocess_is_idempotent():
+    blob = _pack({"word/document.xml": _doc(_para('<w:jc w:val="center"/><w:ind w:left="600"/>')), "word/styles.xml": EMPTY_STYLES_XML})
+    once = DocxParagraphPreProcess.preprocess(blob)
+    # Second pass finds no jc/ind left to rewrite -> returns its input unchanged.
+    assert DocxParagraphPreProcess.preprocess(once) == once
+
+
+# --- robustness -----------------------------------------------------------
+
+
+def test_non_docx_input_is_returned_unchanged():
+    assert DocxParagraphPreProcess.preprocess(b"not a zip") == b"not a zip"
+
+
+def test_docx_without_styles_part_is_skipped():
+    blob = _pack({"word/document.xml": _doc(_para('<w:jc w:val="center"/>'))})
+    assert DocxParagraphPreProcess.preprocess(blob) == blob

--- a/tests/test_docx_paragraphs_to_latex_filter.py
+++ b/tests/test_docx_paragraphs_to_latex_filter.py
@@ -1,0 +1,86 @@
+"""Integration tests for ``filters/docx_paragraphs_to_latex.lua``.
+
+Spawns the real ``pandoc`` binary with the filter loaded and asserts the LaTeX
+output for a ``Div`` carrying the synthetic ``custom-style="PandocPara__..."``
+attribute the ``DocxParagraphPreProcess`` preprocessor produces. The AST shape
+is built via a markdown fenced div (``::: {custom-style="..."}``), which pandoc
+turns into exactly that ``Div`` node — so the test is pandoc-only and needs no
+DOCX fixture or tectonic.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+PANDOC = shutil.which("pandoc")
+FILTER_PATH = Path(__file__).resolve().parents[1] / "filters" / "docx_paragraphs_to_latex.lua"
+
+pytestmark = pytest.mark.skipif(
+    PANDOC is None or not FILTER_PATH.exists(),
+    reason="pandoc binary or filters/docx_paragraphs_to_latex.lua not available",
+)
+
+
+def _md_to_latex(md: str) -> str:
+    """Convert a markdown snippet to LaTeX through the filter; collapse
+    whitespace so assertions don't depend on pandoc's line wrapping."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        src = Path(tmpdir) / "in.md"
+        src.write_text(md, encoding="utf-8")
+        result = subprocess.run(
+            [PANDOC, "-f", "markdown", "-t", "latex", f"--lua-filter={FILTER_PATH}", str(src)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    return " ".join(result.stdout.split())
+
+
+def _div(style: str, text: str = "content") -> str:
+    return f'::: {{custom-style="{style}"}}\n{text}\n:::\n'
+
+
+def test_center_alignment_emits_centering():
+    flat = _md_to_latex(_div("PandocPara__ALIGN_center"))
+    assert "\\centering" in flat, flat
+    assert "\\par}" in flat, flat
+
+
+def test_right_alignment_emits_raggedleft():
+    assert "\\raggedleft" in _md_to_latex(_div("PandocPara__ALIGN_right"))
+
+
+def test_left_alignment_emits_raggedright():
+    assert "\\raggedright" in _md_to_latex(_div("PandocPara__ALIGN_left"))
+
+
+def test_indent_emits_leftskip_in_points():
+    """600 twips = 30pt, 1200 twips = 60pt — distinct, not collapsed."""
+    assert "\\leftskip=30.00pt" in _md_to_latex(_div("PandocPara__IND_600"))
+    assert "\\leftskip=60.00pt" in _md_to_latex(_div("PandocPara__IND_1200"))
+
+
+def test_alignment_and_indent_combined():
+    flat = _md_to_latex(_div("PandocPara__ALIGN_right__IND_600"))
+    assert "\\leftskip=30.00pt" in flat and "\\raggedleft" in flat, flat
+    # Balanced group: one opening brace before content, \par} after.
+    assert flat.count("\\par}") == 1, flat
+
+
+def test_invalid_indent_value_is_dropped():
+    """A non-integer / out-of-range twips value must not reach \\leftskip."""
+    flat = _md_to_latex(_div("PandocPara__IND_99999999"))  # exceeds the 31680 cap
+    assert "\\leftskip" not in flat, flat
+
+
+def test_non_pandocpara_div_is_left_alone():
+    flat = _md_to_latex(_div("SomeOtherStyle"))
+    assert "\\centering" not in flat
+    assert "\\raggedleft" not in flat
+    assert "\\leftskip" not in flat
+    assert "content" in flat

--- a/tests/test_html_lists_preprocess.py
+++ b/tests/test_html_lists_preprocess.py
@@ -135,7 +135,7 @@ def test_unparseable_input_passes_through():
 #
 # lxml's HTML parser is intentionally forgiving, so we patch the symbol the
 # preprocessor calls to force the exception branch. The contract is the same
-# as in HtmlIndentPreProcess: any caught parser exception must return the
+# as in HtmlParagraphPreProcess: any caught parser exception must return the
 # original source object unchanged (identity, not equality) so callers can
 # detect "no work done" without re-parsing.
 

--- a/tests/test_html_paragraph_preprocess.py
+++ b/tests/test_html_paragraph_preprocess.py
@@ -1,9 +1,10 @@
-"""Unit tests for ``app.HtmlIndentPreProcess``.
+"""Unit tests for ``app.HtmlParagraphPreProcess``.
 
-These tests verify the Python side of the paragraph-indent pipeline: that
-``<p style="margin-left:...">`` is rewritten into a marker ``<div>`` carrying
-``class="pandoc-indent"`` and ``data-indent-twips="N"``, and that the unit
-conversion from CSS lengths to Word twips is correct.
+These tests verify the Python side of the paragraph-formatting pipeline: that
+``<p style="margin-left:...; text-align:...">`` is rewritten into a marker
+``<div>`` carrying ``class="pandoc-para"`` plus ``data-indent-twips="N"``
+and/or ``data-text-align="..."``, that the unit conversion from CSS lengths to Word
+twips is correct, and that ``text-align`` keywords map to canonical tokens.
 
 The companion Lua filter (filters/inline_styles.lua) is exercised separately
 in ``test_inline_styles_filter_integration.py``.
@@ -13,12 +14,12 @@ from __future__ import annotations
 
 import pytest
 
-from app import HtmlIndentPreProcess
+from app import HtmlParagraphPreProcess
 
 
 def _twips_after_preprocess(src: bytes) -> int | None:
     """Helper: return the data-indent-twips value as int, or None if not wrapped."""
-    out = HtmlIndentPreProcess.preprocess(src)
+    out = HtmlParagraphPreProcess.preprocess(src)
     if b"data-indent-twips=" not in out:
         return None
     # Look for data-indent-twips="N" in the output.
@@ -29,14 +30,26 @@ def _twips_after_preprocess(src: bytes) -> int | None:
     return int(m.group(1))
 
 
+def _align_after_preprocess(src: bytes) -> str | None:
+    """Helper: return the data-text-align value as str, or None if not wrapped."""
+    out = HtmlParagraphPreProcess.preprocess(src)
+    if b"data-text-align=" not in out:
+        return None
+    import re
+
+    m = re.search(rb'data-text-align="([a-z]+)"', out)
+    assert m, f"data-text-align marker present but unparseable: {out!r}"
+    return m.group(1).decode()
+
+
 # --- happy path -----------------------------------------------------------
 
 
 def test_px_margin_left_is_wrapped_with_twips():
     """40px at the CSS reference DPI (96) = 1/2.4 inch = 600 twips."""
     src = b'<p style="margin-left: 40px;">hi</p>'
-    out = HtmlIndentPreProcess.preprocess(src)
-    assert b'class="pandoc-indent"' in out
+    out = HtmlParagraphPreProcess.preprocess(src)
+    assert b'class="pandoc-para"' in out
     assert b'data-indent-twips="600"' in out
     assert b"<p" in out and b"hi" in out
 
@@ -44,8 +57,8 @@ def test_px_margin_left_is_wrapped_with_twips():
 def test_user_provided_polarion_snippet():
     """Two paragraphs at different indents each get wrapped independently."""
     src = b'<p id="polarion_1" style="margin-left: 40px;">Indentation</p><p id="polarion_2" style="margin-left: 80px;">2 levels</p>'
-    out = HtmlIndentPreProcess.preprocess(src)
-    assert out.count(b'class="pandoc-indent"') == 2
+    out = HtmlParagraphPreProcess.preprocess(src)
+    assert out.count(b'class="pandoc-para"') == 2
     assert b'data-indent-twips="600"' in out
     assert b'data-indent-twips="1200"' in out
 
@@ -87,8 +100,8 @@ def test_css_length_conversion(value: str, expected_twips: int):
 )
 def test_invalid_or_zero_lengths_do_not_wrap(value: str):
     src = f'<p style="margin-left: {value}">x</p>'.encode()
-    out = HtmlIndentPreProcess.preprocess(src)
-    assert b"pandoc-indent" not in out
+    out = HtmlParagraphPreProcess.preprocess(src)
+    assert b"pandoc-para" not in out
 
 
 # --- style parsing --------------------------------------------------------
@@ -108,15 +121,15 @@ def test_margin_left_with_extra_whitespace():
 def test_margin_shorthand_is_not_treated_as_margin_left():
     """`margin: 0 0 0 40px` is a shorthand we deliberately don't parse."""
     src = b'<p style="margin: 0 0 0 40px">x</p>'
-    out = HtmlIndentPreProcess.preprocess(src)
-    assert b"pandoc-indent" not in out
+    out = HtmlParagraphPreProcess.preprocess(src)
+    assert b"pandoc-para" not in out
 
 
 def test_inline_style_left_alone_inside_indented_p():
     """The original <p> keeps its style attribute — the Lua filter doesn't
     need it stripped, and we don't want to alter unrelated CSS."""
     src = b'<p style="margin-left: 40px; color: red">x</p>'
-    out = HtmlIndentPreProcess.preprocess(src)
+    out = HtmlParagraphPreProcess.preprocess(src)
     assert b"color: red" in out
 
 
@@ -125,24 +138,24 @@ def test_inline_style_left_alone_inside_indented_p():
 
 def test_p_without_style_is_unchanged():
     src = b"<p>plain</p>"
-    assert HtmlIndentPreProcess.preprocess(src) == src
+    assert HtmlParagraphPreProcess.preprocess(src) == src
 
 
 def test_p_with_style_but_no_margin_left_is_unchanged():
     src = b'<p style="color: red">plain</p>'
-    assert HtmlIndentPreProcess.preprocess(src) == src
+    assert HtmlParagraphPreProcess.preprocess(src) == src
 
 
 def test_empty_input_is_returned_unchanged():
-    assert HtmlIndentPreProcess.preprocess(b"") == b""
+    assert HtmlParagraphPreProcess.preprocess(b"") == b""
 
 
 def test_non_p_elements_are_ignored():
     """Only <p> is targeted; <div style="margin-left:..."> is left alone for
     now (would need separate handling — see the limitations note)."""
     src = b'<div style="margin-left: 40px">x</div>'
-    out = HtmlIndentPreProcess.preprocess(src)
-    assert b"pandoc-indent" not in out
+    out = HtmlParagraphPreProcess.preprocess(src)
+    assert b"pandoc-para" not in out
 
 
 # --- structure / context --------------------------------------------------
@@ -153,21 +166,21 @@ def test_top_level_p_is_wrapped():
     fragment (no parent in the fragment list) must still be wrapped — we
     re-parent fragments under a synthetic root before walking."""
     src = b'<p style="margin-left: 40px">top-level</p>'
-    out = HtmlIndentPreProcess.preprocess(src)
-    assert b"pandoc-indent" in out
+    out = HtmlParagraphPreProcess.preprocess(src)
+    assert b"pandoc-para" in out
 
 
 def test_nested_p_is_wrapped():
     """A <p> deep inside other elements is still found and wrapped."""
     src = b'<div><section><p style="margin-left: 40px">deep</p></section></div>'
-    out = HtmlIndentPreProcess.preprocess(src)
-    assert b"pandoc-indent" in out
+    out = HtmlParagraphPreProcess.preprocess(src)
+    assert b"pandoc-para" in out
 
 
 def test_multiple_paragraphs_with_mixed_indentation():
     src = b'<p style="margin-left: 40px">A</p><p>plain</p><p style="margin-left: 80px">B</p>'
-    out = HtmlIndentPreProcess.preprocess(src)
-    assert out.count(b'class="pandoc-indent"') == 2
+    out = HtmlParagraphPreProcess.preprocess(src)
+    assert out.count(b'class="pandoc-para"') == 2
     assert b">plain</p>" in out  # un-wrapped one still exists as-is
 
 
@@ -190,11 +203,11 @@ def test_parse_failure_passes_input_through(mocker):
     # extra imports here; the assertion is "any caught exception returns the
     # original source untouched".
     mocker.patch(
-        "app.HtmlIndentPreProcess.html.fragments_fromstring",
+        "app.HtmlParagraphPreProcess.html.fragments_fromstring",
         side_effect=ValueError("synthetic parse failure"),
     )
     src = b'<p style="margin-left: 40px">x</p>'
-    assert HtmlIndentPreProcess.preprocess(src) is src
+    assert HtmlParagraphPreProcess.preprocess(src) is src
 
 
 def test_parse_failure_logs_warning(mocker, caplog):
@@ -205,12 +218,12 @@ def test_parse_failure_logs_warning(mocker, caplog):
     import logging  # noqa: PLC0415
 
     mocker.patch(
-        "app.HtmlIndentPreProcess.html.fragments_fromstring",
+        "app.HtmlParagraphPreProcess.html.fragments_fromstring",
         side_effect=ValueError("boom"),
     )
-    caplog.set_level(logging.WARNING, logger="app.HtmlIndentPreProcess")
-    HtmlIndentPreProcess.preprocess(b"<p>x</p>")
-    assert any("HtmlIndentPreProcess" in rec.message for rec in caplog.records), f"expected a WARNING from HtmlIndentPreProcess; got: {[r.message for r in caplog.records]!r}"
+    caplog.set_level(logging.WARNING, logger="app.HtmlParagraphPreProcess")
+    HtmlParagraphPreProcess.preprocess(b"<p>x</p>")
+    assert any("HtmlParagraphPreProcess" in rec.message for rec in caplog.records), f"expected a WARNING from HtmlParagraphPreProcess; got: {[r.message for r in caplog.records]!r}"
 
 
 # --- leading text ---------------------------------------------------------
@@ -228,9 +241,9 @@ def test_leading_text_before_indented_p_is_preserved_when_rewriting():
     together when there's text AND at least one paragraph gets wrapped.
     """
     src = b'hello there <p style="margin-left: 40px">indented</p>'
-    out = HtmlIndentPreProcess.preprocess(src)
+    out = HtmlParagraphPreProcess.preprocess(src)
     assert out.startswith(b"hello there"), f"leading text not preserved: {out!r}"
-    assert b'class="pandoc-indent"' in out
+    assert b'class="pandoc-para"' in out
 
 
 def test_leading_text_alone_does_not_force_rewrite():
@@ -241,7 +254,7 @@ def test_leading_text_alone_does_not_force_rewrite():
     lets us promise "valid HTML is never modified".
     """
     src = b"hello there <p>no indent</p>"
-    assert HtmlIndentPreProcess.preprocess(src) is src
+    assert HtmlParagraphPreProcess.preprocess(src) is src
 
 
 # --- decimal / rounding behavior ------------------------------------------
@@ -272,7 +285,7 @@ def test_subpixel_and_decimal_lengths(value: str, expected_twips: int):
 def test_very_large_indent_does_not_overflow():
     """Sanity: huge values still work — no overflow, no exception."""
     src = b'<p style="margin-left: 10000px">x</p>'
-    out = HtmlIndentPreProcess.preprocess(src)
+    out = HtmlParagraphPreProcess.preprocess(src)
     assert b'data-indent-twips="150000"' in out
 
 
@@ -312,8 +325,8 @@ def test_empty_p_with_margin_left_is_still_wrapped():
     """An empty paragraph that happens to be indented is still wrapped —
     visual whitespace alone is valid content in a document."""
     src = b'<p style="margin-left: 40px"></p>'
-    out = HtmlIndentPreProcess.preprocess(src)
-    assert b'class="pandoc-indent"' in out
+    out = HtmlParagraphPreProcess.preprocess(src)
+    assert b'class="pandoc-para"' in out
     assert b'data-indent-twips="600"' in out
 
 
@@ -321,7 +334,7 @@ def test_indented_p_with_nested_inline_children_keeps_structure():
     """Nested inline elements inside the indented <p> must not be flattened
     or reordered — the wrap is purely additive."""
     src = b'<p style="margin-left: 40px">a <strong>b</strong> <em>c</em> d</p>'
-    out = HtmlIndentPreProcess.preprocess(src)
+    out = HtmlParagraphPreProcess.preprocess(src)
     assert b"<strong>b</strong>" in out
     assert b"<em>c</em>" in out
     # The strong appears before the em in the output (order preserved).
@@ -333,8 +346,8 @@ def test_scientific_notation_lengths_are_rejected():
     intentionally doesn't accept exponents.
     """
     src = b'<p style="margin-left: 1e10px">x</p>'
-    out = HtmlIndentPreProcess.preprocess(src)
-    assert b"pandoc-indent" not in out
+    out = HtmlParagraphPreProcess.preprocess(src)
+    assert b"pandoc-para" not in out
 
 
 # --- module-level contract ------------------------------------------------
@@ -344,8 +357,9 @@ def test_module_constants_match_documented_contract():
     """The class name and attribute key are part of the contract with the
     Lua filter — pin them so a casual rename here doesn't silently break
     filters/inline_styles.lua, which hard-codes the same strings."""
-    assert HtmlIndentPreProcess.INDENT_CLASS == "pandoc-indent"
-    assert HtmlIndentPreProcess.INDENT_ATTR == "data-indent-twips"
+    assert HtmlParagraphPreProcess.PARA_CLASS == "pandoc-para"
+    assert HtmlParagraphPreProcess.INDENT_ATTR == "data-indent-twips"
+    assert HtmlParagraphPreProcess.ALIGN_ATTR == "data-text-align"
 
 
 # --- helper-function targeted tests ---------------------------------------
@@ -369,7 +383,7 @@ def test_module_constants_match_documented_contract():
     ],
 )
 def test_css_length_to_twips_direct(value: str, expected: int | None):
-    assert HtmlIndentPreProcess._css_length_to_twips(value) == expected
+    assert HtmlParagraphPreProcess._css_length_to_twips(value) == expected
 
 
 @pytest.mark.parametrize(
@@ -384,4 +398,123 @@ def test_css_length_to_twips_direct(value: str, expected: int | None):
     ],
 )
 def test_extract_margin_left_twips_direct(style: str, expected: int | None):
-    assert HtmlIndentPreProcess._extract_margin_left_twips(style) == expected
+    assert HtmlParagraphPreProcess._extract_margin_left_twips(style) == expected
+
+
+# --- text-align: happy path -----------------------------------------------
+
+
+def test_user_provided_alignment_snippet():
+    """The user's Polarion snippet: the style-less left paragraph is left
+    alone, while the centered/right ones get a marker div with data-text-align."""
+    src = b'<p id="polarion_template_0">Left aligned</p>\n<p id="polarion_1" style="text-align: center;">Centered</p>\n<p id="polarion_2" style="text-align: right;">Right aligned</p>'
+    out = HtmlParagraphPreProcess.preprocess(src)
+    # Exactly the two styled paragraphs are wrapped.
+    assert out.count(b'class="pandoc-para"') == 2
+    assert b'data-text-align="center"' in out
+    assert b'data-text-align="right"' in out
+    # The default-left paragraph keeps its text but is NOT wrapped.
+    assert b">Left aligned</p>" in out
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("left", "left"),
+        ("center", "center"),
+        ("right", "right"),
+        ("justify", "justify"),
+        ("start", "left"),  # logical start folds to left (LTR assumption)
+        ("end", "right"),  # logical end folds to right
+    ],
+)
+def test_text_align_keyword_mapping(value: str, expected: str):
+    src = f'<p style="text-align: {value};">x</p>'.encode()
+    assert _align_after_preprocess(src) == expected
+
+
+@pytest.mark.parametrize(
+    "style",
+    [
+        b"TEXT-ALIGN: Center",  # uppercase property + mixed-case value
+        b"text-align:center",  # no spaces around colon
+        b"text-align :center",  # space before colon
+        b"color: red; text-align: center; font-size: 12pt;",  # among other declarations
+        b"  text-align  :   center   ;",  # extra whitespace
+    ],
+)
+def test_text_align_parsing_is_case_and_whitespace_insensitive(style: bytes):
+    src = b'<p style="' + style + b'">x</p>'
+    assert _align_after_preprocess(src) == "center"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "inherit",
+        "initial",
+        "unset",
+        "-moz-center",  # vendor-prefixed
+        "garbage",
+        "",
+    ],
+)
+def test_unmapped_text_align_values_do_not_wrap(value: str):
+    src = f'<p style="text-align: {value};">x</p>'.encode()
+    out = HtmlParagraphPreProcess.preprocess(src)
+    assert b"pandoc-para" not in out
+
+
+def test_last_text_align_loses_to_first_when_declared_twice():
+    """Leftmost-wins, mirroring the margin-left contract — Polarion never
+    emits duplicates, so the simpler behavior is acceptable and pinned here."""
+    src = b'<p style="text-align: center; text-align: right">x</p>'
+    assert _align_after_preprocess(src) == "center"
+
+
+# --- text-align: combined with indent -------------------------------------
+
+
+def test_indent_and_align_share_one_wrapper():
+    """A paragraph with both margin-left and text-align must produce a single
+    marker div carrying both data attributes (not two nested divs)."""
+    src = b'<p style="margin-left: 40px; text-align: center;">both</p>'
+    out = HtmlParagraphPreProcess.preprocess(src)
+    assert out.count(b'class="pandoc-para"') == 1
+    assert b'data-indent-twips="600"' in out
+    assert b'data-text-align="center"' in out
+
+
+def test_align_only_wrapper_has_no_indent_attr():
+    src = b'<p style="text-align: right;">x</p>'
+    out = HtmlParagraphPreProcess.preprocess(src)
+    assert b'class="pandoc-para"' in out
+    assert b"data-indent-twips" not in out
+
+
+def test_indent_only_wrapper_has_no_align_attr():
+    src = b'<p style="margin-left: 40px;">x</p>'
+    out = HtmlParagraphPreProcess.preprocess(src)
+    assert b'class="pandoc-para"' in out
+    assert b"data-text-align" not in out
+
+
+# --- text-align: helper-function targeted tests ---------------------------
+
+
+@pytest.mark.parametrize(
+    ("style", "expected"),
+    [
+        ("text-align: center", "center"),
+        ("text-align: justify", "justify"),
+        ("text-align: start", "left"),
+        ("text-align: end", "right"),
+        ("text-align: inherit", None),
+        ("color: red", None),
+        ("", None),
+        ("text-align:", None),  # empty value
+        ("vertical-align: top", None),  # different property
+    ],
+)
+def test_extract_text_align_direct(style: str, expected: str | None):
+    assert HtmlParagraphPreProcess._extract_text_align(style) == expected

--- a/tests/test_inline_styles_filter_integration.py
+++ b/tests/test_inline_styles_filter_integration.py
@@ -186,13 +186,13 @@ def test_intersecting_text_decorations_are_additive():
 
 
 # ---------------------------------------------------------------------------
-# Paragraph indent (Div handler) — see filter.Div in filters/inline_styles.lua
+# Paragraph formatting (Div handler) — see filter.Div in filters/inline_styles.lua
 # ---------------------------------------------------------------------------
 #
-# These tests cover the contract with app/HtmlIndentPreProcess.py: a
-# <div class="pandoc-indent" data-indent-twips="N"><p>...</p></div> wrapper
-# becomes a raw OOXML <w:p> carrying <w:pPr><w:ind w:left="N"/></w:pPr> and
-# the original inlines rendered as <w:r> runs.
+# These tests cover the contract with app/HtmlParagraphPreProcess.py: a
+# <div class="pandoc-para" data-indent-twips="N" data-text-align="..."><p>...</p></div>
+# wrapper becomes a raw OOXML <w:p> carrying <w:pPr><w:ind w:left="N"/>
+# <w:jc w:val="..."/></w:pPr> and the original inlines rendered as <w:r> runs.
 
 
 def _w_p_with_text(doc: ET.Element, needle: str) -> ET.Element:
@@ -213,6 +213,14 @@ def _ind_left(p: ET.Element) -> str | None:
     return ind.get(f"{{{W_NS}}}left")
 
 
+def _jc_val(p: ET.Element) -> str | None:
+    """Read <w:jc w:val=...> off a paragraph, or None when not set."""
+    jc = p.find(f".//{{{W_NS}}}jc")
+    if jc is None:
+        return None
+    return jc.get(f"{{{W_NS}}}val")
+
+
 def test_indent_div_sets_w_ind_left_in_twips():
     """The canonical Polarion case: two paragraphs at different indents.
 
@@ -220,7 +228,7 @@ def test_indent_div_sets_w_ind_left_in_twips():
     N matches the data-indent-twips on the wrapper. 40px = 600 twips and
     80px = 1200 twips (1 px = 15 twips at the CSS reference DPI).
     """
-    html = '<div class="pandoc-indent" data-indent-twips="600"><p>Indentation</p></div><div class="pandoc-indent" data-indent-twips="1200"><p>2 levels</p></div>'
+    html = '<div class="pandoc-para" data-indent-twips="600"><p>Indentation</p></div><div class="pandoc-para" data-indent-twips="1200"><p>2 levels</p></div>'
     with tempfile.TemporaryDirectory() as tmpdir:
         out = Path(tmpdir) / "out.docx"
         _convert_html_to_docx(html, out)
@@ -237,7 +245,7 @@ def test_indent_preserves_inline_formatting_via_walk():
     still produce the right run properties. This is the key reason the Div
     handler reuses the existing walk() — without it, we'd lose all inline
     styling when rewriting the Para as raw OOXML."""
-    html = '<div class="pandoc-indent" data-indent-twips="600"><p>plain <strong>bold</strong> and <span style="color:#FF0000">red</span> text</p></div>'
+    html = '<div class="pandoc-para" data-indent-twips="600"><p>plain <strong>bold</strong> and <span style="color:#FF0000">red</span> text</p></div>'
     with tempfile.TemporaryDirectory() as tmpdir:
         out = Path(tmpdir) / "out.docx"
         _convert_html_to_docx(html, out)
@@ -268,7 +276,7 @@ def test_indent_div_without_twips_attribute_is_passthrough():
     """A Div with the class but no data-indent-twips must not be rewritten —
     we degrade to letting pandoc render the inner Para normally so we don't
     emit a <w:p> with malformed <w:ind w:left=""/>."""
-    html = '<div class="pandoc-indent"><p>no indent</p></div>'
+    html = '<div class="pandoc-para"><p>no indent</p></div>'
     with tempfile.TemporaryDirectory() as tmpdir:
         out = Path(tmpdir) / "out.docx"
         _convert_html_to_docx(html, out)
@@ -285,10 +293,10 @@ def test_indent_div_falls_back_when_para_contains_a_link():
     word/_rels/document.xml.rels — something the Div handler can't reproduce
     when it emits a single raw <w:p>. The handler must detect a Link inside
     the Para and fall back to leaving the Para alone (indent dropped, link
-    kept) rather than corrupting the document. See the build_indented_w_p
+    kept) rather than corrupting the document. See the build_para_w_p
     "graceful degradation" comment in filters/inline_styles.lua.
     """
-    html = '<div class="pandoc-indent" data-indent-twips="600"><p>see <a href="https://example.com/t">this link</a> please</p></div>'
+    html = '<div class="pandoc-para" data-indent-twips="600"><p>see <a href="https://example.com/t">this link</a> please</p></div>'
     with tempfile.TemporaryDirectory() as tmpdir:
         out = Path(tmpdir) / "out.docx"
         _convert_html_to_docx(html, out)
@@ -305,7 +313,7 @@ def test_indent_div_falls_back_when_para_contains_a_link():
 
 
 def test_plain_div_is_left_alone():
-    """A Div without the pandoc-indent class must pass through unchanged —
+    """A Div without the pandoc-para class must pass through unchanged —
     the handler's first guard. Otherwise unrelated <div>s in user content
     would all get rewritten as raw OOXML and lose pandoc's default styling."""
     html = '<div class="some-other-class"><p>just a div</p></div>'
@@ -317,7 +325,7 @@ def test_plain_div_is_left_alone():
 
     doc = ET.fromstring(doc_xml)
     p = _w_p_with_text(doc, "just a div")
-    assert _ind_left(p) is None, "filter applied an indent to a Div that doesn't have the pandoc-indent class"
+    assert _ind_left(p) is None, "filter applied an indent to a Div that doesn't have the pandoc-para class"
     # And the Para should still have whatever pStyle pandoc would normally
     # give it (not a raw <w:p> with no pStyle).
     pstyle = p.find(f".//{{{W_NS}}}pStyle")
@@ -325,12 +333,121 @@ def test_plain_div_is_left_alone():
 
 
 # ---------------------------------------------------------------------------
+# Paragraph alignment (data-text-align -> <w:jc>)
+# ---------------------------------------------------------------------------
+
+
+def test_align_div_sets_w_jc_val():
+    """The canonical Polarion case: centered and right-aligned paragraphs.
+
+    The filter must emit <w:p> with <w:pPr><w:jc w:val="..."/></w:pPr>, where
+    CSS center -> "center" and right -> "right".
+    """
+    html = '<div class="pandoc-para" data-text-align="center"><p>Centered</p></div><div class="pandoc-para" data-text-align="right"><p>Right aligned</p></div>'
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir) / "out.docx"
+        _convert_html_to_docx(html, out)
+        with zipfile.ZipFile(out) as zf:
+            doc_xml = zf.read("word/document.xml")
+
+    doc = ET.fromstring(doc_xml)
+    assert _jc_val(_w_p_with_text(doc, "Centered")) == "center"
+    assert _jc_val(_w_p_with_text(doc, "Right aligned")) == "right"
+
+
+def test_align_justify_maps_to_both():
+    """CSS `justify` becomes OOXML `both` — the one keyword whose OOXML
+    spelling differs from CSS."""
+    html = '<div class="pandoc-para" data-text-align="justify"><p>Justified</p></div>'
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir) / "out.docx"
+        _convert_html_to_docx(html, out)
+        with zipfile.ZipFile(out) as zf:
+            doc_xml = zf.read("word/document.xml")
+
+    doc = ET.fromstring(doc_xml)
+    assert _jc_val(_w_p_with_text(doc, "Justified")) == "both"
+
+
+def test_indent_and_align_emit_both_in_schema_order():
+    """A paragraph wrapper carrying both data attributes must produce a single
+    <w:p> whose <w:pPr> has <w:ind> immediately before <w:jc> (CT_PPr schema
+    order — Word reorders or drops out-of-order children otherwise)."""
+    html = '<div class="pandoc-para" data-indent-twips="600" data-text-align="center"><p>Both</p></div>'
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir) / "out.docx"
+        _convert_html_to_docx(html, out)
+        with zipfile.ZipFile(out) as zf:
+            doc_xml = zf.read("word/document.xml")
+
+    doc = ET.fromstring(doc_xml)
+    p = _w_p_with_text(doc, "Both")
+    assert _ind_left(p) == "600"
+    assert _jc_val(p) == "center"
+    # <w:ind> must come before <w:jc> within <w:pPr>.
+    ppr = p.find(f"{{{W_NS}}}pPr")
+    assert ppr is not None, "indented+aligned paragraph has no <w:pPr>"
+    child_tags = [c.tag.split("}", 1)[-1] for c in ppr]
+    assert "ind" in child_tags and "jc" in child_tags, f"missing ind/jc in pPr: {child_tags!r}"
+    assert child_tags.index("ind") < child_tags.index("jc"), f"<w:ind> must precede <w:jc> per CT_PPr schema order, got {child_tags!r}"
+
+
+def test_align_preserves_inline_formatting_via_walk():
+    """Nested inline formatting inside an aligned paragraph must survive the
+    raw-OOXML rewrite, same as for indent."""
+    html = '<div class="pandoc-para" data-text-align="center"><p>plain <strong>bold</strong> text</p></div>'
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir) / "out.docx"
+        _convert_html_to_docx(html, out)
+        with zipfile.ZipFile(out) as zf:
+            doc_xml = zf.read("word/document.xml")
+
+    doc = ET.fromstring(doc_xml)
+    p = _w_p_with_text(doc, "bold")
+    assert _jc_val(p) == "center", "alignment dropped on paragraph that contains inline formatting"
+    bold_run = next((r for r in p.iter(f"{{{W_NS}}}r") if "".join(t.text or "" for t in r.iter(f"{{{W_NS}}}t")) == "bold"), None)
+    assert bold_run is not None and bold_run.find(f".//{{{W_NS}}}b") is not None, "bold run lost <w:b/> after Div handler rewrote the aligned Para"
+
+
+def test_align_div_falls_back_when_para_contains_a_link():
+    """Same graceful-degradation contract as the indent path: a Link inside the
+    Para can't be reproduced in a raw <w:p>, so the handler keeps the original
+    Para (alignment dropped, link + relationship kept)."""
+    html = '<div class="pandoc-para" data-text-align="center"><p>see <a href="https://example.com/t">this link</a> please</p></div>'
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir) / "out.docx"
+        _convert_html_to_docx(html, out)
+        with zipfile.ZipFile(out) as zf:
+            doc_xml = zf.read("word/document.xml")
+            rels_xml = zf.read("word/_rels/document.xml.rels")
+
+    doc = ET.fromstring(doc_xml)
+    assert doc.find(f".//{{{W_NS}}}hyperlink") is not None, "Div handler dropped the <w:hyperlink> when falling back on an aligned paragraph"
+    assert b"hyperlink" in rels_xml, "hyperlink relationship missing — graceful degradation dropped the rel side-effect"
+
+
+def test_unknown_align_value_is_rejected():
+    """data-text-align is mapped through a fixed allowlist; an unrecognized value
+    must not reach <w:jc> and must not corrupt the paragraph."""
+    html = '<div class="pandoc-para" data-text-align="bogus"><p>visible text</p></div>'
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir) / "out.docx"
+        _convert_html_to_docx(html, out)
+        with zipfile.ZipFile(out) as zf:
+            doc_xml = zf.read("word/document.xml")
+
+    doc = ET.fromstring(doc_xml)
+    p = _w_p_with_text(doc, "visible text")
+    assert _jc_val(p) is None, "filter emitted a <w:jc> for an unmapped data-text-align value"
+
+
+# ---------------------------------------------------------------------------
 # Security: data-indent-twips validation
 # ---------------------------------------------------------------------------
 #
-# The HtmlIndentPreProcess preprocessor only ever writes integer values into
+# The HtmlParagraphPreProcess preprocessor only ever writes integer values into
 # data-indent-twips, but an HTTP caller can submit HTML that already contains
-# `<div class="pandoc-indent" data-indent-twips="…">` with arbitrary content.
+# `<div class="pandoc-para" data-indent-twips="…">` with arbitrary content.
 # Without validation that value is concatenated straight into a
 # <w:ind w:left="..."/> attribute, letting the attacker close the attribute
 # early and splice arbitrary OOXML into the document. The filter MUST treat
@@ -347,7 +464,7 @@ def test_attribute_injection_in_data_indent_twips_is_rejected():
     indent rather than splice the attacker's payload into the document.
     """
     payload = '600"/></w:pPr><w:r><w:t>INJECTED_PAYLOAD_marker_xyz</w:t></w:r><w:pPr x="'
-    html = f"<div class=\"pandoc-indent\" data-indent-twips='{payload}'><p>visible text</p></div>"
+    html = f"<div class=\"pandoc-para\" data-indent-twips='{payload}'><p>visible text</p></div>"
 
     with tempfile.TemporaryDirectory() as tmpdir:
         out = Path(tmpdir) / "out.docx"
@@ -398,7 +515,7 @@ def test_invalid_twips_values_drop_indent_but_keep_content(bad_value: str):
     permissive. The security boundary is "the value reaches OOXML as a
     bounded integer", not "the string looks lexically tidy".
     """
-    html = f"<div class=\"pandoc-indent\" data-indent-twips='{bad_value}'><p>some content here</p></div>"
+    html = f"<div class=\"pandoc-para\" data-indent-twips='{bad_value}'><p>some content here</p></div>"
     with tempfile.TemporaryDirectory() as tmpdir:
         out = Path(tmpdir) / "out.docx"
         _convert_html_to_docx(html, out)
@@ -421,7 +538,7 @@ def test_valid_integer_twips_values_still_work():
     bound, anything above is dropped)."""
     cases = [("1", "1"), ("600", "600"), ("31680", "31680")]
     for raw, expected in cases:
-        html = f'<div class="pandoc-indent" data-indent-twips="{raw}"><p>val_{raw}</p></div>'
+        html = f'<div class="pandoc-para" data-indent-twips="{raw}"><p>val_{raw}</p></div>'
         with tempfile.TemporaryDirectory() as tmpdir:
             out = Path(tmpdir) / "out.docx"
             _convert_html_to_docx(html, out)


### PR DESCRIPTION

### Proposed changes

Add filter to preserve alignment of paragraphs and fixes for preserving styling when converting DOCX to PDF.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
