### PR TITLE
fix: validate CLI path before filesystem access

### DIFF
--- a/app/DocxPostProcess.py
+++ b/app/DocxPostProcess.py
@@ -305,14 +305,19 @@ def main() -> int:
         logger.info("Usage: <path_to_docx> [paper_size] [orientation]")
         return 1
 
-    docx_path = sys.argv[DOCX_PATH_ARG_INDEX]
+    docx_path = Path(sys.argv[DOCX_PATH_ARG_INDEX]).resolve()
+    base_dir = Path.cwd().resolve()
+    if not docx_path.is_relative_to(base_dir):
+        logger.error(f"Refusing to access path outside the working directory: {docx_path}")
+        return 1
+
     paper_size = sys.argv[PAPER_SIZE_ARG_INDEX] if len(sys.argv) > PAPER_SIZE_ARG_INDEX and sys.argv[PAPER_SIZE_ARG_INDEX] != "None" else None
     orientation = sys.argv[ORIENTATION_ARG_INDEX] if len(sys.argv) > ORIENTATION_ARG_INDEX and sys.argv[ORIENTATION_ARG_INDEX] != "None" else None
 
-    with Path(docx_path).open("rb") as docx_file_reader:
+    with docx_path.open("rb") as docx_file_reader:
         result_bytes = process(docx_file_reader.read(), paper_size, orientation)
 
-    with Path(docx_path).open("wb") as docx_file_writer:
+    with docx_path.open("wb") as docx_file_writer:
         docx_file_writer.write(result_bytes)
 
     logger.debug(f"Successfully modified table properties in {docx_path}")

--- a/tests/test_docx_post_process.py
+++ b/tests/test_docx_post_process.py
@@ -1,4 +1,6 @@
 import sys
+import tempfile
+from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
@@ -815,6 +817,23 @@ def test_main_function(argv, expected_exit, paper_size, orientation):
             handle = mock_file()
             handle.write.assert_called_once_with(modified_content)
             mock_logging.debug.assert_called_once()
+
+
+def test_main_function_rejects_path_outside_working_directory():
+    outside_path = str(Path(tempfile.gettempdir()).resolve() / "escape.docx")
+
+    with (
+        patch.object(sys, "argv", ["script.py", outside_path]),
+        patch("pathlib.Path.open", mock_open()) as mock_file,
+        patch("app.DocxPostProcess.process") as mock_process,
+        patch("app.DocxPostProcess.logger") as mock_logging,
+    ):
+        result = DocxPostProcess.main()
+
+        assert result == 1
+        mock_process.assert_not_called()
+        mock_file.assert_not_called()
+        mock_logging.error.assert_called_once()
 
 
 # Integration tests for the process() function to ensure 100% coverage

--- a/tests/test_docx_post_process.py
+++ b/tests/test_docx_post_process.py
@@ -1,5 +1,4 @@
 import sys
-import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
@@ -820,10 +819,12 @@ def test_main_function(argv, expected_exit, paper_size, orientation):
 
 
 def test_main_function_rejects_path_outside_working_directory():
-    outside_path = str(Path(tempfile.gettempdir()).resolve() / "escape.docx")
+    fixed_cwd = Path("/app/workdir").resolve()
+    outside_path = str(Path("/outside/escape.docx").resolve())
 
     with (
         patch.object(sys, "argv", ["script.py", outside_path]),
+        patch("pathlib.Path.cwd", return_value=fixed_cwd),
         patch("pathlib.Path.open", mock_open()) as mock_file,
         patch("app.DocxPostProcess.process") as mock_process,
         patch("app.DocxPostProcess.logger") as mock_logging,


### PR DESCRIPTION
Refs: #174

### Proposed changes

We have to validate CLI path before filesystem access.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
