### PR TITLE
fix: math formula color is lost when converting HTML to DOCX

### DIFF
--- a/app/DocxMathColorPostProcess.py
+++ b/app/DocxMathColorPostProcess.py
@@ -1,0 +1,102 @@
+r"""Decode math color markers into real OMML color (companion to HtmlMathColorPreProcess).
+
+``HtmlMathColorPreProcess`` rewrites ``\color``/``\textcolor`` inside math scripts
+into ``\text{@@PMC:RRGGBB@@}...\text{@@PMCEND@@}`` markers before pandoc runs,
+because ``texmath`` cannot carry color through to OMML. Pandoc emits each
+``\text{}`` marker as its own ``<m:r>`` run, with the formerly-colored content as
+separate runs between the start and end markers in document order.
+
+:func:`apply_math_colors` walks the OMML runs of the document **in place** (it operates
+on the lxml tree ``DocxPostProcess`` has already parsed, so there is no extra
+serialize/parse round-trip), maintaining a stack of active colors:
+
+* a run whose text is a start marker pushes its color and is deleted;
+* a run whose text is the end marker pops and is deleted;
+* every other run, while the stack is non-empty, gets ``<w:color w:val="RRGGBB"/>``
+  (the innermost/top-of-stack color) added to its ``<w:rPr>``.
+
+Word renders per-run color inside equations, so the formula stays a live, editable
+equation *and* regains the color that ``texmath`` dropped.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from lxml import etree  # type: ignore[import-untyped]
+
+from app.HtmlMathColorPreProcess import MARKER_END, MARKER_PREFIX, MARKER_SUFFIX
+
+if TYPE_CHECKING:
+    from docx.document import Document as DocumentObject
+
+W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"  # NOSONAR OOXML namespace identifier (ECMA-376), never dereferenced
+M_NS = "http://schemas.openxmlformats.org/officeDocument/2006/math"  # NOSONAR OOXML math namespace identifier (ECMA-376), never dereferenced
+
+_M_R = f"{{{M_NS}}}r"
+_M_T = f"{{{M_NS}}}t"
+_M_RPR = f"{{{M_NS}}}rPr"
+_W_RPR = f"{{{W_NS}}}rPr"
+_W_COLOR = f"{{{W_NS}}}color"
+_W_VAL = f"{{{W_NS}}}val"
+
+# A start-marker run's text is exactly "@@PMC:RRGGBB@@"; capture the 6-hex color.
+_START_MARKER_RE = re.compile(rf"^{re.escape(MARKER_PREFIX)}([0-9A-Fa-f]{{6}}){re.escape(MARKER_SUFFIX)}$")
+
+
+def apply_math_colors(doc: DocumentObject) -> None:
+    """Colorize the math runs between marker pairs and remove the markers, mutating the
+    document in place. A document with no markers is left untouched.
+
+    Kept parallel to ``DocxReferencesPostProcess.add_table_of_contents_entries``: a public
+    function that takes the ``Document`` and is called directly from ``DocxPostProcess.process``.
+    """
+    color_stack: list[str] = []
+    marker_runs: list[etree._Element] = []
+
+    # Materialize the run list before mutating, so inserting <w:rPr> / removing marker
+    # runs cannot disturb a live tree walk.
+    for run in list(doc.element.iter(_M_R)):
+        text = _run_text(run)
+        if text == MARKER_END:
+            if color_stack:
+                color_stack.pop()
+            marker_runs.append(run)
+            continue
+        start = _START_MARKER_RE.match(text) if text is not None else None
+        if start is not None:
+            color_stack.append(start.group(1).upper())
+            marker_runs.append(run)
+            continue
+        if color_stack:
+            _apply_color(run, color_stack[-1])
+
+    for run in marker_runs:
+        parent = run.getparent()
+        if parent is not None:
+            parent.remove(run)
+
+
+def _run_text(run: etree._Element) -> str | None:
+    """The text of a math run's ``<m:t>`` child, or ``None`` if it has none."""
+    text_element = run.find(_M_T)
+    if text_element is None:
+        return None
+    return text_element.text
+
+
+def _apply_color(run: etree._Element, hex_color: str) -> None:
+    """Set ``<w:color w:val=hex_color>`` on a math run, creating its ``<w:rPr>`` if absent.
+    ``<w:rPr>`` sits after the math run properties ``<m:rPr>`` (if present) and before
+    ``<m:t>``, matching how Word writes colored equation runs.
+    """
+    w_rpr = run.find(_W_RPR)
+    if w_rpr is None:
+        w_rpr = run.makeelement(_W_RPR, {})
+        insert_at = 1 if run.find(_M_RPR) is not None else 0
+        run.insert(insert_at, w_rpr)
+    color = w_rpr.find(_W_COLOR)
+    if color is None:
+        color = etree.SubElement(w_rpr, _W_COLOR)
+    color.set(_W_VAL, hex_color)

--- a/app/DocxMathColorPostProcess.py
+++ b/app/DocxMathColorPostProcess.py
@@ -55,9 +55,10 @@ def apply_math_colors(doc: DocumentObject) -> None:
     color_stack: list[str] = []
     marker_runs: list[etree._Element] = []
 
-    # Materialize the run list before mutating, so inserting <w:rPr> / removing marker
-    # runs cannot disturb a live tree walk.
-    for run in list(doc.element.iter(_M_R)):
+    # Walking the live tree is safe here: marker runs are removed in a second pass
+    # (below), never during this walk, and _apply_color inserts only <w:rPr> (never an
+    # <m:r>), so the set of runs this loop visits does not change under it.
+    for run in doc.element.iter(_M_R):
         text = _run_text(run)
         if text == MARKER_END:
             if color_stack:
@@ -74,7 +75,7 @@ def apply_math_colors(doc: DocumentObject) -> None:
 
     for run in marker_runs:
         parent = run.getparent()
-        if parent is not None:
+        if parent is not None:  # pragma: no branch - a marker run always has a parent
             parent.remove(run)
 
 
@@ -94,7 +95,8 @@ def _apply_color(run: etree._Element, hex_color: str) -> None:
     w_rpr = run.find(_W_RPR)
     if w_rpr is None:
         w_rpr = run.makeelement(_W_RPR, {})
-        insert_at = 1 if run.find(_M_RPR) is not None else 0
+        m_rpr = run.find(_M_RPR)
+        insert_at = list(run).index(m_rpr) + 1 if m_rpr is not None else 0
         run.insert(insert_at, w_rpr)
     color = w_rpr.find(_W_COLOR)
     if color is None:

--- a/app/DocxPostProcess.py
+++ b/app/DocxPostProcess.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from docx.section import Section
     from docx.table import Table, _Cell
 
+from app.DocxMathColorPostProcess import apply_math_colors
 from app.DocxReferencesPostProcess import add_table_of_contents_entries, enable_auto_update_fields
 
 # Patch the python-docx parser to handle large XML documents (> 10MB)
@@ -52,6 +53,7 @@ def process(docx_bytes: bytes, paper_size: str | None = None, orientation: str |
     _move_header_footer_references_to_first_section(doc)
     _replace_size_and_orientation(doc, paper_size, orientation)
     _replace_table_properties(doc)
+    apply_math_colors(doc)
     add_table_of_contents_entries(doc)
     enable_auto_update_fields(doc)
     out = io.BytesIO()

--- a/app/HtmlMathColorPreProcess.py
+++ b/app/HtmlMathColorPreProcess.py
@@ -1,0 +1,295 @@
+r"""Preserve LaTeX math color (``\color`` / ``\textcolor``) across pandoc.
+
+Pandoc converts the LaTeX inside ``<script type="math/tex">`` to native Word
+equations (OMML) through its ``texmath`` library. ``texmath`` discards ``\color``
+(it parses the formula but drops the color), cannot parse ``\textcolor`` at all
+(the whole formula then leaks as ``$$...$$`` text), and its OMML writer has no
+color output — so a colored math run reaches Word black, or not at all.
+
+This preprocessor is the *encode* half of a two-step shim (the *decode* half is
+``app/DocxMathColorPostProcess.py``). For every math script it rewrites
+
+    \color{NAME}{X}   \textcolor[HTML]{RRGGBB}{X}
+
+into
+
+    \text{@@PMC:RRGGBB@@}X\text{@@PMCEND@@}
+
+The ``\text{...}`` markers are plain text that ``texmath`` keeps as distinct OMML
+runs (verified: each ``\text{}`` becomes one ``<m:r><m:t>...</m:t></m:r>``), with
+the formerly-colored content sitting as separate runs between the start and end
+markers in document order. ``DocxMathColorPostProcess`` then walks the OMML runs,
+turns each start/end marker pair into a ``<w:color>`` on the runs between them,
+and deletes the marker runs.
+
+Why encode here and not just leave the color to ``texmath``: ``texmath`` has no
+path to colored OMML (reader drops it, writer can't emit it), so the intent must
+be carried across the conversion as text that survives, then re-applied to the
+OOXML afterwards.
+
+Scope: the two color macros MathJax's color extension actually defines are
+``\color`` and ``\textcolor`` (not ``\mathcolor``, which is a KaTeX command MathJax
+never emits). Only their two-argument form ``\cmd{color}{content}`` is transformed
+— in Polarion's MathJax 2.7.9 ``\color`` is the two-argument macro that colors its
+argument. The one-argument switch form ``\color{name}`` (color applies to the rest
+of the group, the standard-LaTeX/MathJax-v3 behavior) is left untouched — that is
+``texmath``'s existing behavior for ``\color`` (content survives, color dropped). A
+color we cannot resolve to a hex value unwraps to its bare content (dropping the
+color) rather than being left in place, so ``\textcolor`` — which would otherwise
+leak the whole formula — still renders.
+
+Not handled: ``\colorbox`` / ``\fcolorbox`` (background/border shading, a different
+OMML feature than run ``<w:color>``) leak or lose their box.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+# Marker sentinels. Shared with app/DocxMathColorPostProcess.py, which parses them
+# back out. Chosen to (a) survive texmath intact inside \text{} as a single run and
+# (b) be vanishingly unlikely to collide with real formula text. The start marker
+# carries the resolved 6-hex color; the end marker is generic (the decoder uses a
+# color stack, so nested colors pop correctly without the end marker naming a color).
+MARKER_PREFIX = "@@PMC:"
+MARKER_SUFFIX = "@@"
+MARKER_END = "@@PMCEND@@"
+
+# The math scripts Polarion emits: <script type="math/tex; mode=display">LATEX</script>.
+# We locate them with a regex and rewrite only their body, leaving the rest of the
+# HTML byte-for-byte unchanged (safer than a full HTML round-trip, which could
+# normalize unrelated markup or escape the "<"/">" that appears in math like a<b).
+# The body is captured non-greedily up to the closing tag; LaTeX never contains
+# "</script>". Both quote styles and a trailing "; mode=display" are tolerated.
+_MATH_SCRIPT_RE = re.compile(
+    r"""(<script\b[^>]*\btype\s*=\s*["']math/tex[^"']*["'][^>]*>)(.*?)(</script>)""",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# The color macros MathJax's color extension defines that take a (color, content)
+# argument pair. \color's one-argument switch form (standard LaTeX / MathJax v3) is
+# handled by the "no second brace group -> leave untouched" fallback. \mathcolor is
+# deliberately absent: it is a KaTeX command, not a MathJax one, so Polarion never
+# emits it.
+_COLOR_COMMANDS = frozenset({"color", "textcolor"})
+
+# CSS/xcolor color name -> 6-hex (uppercase). Keys are lowercased on lookup, so
+# "Red"/"RED"/"red" all resolve. Covers the CSS basic/extended names and the
+# dvips-style capitalized names Polarion authors commonly type; an unlisted name
+# resolves to None and the content renders uncolored (never leaks).
+_COLOR_NAMES: dict[str, str] = {
+    "black": "000000",
+    "white": "FFFFFF",
+    "red": "FF0000",
+    "green": "008000",
+    "lime": "00FF00",
+    "blue": "0000FF",
+    "yellow": "FFFF00",
+    "cyan": "00FFFF",
+    "aqua": "00FFFF",
+    "magenta": "FF00FF",
+    "fuchsia": "FF00FF",
+    "gray": "808080",
+    "grey": "808080",
+    "silver": "C0C0C0",
+    "lightgray": "D3D3D3",
+    "lightgrey": "D3D3D3",
+    "darkgray": "A9A9A9",
+    "darkgrey": "A9A9A9",
+    "maroon": "800000",
+    "olive": "808000",
+    "purple": "800080",
+    "teal": "008080",
+    "navy": "000080",
+    "orange": "FFA500",
+    "pink": "FFC0CB",
+    "brown": "A52A2A",
+    "violet": "EE82EE",
+    "gold": "FFD700",
+    "indigo": "4B0082",
+    "darkred": "8B0000",
+    "darkgreen": "006400",
+    "darkblue": "00008B",
+    "lightblue": "ADD8E6",
+    "darkorange": "FF8C00",
+}
+
+_HEX6_RE = re.compile(r"^[0-9A-Fa-f]{6}$")
+_HEX3_RE = re.compile(r"^[0-9A-Fa-f]{3}$")
+
+
+def preprocess(source: bytes) -> bytes:
+    """Rewrite ``\\color``/``\\textcolor`` inside math scripts into color markers.
+    Idempotent on input with no color to rewrite — returns the original bytes
+    unchanged (so the byte-preserving guarantee holds for the common case).
+    """
+    try:
+        text = source.decode("utf-8")
+    except UnicodeDecodeError:
+        logger.warning("HtmlMathColorPreProcess: input is not valid UTF-8; passing through unchanged")
+        return source
+
+    # Cheap guard: nothing to do unless a color command appears somewhere. ("\\color"
+    # is not a substring of "\\textcolor", so both spellings must be checked.)
+    if "\\color" not in text and "\\textcolor" not in text:
+        return source
+
+    changed = False
+
+    def replace_script(match: re.Match[str]) -> str:
+        nonlocal changed
+        open_tag, body, close_tag = match.group(1), match.group(2), match.group(3)
+        new_body = _rewrite_math_colors(body)
+        if new_body != body:
+            changed = True
+        return open_tag + new_body + close_tag
+
+    result = _MATH_SCRIPT_RE.sub(replace_script, text)
+    if not changed:
+        return source
+    return result.encode("utf-8")
+
+
+def _rewrite_math_colors(latex: str) -> str:
+    """Rewrite the color commands in one LaTeX string, recursing into their content."""
+    out: list[str] = []
+    i = 0
+    n = len(latex)
+    while i < n:
+        char = latex[i]
+        if char != "\\":
+            out.append(char)
+            i += 1
+            continue
+
+        name, name_end = _read_control_word(latex, i)
+        if name in _COLOR_COMMANDS:
+            parsed = _parse_color_command(latex, name_end)
+            if parsed is not None:
+                hex_color, content, end = parsed
+                inner = _rewrite_math_colors(content)  # nested colors convert too
+                if hex_color is not None:
+                    out.append("\\text{" + MARKER_PREFIX + hex_color + MARKER_SUFFIX + "}")
+                    out.append(inner)
+                    out.append("\\text{" + MARKER_END + "}")
+                else:
+                    # Color we cannot resolve: keep the content (uncolored) rather than
+                    # leave the command in place, so \textcolor does not leak.
+                    out.append(inner)
+                i = end
+                continue
+
+        # Not a color command (or its arguments were malformed): copy the control
+        # sequence verbatim. A control word is backslash + letters; a control symbol
+        # (backslash + single non-letter, e.g. "\{") is copied as its two characters.
+        if name_end > i + 1:
+            out.append(latex[i:name_end])
+            i = name_end
+        else:
+            out.append(latex[i : i + 2])
+            i += 2
+    return "".join(out)
+
+
+def _read_control_word(latex: str, backslash_index: int) -> tuple[str, int]:
+    """Return the control-word name after the backslash at ``backslash_index`` and the
+    index just past it. An empty name means a control symbol (backslash + non-letter).
+    """
+    j = backslash_index + 1
+    while j < len(latex) and latex[j].isascii() and latex[j].isalpha():
+        j += 1
+    return latex[backslash_index + 1 : j], j
+
+
+def _parse_color_command(latex: str, pos: int) -> tuple[str | None, str, int] | None:
+    """Parse the ``[model]{color}{content}`` arguments starting at ``pos`` (just past the
+    command name). Returns ``(hex_or_None, content, end_index)``, or ``None`` when the
+    two-argument brace form is absent (switch form or malformed) so the caller leaves
+    the command untouched. ``hex_or_None`` is ``None`` when the color cannot be resolved.
+    """
+    i = _skip_ws(latex, pos)
+    model: str | None = None
+    if i < len(latex) and latex[i] == "[":
+        close = latex.find("]", i)
+        if close == -1:
+            return None
+        model = latex[i + 1 : close].strip()
+        i = _skip_ws(latex, close + 1)
+
+    color_value = _read_brace_group(latex, i)
+    if color_value is None:
+        return None
+    i = _skip_ws(latex, color_value[1])
+
+    content = _read_brace_group(latex, i)
+    if content is None:
+        return None
+
+    return _resolve_color(model, color_value[0].strip()), content[0], content[1]
+
+
+def _read_brace_group(latex: str, i: int) -> tuple[str, int] | None:
+    """If ``latex[i]`` opens a brace group, return ``(inner_text, index_past_close)``;
+    otherwise ``None``.
+    """
+    if i >= len(latex) or latex[i] != "{":
+        return None
+    close = _find_matching_brace(latex, i)
+    if close == -1:
+        return None
+    return latex[i + 1 : close], close + 1
+
+
+def _find_matching_brace(latex: str, open_index: int) -> int:
+    """Index of the ``}`` matching the ``{`` at ``open_index`` (honoring nesting and
+    skipping escaped characters), or ``-1`` if unbalanced.
+    """
+    depth = 0
+    i = open_index
+    n = len(latex)
+    while i < n:
+        char = latex[i]
+        if char == "\\":
+            i += 2  # skip the escaped character
+            continue
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return -1
+
+
+def _skip_ws(latex: str, i: int) -> int:
+    while i < len(latex) and latex[i].isspace():
+        i += 1
+    return i
+
+
+def _resolve_color(model: str | None, value: str) -> str | None:
+    """Resolve a color argument to an uppercase 6-hex string, or ``None`` if unknown.
+
+    Supported: the default model (a named color, ``#RGB``/``#RRGGBB`` or bare
+    ``RRGGBB`` hex) and ``[HTML]{RRGGBB}``. Other xcolor models (rgb, cmyk, gray)
+    are not resolved — the content then renders uncolored.
+    """
+    if model is None or model == "":
+        return _resolve_hex(value) or _COLOR_NAMES.get(value.lower())
+    if model.lower() == "html":
+        return _resolve_hex(value)
+    return None
+
+
+def _resolve_hex(value: str) -> str | None:
+    """Normalize ``#RRGGBB``, ``#RGB``, ``RRGGBB`` or ``RGB`` to uppercase ``RRGGBB``."""
+    candidate = value[1:] if value.startswith("#") else value
+    if _HEX6_RE.match(candidate):
+        return candidate.upper()
+    if _HEX3_RE.match(candidate):
+        return "".join(component * 2 for component in candidate).upper()
+    return None

--- a/app/HtmlMathColorPreProcess.py
+++ b/app/HtmlMathColorPreProcess.py
@@ -167,19 +167,10 @@ def _rewrite_math_colors(latex: str) -> str:
 
         name, name_end = _read_control_word(latex, i)
         if name in _COLOR_COMMANDS:
-            parsed = _parse_color_command(latex, name_end)
-            if parsed is not None:
-                hex_color, content, end = parsed
-                inner = _rewrite_math_colors(content)  # nested colors convert too
-                if hex_color is not None:
-                    out.append("\\text{" + MARKER_PREFIX + hex_color + MARKER_SUFFIX + "}")
-                    out.append(inner)
-                    out.append("\\text{" + MARKER_END + "}")
-                else:
-                    # Color we cannot resolve: keep the content (uncolored) rather than
-                    # leave the command in place, so \textcolor does not leak.
-                    out.append(inner)
-                i = end
+            rewritten = _rewrite_color_command(latex, name, name_end)
+            if rewritten is not None:
+                text, i = rewritten
+                out.append(text)
                 continue
 
         # Not a color command (or its arguments were malformed): copy the control
@@ -194,6 +185,26 @@ def _rewrite_math_colors(latex: str) -> str:
     return "".join(out)
 
 
+def _rewrite_color_command(latex: str, name: str, name_end: int) -> tuple[str, int] | None:
+    """Rewrite the color command ``name`` whose name ends at ``name_end``, recursing into
+    its content. Returns ``(replacement_text, index_past_command)``, or ``None`` when the
+    two-argument brace form is absent (switch form or malformed) so the caller copies
+    the command verbatim.
+    """
+    parsed = _parse_color_command(latex, name_end)
+    if parsed is None:
+        return None
+    hex_color, raw_color, content, end = parsed
+    inner = _rewrite_math_colors(content)  # nested colors convert too
+    if hex_color is None:
+        # Color we cannot resolve: keep the content (uncolored) rather than leave the
+        # command in place, so \textcolor does not leak. Warn so the dropped color is
+        # traceable when debugging a formula.
+        logger.warning("HtmlMathColorPreProcess: unresolvable color %r in \\%s - content kept, color dropped", raw_color, name)
+        return inner, end
+    return "\\text{" + MARKER_PREFIX + hex_color + MARKER_SUFFIX + "}" + inner + "\\text{" + MARKER_END + "}", end
+
+
 def _read_control_word(latex: str, backslash_index: int) -> tuple[str, int]:
     """Return the control-word name after the backslash at ``backslash_index`` and the
     index just past it. An empty name means a control symbol (backslash + non-letter).
@@ -204,10 +215,10 @@ def _read_control_word(latex: str, backslash_index: int) -> tuple[str, int]:
     return latex[backslash_index + 1 : j], j
 
 
-def _parse_color_command(latex: str, pos: int) -> tuple[str | None, str, int] | None:
+def _parse_color_command(latex: str, pos: int) -> tuple[str | None, str, str, int] | None:
     """Parse the ``[model]{color}{content}`` arguments starting at ``pos`` (just past the
-    command name). Returns ``(hex_or_None, content, end_index)``, or ``None`` when the
-    two-argument brace form is absent (switch form or malformed) so the caller leaves
+    command name). Returns ``(hex_or_None, raw_color, content, end_index)``, or ``None`` when
+    the two-argument brace form is absent (switch form or malformed) so the caller leaves
     the command untouched. ``hex_or_None`` is ``None`` when the color cannot be resolved.
     """
     i = _skip_ws(latex, pos)
@@ -228,7 +239,8 @@ def _parse_color_command(latex: str, pos: int) -> tuple[str | None, str, int] | 
     if content is None:
         return None
 
-    return _resolve_color(model, color_value[0].strip()), content[0], content[1]
+    raw_color = color_value[0].strip()
+    return _resolve_color(model, raw_color), raw_color, content[0], content[1]
 
 
 def _read_brace_group(latex: str, i: int) -> tuple[str, int] | None:

--- a/app/PandocController.py
+++ b/app/PandocController.py
@@ -23,7 +23,7 @@ from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.schema import VersionSchema
 
-from . import DocxLatexPreProcess, DocxPostProcess, HtmlListsPreProcess, HtmlParagraphPreProcess, PptxPostProcess
+from . import DocxLatexPreProcess, DocxPostProcess, HtmlListsPreProcess, HtmlMathColorPreProcess, HtmlParagraphPreProcess, PptxPostProcess
 from .chromium_manager import get_chromium_manager
 from .metrics_server import MetricsServer, get_metrics_port, is_metrics_server_enabled
 from .pandoc_metrics import get_pandoc_metrics
@@ -678,6 +678,7 @@ def run_pandoc_conversion(source_data: str | bytes, source_format: str, target_f
     if source_format == "html" and target_format == "docx":
         source_data = HtmlListsPreProcess.preprocess(source_data)
         source_data = HtmlParagraphPreProcess.preprocess(source_data)
+        source_data = HtmlMathColorPreProcess.preprocess(source_data)
 
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as source_file, tempfile.NamedTemporaryFile(delete=False) as output_file:
         try:

--- a/tests/test_docx_math_color_postprocess.py
+++ b/tests/test_docx_math_color_postprocess.py
@@ -103,6 +103,38 @@ def test_document_without_markers_is_unchanged() -> None:
     assert etree.tostring(doc.element) == before
 
 
+def test_end_marker_without_open_is_ignored() -> None:
+    # A stray end marker (empty color stack) is removed without error; following runs
+    # stay uncolored.
+    doc = _doc(_run("@@PMCEND@@") + _run("x"))
+    apply_math_colors(doc)
+    runs = _runs(doc)
+    assert [_text(r) for r in runs] == ["x"]  # end marker removed
+    assert _color(runs[0]) is None
+
+
+def test_content_run_without_text_element_is_colored() -> None:
+    # A math run carrying no <m:t> (text is None) is neither marker; while a color is
+    # active it still gets <w:color>, and the walk does not crash on the missing text.
+    doc = _doc(_run("@@PMC:FF0000@@") + "<m:r></m:r>" + _run("@@PMCEND@@"))
+    apply_math_colors(doc)
+    (run,) = _runs(doc)
+    assert _text(run) is None
+    assert _color(run) == "FF0000"
+
+
+def test_existing_run_color_is_overwritten() -> None:
+    # A content run that already carries <w:rPr> with a <w:color> keeps that single
+    # rPr/color pair, with the value replaced by the active marker color.
+    existing = '<m:r><w:rPr><w:color w:val="000000"/></w:rPr><m:t>x</m:t></m:r>'
+    doc = _doc(_run("@@PMC:FF0000@@") + existing + _run("@@PMCEND@@"))
+    apply_math_colors(doc)
+    (run,) = _runs(doc)
+    assert len(run.findall(f"{{{W_NS}}}rPr")) == 1
+    assert len(run.find(f"{{{W_NS}}}rPr").findall(f"{{{W_NS}}}color")) == 1
+    assert _color(run) == "FF0000"
+
+
 def test_color_survives_document_save() -> None:
     # The injected <w:color> must survive a python-docx save/reload round-trip.
     doc = _doc(_run("@@PMC:FF0000@@") + _run("x") + _run("@@PMCEND@@"))

--- a/tests/test_docx_math_color_postprocess.py
+++ b/tests/test_docx_math_color_postprocess.py
@@ -1,0 +1,116 @@
+"""Unit tests for ``app.DocxMathColorPostProcess.apply_math_colors``.
+
+These verify the *decode* half of the math-color shim: given a ``Document`` whose OMML
+carries ``@@PMC:RRGGBB@@`` / ``@@PMCEND@@`` marker runs (as pandoc emits them from the
+``\\text{}`` markers ``HtmlMathColorPreProcess`` injects), ``apply_math_colors`` adds
+``<w:color>`` to the runs between each marker pair and deletes the markers, mutating the
+document in place. The encoder is tested in ``test_html_math_color_preprocess.py`` and the
+full round-trip through pandoc in ``test_math_color_integration.py``.
+"""
+
+from __future__ import annotations
+
+import io
+
+from docx import Document
+from docx.oxml import parse_xml
+from lxml import etree
+
+from app.DocxMathColorPostProcess import apply_math_colors
+
+W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+M_NS = "http://schemas.openxmlformats.org/officeDocument/2006/math"
+
+
+def _run(text: str, *, with_m_rpr: bool = False) -> str:
+    rpr = "<m:rPr></m:rPr>" if with_m_rpr else ""
+    return f"<m:r>{rpr}<m:t>{text}</m:t></m:r>"
+
+
+def _doc(omath_body: str) -> Document:
+    """A Document whose body holds one <m:oMath> built from the given run fragments."""
+    doc = Document()
+    body = doc.element.find(f"{{{W_NS}}}body")
+    body.append(parse_xml(f'<w:p xmlns:w="{W_NS}" xmlns:m="{M_NS}"><m:oMath>{omath_body}</m:oMath></w:p>'))
+    return doc
+
+
+def _runs(doc: Document) -> list[etree._Element]:
+    return list(doc.element.iter(f"{{{M_NS}}}r"))
+
+
+def _text(run: etree._Element) -> str | None:
+    t = run.find(f"{{{M_NS}}}t")
+    return None if t is None else t.text
+
+
+def _color(run: etree._Element) -> str | None:
+    color = run.find(f"{{{W_NS}}}rPr/{{{W_NS}}}color")
+    return None if color is None else color.get(f"{{{W_NS}}}val")
+
+
+def test_single_colored_run() -> None:
+    doc = _doc(_run("@@PMC:FF0000@@") + _run("x") + _run("@@PMCEND@@"))
+    apply_math_colors(doc)
+    runs = _runs(doc)
+    assert len(runs) == 1  # both markers removed
+    assert _text(runs[0]) == "x"
+    assert _color(runs[0]) == "FF0000"
+
+
+def test_multiple_content_runs_all_colored() -> None:
+    doc = _doc(_run("@@PMC:00FF00@@") + _run("b") + _run("2") + _run("@@PMCEND@@"))
+    apply_math_colors(doc)
+    runs = _runs(doc)
+    assert [_text(r) for r in runs] == ["b", "2"]
+    assert all(_color(r) == "00FF00" for r in runs)
+
+
+def test_nested_colors_use_innermost() -> None:
+    body = _run("@@PMC:FF0000@@") + _run("a") + _run("@@PMC:0000FF@@") + _run("b") + _run("@@PMCEND@@") + _run("c") + _run("@@PMCEND@@")
+    doc = _doc(body)
+    apply_math_colors(doc)
+    colors = {_text(r): _color(r) for r in _runs(doc)}
+    assert colors == {"a": "FF0000", "b": "0000FF", "c": "FF0000"}
+
+
+def test_content_nested_in_fraction_is_colored() -> None:
+    # The colored content is a fraction, so its runs live inside <m:num>/<m:den>,
+    # between the marker runs in document order.
+    frac = "<m:f><m:num>" + _run("a") + "</m:num><m:den>" + _run("b") + "</m:den></m:f>"
+    doc = _doc(_run("@@PMC:EA1B2C@@") + frac + _run("@@PMCEND@@"))
+    apply_math_colors(doc)
+    runs = _runs(doc)
+    assert [_text(r) for r in runs] == ["a", "b"]
+    assert all(_color(r) == "EA1B2C" for r in runs)
+
+
+def test_existing_math_run_properties_are_kept() -> None:
+    # A content run carrying <m:rPr> must keep it; <w:rPr> is inserted after it.
+    doc = _doc(_run("@@PMC:FF0000@@") + _run("x", with_m_rpr=True) + _run("@@PMCEND@@"))
+    apply_math_colors(doc)
+    (run,) = _runs(doc)
+    children = list(run)
+    assert children[0].tag == f"{{{M_NS}}}rPr"
+    assert children[1].tag == f"{{{W_NS}}}rPr"
+    assert _color(run) == "FF0000"
+
+
+def test_document_without_markers_is_unchanged() -> None:
+    doc = _doc(_run("x") + _run("y"))
+    before = etree.tostring(doc.element)
+    apply_math_colors(doc)
+    assert etree.tostring(doc.element) == before
+
+
+def test_color_survives_document_save() -> None:
+    # The injected <w:color> must survive a python-docx save/reload round-trip.
+    doc = _doc(_run("@@PMC:FF0000@@") + _run("x") + _run("@@PMCEND@@"))
+    apply_math_colors(doc)
+    buf = io.BytesIO()
+    doc.save(buf)
+    reloaded = Document(io.BytesIO(buf.getvalue()))
+    runs = _runs(reloaded)
+    assert len(runs) == 1
+    assert _color(runs[0]) == "FF0000"
+    assert b"@@PMC" not in etree.tostring(reloaded.element)

--- a/tests/test_html_math_color_preprocess.py
+++ b/tests/test_html_math_color_preprocess.py
@@ -101,6 +101,30 @@ def test_non_color_command_untouched() -> None:
     assert _encode_body("\\frac{a}{b} + \\sqrt{c}") == "\\frac{a}{b} + \\sqrt{c}"
 
 
+def test_control_symbol_is_copied_verbatim() -> None:
+    # A control symbol (backslash + non-letter, e.g. "\,") is copied as its two
+    # characters; the surrounding color command still rewrites.
+    assert _encode_body("\\,\\color{red}{x}") == "\\," + _start("FF0000") + "x" + _END
+
+
+def test_unclosed_model_bracket_leaves_command_untouched() -> None:
+    # A "[model" with no closing "]" is malformed; the command is copied verbatim.
+    latex = "\\textcolor[HTML{FF0000}{x}"
+    assert _encode_body(latex) == latex
+
+
+def test_color_command_without_brace_group_untouched() -> None:
+    # A color command not followed by a "{color}" brace group is copied verbatim.
+    latex = "\\textcolor abc"
+    assert _encode_body(latex) == latex
+
+
+def test_unbalanced_content_brace_leaves_command_untouched() -> None:
+    # The content group "{x" is never closed; the command is copied verbatim.
+    latex = "\\color{red}{x"
+    assert _encode_body(latex) == latex
+
+
 def test_color_outside_math_script_is_untouched() -> None:
     # \textcolor in ordinary HTML text (not a math script) must not be rewritten.
     html = b"<html><body><p>literal \\textcolor{red}{x} here</p></body></html>"

--- a/tests/test_html_math_color_preprocess.py
+++ b/tests/test_html_math_color_preprocess.py
@@ -1,0 +1,131 @@
+"""Unit tests for ``app.HtmlMathColorPreProcess``.
+
+These verify the *encode* half of the math-color shim: that ``\\color`` /
+``\\textcolor`` inside ``<script type="math/tex">`` blocks are
+rewritten into ``\\text{@@PMC:RRGGBB@@}...\\text{@@PMCEND@@}`` markers, that color
+values (named, ``#hex``, bare hex, ``[HTML]{hex}``) resolve correctly, that nested
+colors and braced content are handled, and that non-color/non-math input is left
+untouched. The companion decoder is exercised in ``test_docx_math_color_postprocess.py``
+and end-to-end in ``test_math_color_integration.py``.
+"""
+
+from __future__ import annotations
+
+import re
+
+from app import HtmlMathColorPreProcess
+from app.HtmlMathColorPreProcess import MARKER_END, MARKER_PREFIX, MARKER_SUFFIX
+
+_SCRIPT_OPEN = '<html><body><p><script type="math/tex; mode=display">'
+_SCRIPT_CLOSE = "</script></p></body></html>"
+
+
+def _encode_body(latex: str) -> str:
+    """Run one math formula through preprocess() and return the rewritten script body."""
+    html = (_SCRIPT_OPEN + latex + _SCRIPT_CLOSE).encode("utf-8")
+    out = HtmlMathColorPreProcess.preprocess(html).decode("utf-8")
+    match = re.search(r'mode=display">(.*)</script>', out, re.DOTALL)
+    assert match, f"script body not found in output: {out!r}"
+    return match.group(1)
+
+
+def _start(hex_color: str) -> str:
+    return "\\text{" + MARKER_PREFIX + hex_color + MARKER_SUFFIX + "}"
+
+
+_END = "\\text{" + MARKER_END + "}"
+
+
+def test_named_color_textcolor() -> None:
+    assert _encode_body("\\textcolor{red}{x^2}") == _start("FF0000") + "x^2" + _END
+
+
+def test_named_color_is_case_insensitive() -> None:
+    # Polarion emits dvips-style capitalized names such as \color{Red}.
+    assert _encode_body("\\color{Red}{b^2-4ac}") == _start("FF0000") + "b^2-4ac" + _END
+
+
+def test_bare_hex_color() -> None:
+    assert _encode_body("\\color{FFA500}{x}") == _start("FFA500") + "x" + _END
+
+
+def test_hash_hex_color() -> None:
+    assert _encode_body("\\color{#00ff00}{x}") == _start("00FF00") + "x" + _END
+
+
+def test_three_digit_hex_expands() -> None:
+    assert _encode_body("\\color{#0f0}{x}") == _start("00FF00") + "x" + _END
+
+
+def test_html_model_color() -> None:
+    assert _encode_body("\\textcolor[HTML]{EA1B2C}{x}") == _start("EA1B2C") + "x" + _END
+
+
+def test_mathcolor_is_left_untouched() -> None:
+    # \mathcolor is a KaTeX command, not a MathJax one, so Polarion never emits it;
+    # we do not transform it (it is not in the color-command set).
+    assert _encode_body("\\mathcolor{blue}{y}") == "\\mathcolor{blue}{y}"
+
+
+def test_braced_content_is_preserved() -> None:
+    assert _encode_body("\\textcolor{red}{\\frac{a}{b}}") == _start("FF0000") + "\\frac{a}{b}" + _END
+
+
+def test_nested_colors() -> None:
+    result = _encode_body("\\color{red}{a\\color{blue}{b}c}")
+    assert result == _start("FF0000") + "a" + _start("0000FF") + "b" + _END + "c" + _END
+
+
+def test_color_inside_larger_formula() -> None:
+    result = _encode_body("x=\\frac{-b\\pm\\sqrt{\\color{Red}{b^2-4ac}}}{2a}")
+    assert result == "x=\\frac{-b\\pm\\sqrt{" + _start("FF0000") + "b^2-4ac" + _END + "}}{2a}"
+
+
+def test_unknown_color_name_unwraps_content() -> None:
+    # An unresolvable color drops the color but keeps the content, so \textcolor
+    # (which texmath cannot parse) does not leak the whole formula.
+    assert _encode_body("\\textcolor{notacolor}{x^2}") == "x^2"
+
+
+def test_unsupported_color_model_unwraps_content() -> None:
+    assert _encode_body("\\textcolor[rgb]{1,0,0}{x}") == "x"
+
+
+def test_switch_form_left_untouched() -> None:
+    # One-argument \color (color applies to the rest of the group) has no second
+    # brace group; we leave it as-is (texmath keeps the content, drops the color).
+    assert _encode_body("\\color{red} x + y") == "\\color{red} x + y"
+
+
+def test_non_color_command_untouched() -> None:
+    assert _encode_body("\\frac{a}{b} + \\sqrt{c}") == "\\frac{a}{b} + \\sqrt{c}"
+
+
+def test_color_outside_math_script_is_untouched() -> None:
+    # \textcolor in ordinary HTML text (not a math script) must not be rewritten.
+    html = b"<html><body><p>literal \\textcolor{red}{x} here</p></body></html>"
+    assert HtmlMathColorPreProcess.preprocess(html) == html
+
+
+def test_no_color_returns_input_unchanged() -> None:
+    html = (_SCRIPT_OPEN + "\\frac{a}{b}" + _SCRIPT_CLOSE).encode("utf-8")
+    assert HtmlMathColorPreProcess.preprocess(html) is html or HtmlMathColorPreProcess.preprocess(html) == html
+
+
+def test_multiple_scripts_each_rewritten() -> None:
+    html = b'<script type="math/tex">\\color{red}{a}</script>X<script type="math/tex; mode=display">\\textcolor{blue}{b}</script>'
+    out = HtmlMathColorPreProcess.preprocess(html).decode("utf-8")
+    assert _start("FF0000") + "a" + _END in out
+    assert _start("0000FF") + "b" + _END in out
+    assert "X" in out
+
+
+def test_non_utf8_input_passes_through() -> None:
+    garbage = b"\xff\xfe\\textcolor{red}{x}"
+    assert HtmlMathColorPreProcess.preprocess(garbage) == garbage
+
+
+def test_single_quoted_script_type() -> None:
+    html = b"<script type='math/tex'>\\color{red}{a}</script>"
+    out = HtmlMathColorPreProcess.preprocess(html).decode("utf-8")
+    assert _start("FF0000") + "a" + _END in out

--- a/tests/test_math_color_integration.py
+++ b/tests/test_math_color_integration.py
@@ -1,0 +1,77 @@
+"""End-to-end integration tests for the math-color shim.
+
+Convert HTML containing colored LaTeX math (``\\color`` / ``\\textcolor``) to DOCX
+through the pandoc-service container and assert the resulting OMML carries real
+per-run color (``<w:color>``) and no leftover ``@@PMC`` markers.
+
+Why an integration test (vs. the mocked encode/decode unit tests): the shim only
+works if the ``\\text{}`` markers survive pandoc's ``texmath`` conversion as distinct
+OMML runs, with the colored content as separate runs between them. That contract
+lives in ``texmath`` and could shift with a pandoc bump; only a real round-trip
+catches such a regression. See ``app/HtmlMathColorPreProcess.py`` and
+``app/DocxMathColorPostProcess.py``.
+"""
+
+import zipfile
+from io import BytesIO
+from xml.etree import ElementTree as ET
+
+from tests.test_container import TestParameters
+
+W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+M_NS = "http://schemas.openxmlformats.org/officeDocument/2006/math"
+
+
+def _convert_html_to_docx(test_parameters: TestParameters, html: str) -> bytes:
+    url = f"{test_parameters.base_url}/convert/html/to/docx"
+    response = test_parameters.request_session.post(url, data=html)
+    if response.status_code // 100 != 2:
+        raise AssertionError(f"pandoc-service returned {response.status_code}:\n{response.text}")
+    return response.content
+
+
+def _document_xml(docx_bytes: bytes) -> ET.Element:
+    with zipfile.ZipFile(BytesIO(docx_bytes)) as zf:
+        return ET.fromstring(zf.read("word/document.xml"))
+
+
+def _math_run_colors(tree: ET.Element) -> dict[str, str]:
+    """Map each math run's text to its <w:color> value (runs without color omitted)."""
+    colors: dict[str, str] = {}
+    for run in tree.iter(f"{{{M_NS}}}r"):
+        text_el = run.find(f"{{{M_NS}}}t")
+        color_el = run.find(f"{{{W_NS}}}rPr/{{{W_NS}}}color")
+        if text_el is not None and text_el.text and color_el is not None:
+            colors[text_el.text] = color_el.get(f"{{{W_NS}}}val") or ""
+    return colors
+
+
+def _math_html(latex: str) -> str:
+    return f'<html><body><p><script type="math/tex; mode=display">{latex}</script></p></body></html>'
+
+
+def test_textcolor_produces_omml_color(test_parameters: TestParameters):
+    docx = _convert_html_to_docx(test_parameters, _math_html("\\textcolor{red}{x}"))
+    tree = _document_xml(docx)
+    # A real Word equation is produced (texmath would otherwise leak \textcolor as text).
+    assert tree.find(f".//{{{M_NS}}}oMath") is not None
+    assert _math_run_colors(tree).get("x") == "FF0000"
+
+
+def test_color_content_is_colored(test_parameters: TestParameters):
+    docx = _convert_html_to_docx(test_parameters, _math_html("\\color{Red}{b}"))
+    assert _math_run_colors(_document_xml(docx)).get("b") == "FF0000"
+
+
+def test_markers_do_not_leak_into_output(test_parameters: TestParameters):
+    docx = _convert_html_to_docx(test_parameters, _math_html("\\textcolor{red}{x}"))
+    with zipfile.ZipFile(BytesIO(docx)) as zf:
+        assert b"@@PMC" not in zf.read("word/document.xml")
+
+
+def test_nested_colors_round_trip(test_parameters: TestParameters):
+    docx = _convert_html_to_docx(test_parameters, _math_html("\\color{red}{a\\color{blue}{b}c}"))
+    colors = _math_run_colors(_document_xml(docx))
+    assert colors.get("a") == "FF0000"
+    assert colors.get("b") == "0000FF"
+    assert colors.get("c") == "FF0000"


### PR DESCRIPTION
Refs: #185

### Proposed changes

We have to find a workaround for the case when formula colors are lost because `textmath` cuts them out.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
