### PR TITLE
fix: math colors are lost during DOCX to PDF conversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,6 +120,7 @@ COPY filters/heading_levels.lua "/usr/local/share/pandoc/filters/heading_levels.
 COPY filters/inline_styles.lua "/usr/local/share/pandoc/filters/inline_styles.lua"
 COPY filters/docx_text_decorations.lua "/usr/local/share/pandoc/filters/docx_text_decorations.lua"
 COPY filters/docx_colors_to_latex.lua "/usr/local/share/pandoc/filters/docx_colors_to_latex.lua"
+COPY filters/docx_math_colors_to_latex.lua "/usr/local/share/pandoc/filters/docx_math_colors_to_latex.lua"
 COPY filters/docx_paragraphs_to_latex.lua "/usr/local/share/pandoc/filters/docx_paragraphs_to_latex.lua"
 COPY filters/docx_lists_to_latex.lua "/usr/local/share/pandoc/filters/docx_lists_to_latex.lua"
 COPY filters/docx_tables_to_latex.lua "/usr/local/share/pandoc/filters/docx_tables_to_latex.lua"

--- a/app/DocxLatexPreProcess.py
+++ b/app/DocxLatexPreProcess.py
@@ -17,7 +17,7 @@ lighter on memory.
 
 from __future__ import annotations
 
-from . import DocxColorPreProcess, DocxListLevelPreProcess, DocxParagraphPreProcess, DocxTablePreProcess
+from . import DocxColorPreProcess, DocxListLevelPreProcess, DocxMathColorPreProcess, DocxParagraphPreProcess, DocxTablePreProcess
 from .docx_ooxml import STYLES_PART, augment_styles, enumerate_body_parts, read_entries, repack
 
 
@@ -45,6 +45,9 @@ def _rewrite_body_part(
         xml, changed = rewritten, True
     rewritten, table_changed = DocxTablePreProcess._rewrite_part(xml)
     if table_changed:
+        xml, changed = rewritten, True
+    rewritten, math_color_changed = DocxMathColorPreProcess._rewrite_part(xml)
+    if math_color_changed:
         xml, changed = rewritten, True
     return xml, changed
 

--- a/app/DocxLatexPreProcess.py
+++ b/app/DocxLatexPreProcess.py
@@ -1,18 +1,19 @@
 """Single-pass docx→latex preprocessing.
 
-For LaTeX/PDF targets three independent rewrites run on the source DOCX before
+For LaTeX/PDF targets five independent rewrites run on the source DOCX before
 pandoc reads it: colour/size runs (:mod:`app.DocxColorPreProcess`), paragraph
-alignment/indent (:mod:`app.DocxParagraphPreProcess`) and list-level tagging
-(:mod:`app.DocxListLevelPreProcess`). Run separately they each unzip the whole
+alignment/indent (:mod:`app.DocxParagraphPreProcess`), list-level tagging
+(:mod:`app.DocxListLevelPreProcess`), table-cell backgrounds
+(:mod:`app.DocxTablePreProcess`), and math-run colour encoding
+(:mod:`app.DocxMathColorPreProcess`). Run separately they each unzip the whole
 package, rewrite their body parts and re-zip — so an image-heavy document gets
-its media decompressed and recompressed three times, tripling the peak memory
+its media decompressed and recompressed five times, quintupling the peak memory
 and CPU of the step.
 
 This module orchestrates the same per-part transforms over a single unzip /
-re-zip: the media is held once and the body XML flows colour → paragraph →
-list through the existing ``_rewrite_part`` helpers, so the produced DOCX is
-byte-for-byte identical to chaining the three ``preprocess`` calls — only much
-lighter on memory.
+re-zip: the media is held once and the body XML flows through the existing
+``_rewrite_part`` helpers, so the produced DOCX is byte-for-byte identical to
+chaining the five ``preprocess`` calls — only much lighter on memory.
 """
 
 from __future__ import annotations
@@ -53,13 +54,14 @@ def _rewrite_body_part(
 
 
 def preprocess(docx_bytes: bytes) -> bytes:
-    """Apply the colour, paragraph, list-level and table-cell rewrites in one
-    unzip/re-zip.
+    """Apply the colour, paragraph, list-level, table-cell and math-colour
+    rewrites in one unzip/re-zip.
 
     Equivalent to chaining ``DocxColorPreProcess.preprocess``,
     ``DocxParagraphPreProcess.preprocess``, ``DocxListLevelPreProcess
-    .preprocess`` and ``DocxTablePreProcess.preprocess`` but without
-    re-zipping the package (and its media) between each step.
+    .preprocess``, ``DocxTablePreProcess.preprocess`` and
+    ``DocxMathColorPreProcess.preprocess`` but without re-zipping the package
+    (and its media) between each step.
     """
     entries = read_entries(docx_bytes)
     if entries is None:

--- a/app/DocxMathColorPreProcess.py
+++ b/app/DocxMathColorPreProcess.py
@@ -1,0 +1,140 @@
+r"""Preserve OMML math-run color across the DOCX -> LaTeX/PDF path.
+
+Pandoc reads Office math (``<m:oMath>``) through the ``texmath`` library
+(``readOMML`` -> ``[Exp]`` -> ``writeTeX``). ``texmath``'s expression AST has no
+color constructor and its OMML reader ignores ``<w:color>`` on math runs
+entirely, so a colored equation reaches the LaTeX/PDF writer black — even though
+the color is right there in the DOCX (``<m:r><w:rPr><w:color w:val="RRGGBB"/>``,
+which is exactly what ``app/DocxMathColorPostProcess.py`` writes on the
+HTML -> DOCX path, and what Word renders).
+
+This preprocessor is the *encode* half of a shim that is the mirror image of the
+HTML -> DOCX one (:mod:`app.HtmlMathColorPreProcess` + :mod:`app.DocxMathColorPostProcess`).
+For every math run carrying a direct ``<w:color>`` it wraps the run's ``<m:t>``
+text in plain-text markers::
+
+    <m:t>x</m:t>   with color RRGGBB   ->   <m:t>PMCzzzRRGGBBzzzxzzzPMCENDzzz</m:t>
+
+The markers are pure alphanumerics, which ``texmath`` emits contiguously into the
+TeX string (only operators get spacing), so they survive ``readOMML`` ->
+``writeTeX`` intact inside the produced ``Math`` inline. ``filters/docx_math_colors_to_latex.lua``
+then rewrites each marker pair in the math string into ``{\color[HTML]{RRGGBB} ...}``,
+which ``xcolor`` (already loaded by the pipeline) renders in the PDF.
+
+The direct ``<w:color>`` is stripped once its color is encoded: ``texmath``
+ignores it anyway, and removing it keeps the run from being re-detected if the
+preprocessor is ever run twice.
+
+Scope / limitations
+-------------------
+* Only a direct ``<w:color w:val="RRGGBB"/>`` on the run is handled. Theme colors
+  (``w:themeColor``) and the literal ``auto`` are skipped (left uncolored), and a
+  non 6-hex value is ignored — matching what ``\color[HTML]{...}`` can accept.
+* Background shading (``<w:shd>``) and highlight (``<w:highlight>``) inside math
+  are not handled — math runs carry only ``<w:color>`` in our pipeline.
+* Only meaningful for the DOCX -> LaTeX/PDF targets; wire it in there
+  (see :mod:`app.DocxLatexPreProcess`), never for DOCX -> DOCX/HTML/etc.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from .docx_ooxml import W_NS, enumerate_body_parts, parse_xml, read_entries, repack, serialize_tree
+
+logger = logging.getLogger(__name__)
+
+M_NS = "http://schemas.openxmlformats.org/officeDocument/2006/math"  # NOSONAR OOXML math namespace identifier (ECMA-376), never dereferenced
+
+_M_R = f"{{{M_NS}}}r"
+_M_T = f"{{{M_NS}}}t"
+_W_RPR = f"{{{W_NS}}}rPr"
+_W_COLOR = f"{{{W_NS}}}color"
+_W_VAL = f"{{{W_NS}}}val"
+
+HEX_COLOR_LENGTH = 6
+_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+
+# Marker sentinels wrapping a colored run's text. Shared, by construction, with
+# the regex in filters/docx_math_colors_to_latex.lua:
+#     PMCzzz(%x%x%x%x%x%x)zzz(.-)zzzPMCENDzzz  ->  {\color[HTML]{%1} %2}
+# Pure alphanumerics on purpose: texmath concatenates letters/digits without
+# inserting spacing (only operators get spaced), so "PMCzzzRRGGBBzzz...zzzPMCENDzzz"
+# reaches the TeX output byte-for-byte. The "zzz" delimiters plus the PMC/PMCEND
+# tokens make an accidental collision with real formula text vanishingly unlikely.
+MARKER_PREFIX = "PMCzzz"
+MARKER_INFIX = "zzz"
+MARKER_END = "zzzPMCENDzzz"
+
+
+def preprocess(docx_bytes: bytes) -> bytes:
+    """Return a DOCX byte-string with colored math runs' text wrapped in color
+    markers. Returns the input unchanged when there is no colored math run or the
+    package is not a recognizable DOCX.
+    """
+    entries = read_entries(docx_bytes)
+    if entries is None:
+        logger.warning("Input is not a valid zip / DOCX; skipping math-color preprocess")
+        return docx_bytes
+
+    changed = False
+    for part in enumerate_body_parts(entries.keys()):
+        rewritten, part_changed = _rewrite_part(entries[part])
+        if part_changed:
+            entries[part] = rewritten
+            changed = True
+
+    # Fast path: no colored math anywhere -> return the original bytes so the
+    # zip layout is preserved and no needless re-zip happens.
+    if not changed:
+        return docx_bytes
+    return repack(entries)
+
+
+def _rewrite_part(xml_bytes: bytes) -> tuple[bytes, bool]:
+    """Wrap colored math runs in one body part. Returns (new_bytes, changed)."""
+    tree = parse_xml(xml_bytes)
+    if tree is None:
+        logger.warning("Unparseable XML in DOCX part; skipping math-color preprocess")
+        return xml_bytes, False
+
+    changed = False
+    # iter() reaches every <m:r> regardless of nesting (fractions, scripts,
+    # matrices, ...); a math run is <m:r>, distinct from a text run <w:r>, so
+    # this never touches the runs DocxColorPreProcess handles.
+    for run in tree.iter(_M_R):
+        w_rpr = run.find(_W_RPR)
+        if w_rpr is None:
+            continue
+        color_el = w_rpr.find(_W_COLOR)
+        if color_el is None:
+            continue
+        hex_color = _normalize_hex(color_el.get(_W_VAL))
+        if hex_color is None:
+            continue
+        t_el = run.find(_M_T)
+        if t_el is None:
+            # No <m:t> to wrap (e.g. a run holding only properties); leave it.
+            continue
+        t_el.text = f"{MARKER_PREFIX}{hex_color}{MARKER_INFIX}{t_el.text or ''}{MARKER_END}"
+        # Strip the now-encoded color so the run isn't re-detected on a re-run.
+        w_rpr.remove(color_el)
+        changed = True
+
+    if not changed:
+        return xml_bytes, False
+    return serialize_tree(tree), True
+
+
+def _normalize_hex(value: str | None) -> str | None:
+    """Uppercase a 6-digit hex color, accepting an optional leading '#'. Returns
+    None for absent/``auto``/theme/non 6-hex values (the run then stays uncolored,
+    which is safer than emitting a wrong ``\\color``)."""
+    if not value:
+        return None
+    stripped = value.strip()
+    if stripped.startswith("#"):
+        stripped = stripped[1:]
+    if len(stripped) == HEX_COLOR_LENGTH and all(c in _HEX_DIGITS for c in stripped):
+        return stripped.upper()
+    return None

--- a/app/PandocController.py
+++ b/app/PandocController.py
@@ -55,6 +55,7 @@ FILTERS = {
     "inline_styles": f"{FILTER_BASE_PATH}/inline_styles.lua",
     "docx_text_decorations": f"{FILTER_BASE_PATH}/docx_text_decorations.lua",
     "docx_colors_to_latex": f"{FILTER_BASE_PATH}/docx_colors_to_latex.lua",
+    "docx_math_colors_to_latex": f"{FILTER_BASE_PATH}/docx_math_colors_to_latex.lua",
     "docx_paragraphs_to_latex": f"{FILTER_BASE_PATH}/docx_paragraphs_to_latex.lua",
     "docx_lists_to_latex": f"{FILTER_BASE_PATH}/docx_lists_to_latex.lua",
     "docx_tables_to_latex": f"{FILTER_BASE_PATH}/docx_tables_to_latex.lua",
@@ -69,6 +70,7 @@ ALLOWED_PANDOC_OPTIONS = [
     f"--lua-filter={FILTERS['inline_styles']}",
     f"--lua-filter={FILTERS['docx_text_decorations']}",
     f"--lua-filter={FILTERS['docx_colors_to_latex']}",
+    f"--lua-filter={FILTERS['docx_math_colors_to_latex']}",
     f"--lua-filter={FILTERS['docx_paragraphs_to_latex']}",
     f"--lua-filter={FILTERS['docx_lists_to_latex']}",
     f"--lua-filter={FILTERS['docx_tables_to_latex']}",
@@ -554,6 +556,7 @@ def _build_pandoc_command(  # noqa: PLR0913
         # before the colour filter turns those spans into \textcolor/\hl.
         cmd.append(f"--lua-filter={FILTERS['docx_text_decorations']}")
         cmd.append(f"--lua-filter={FILTERS['docx_colors_to_latex']}")
+        cmd.append(f"--lua-filter={FILTERS['docx_math_colors_to_latex']}")
         cmd.append(f"--lua-filter={FILTERS['docx_paragraphs_to_latex']}")
         cmd.append(f"--lua-filter={FILTERS['docx_lists_to_latex']}")
         cmd.append(f"--lua-filter={FILTERS['docx_tables_to_latex']}")

--- a/filters/docx_math_colors_to_latex.lua
+++ b/filters/docx_math_colors_to_latex.lua
@@ -1,0 +1,39 @@
+-- docx_math_colors_to_latex.lua
+--
+-- Companion to app/DocxMathColorPreProcess.py. On the DOCX -> LaTeX/PDF path,
+-- pandoc reads Office math (<m:oMath>) through texmath, whose AST has no color
+-- and whose OMML reader ignores <w:color> on math runs, so an equation's color
+-- is lost before any filter sees it. The preprocessor works around that by
+-- wrapping each colored math run's text in plain-text markers that survive
+-- texmath:
+--
+--   <m:t>x</m:t>  (color RRGGBB)  ->  <m:t>PMCzzzRRGGBBzzzxzzzPMCENDzzz</m:t>
+--
+-- which reach this filter inside the Math inline's TeX string. Here we turn each
+-- marker pair back into an inline color group:
+--
+--   PMCzzzRRGGBBzzz<content>zzzPMCENDzzz  ->  {\color[HTML]{RRGGBB} <content>}
+--
+-- \color[HTML]{...} needs xcolor, which the pipeline already loads (the sibling
+-- docx_colors_to_latex.lua emits \textcolor for regular text). The markers are
+-- pure alphanumerics, so texmath emits them contiguously and this single gsub
+-- recovers every colored segment; non-overlapping matches keep adjacent and
+-- nested colored runs independent.
+
+local MARKER = "PMCzzz(%x%x%x%x%x%x)zzz(.-)zzzPMCENDzzz"
+
+local filter = {}
+
+function filter.Math(el)
+  -- Only the LaTeX/PDF writer consumes raw LaTeX in a Math string; for any other
+  -- target this would corrupt the math, so leave it untouched. (This filter is
+  -- only wired in on the docx->latex/pdf path, but gate defensively.)
+  if not FORMAT:match("latex") then
+    return nil
+  end
+  local replaced = el.text:gsub(MARKER, "{\\color[HTML]{%1} %2}")
+  el.text = replaced
+  return el
+end
+
+return filter

--- a/filters/docx_math_colors_to_latex.lua
+++ b/filters/docx_math_colors_to_latex.lua
@@ -31,7 +31,10 @@ function filter.Math(el)
   if not FORMAT:match("latex") then
     return nil
   end
-  local replaced = el.text:gsub(MARKER, "{\\color[HTML]{%1} %2}")
+  local replaced, count = el.text:gsub(MARKER, "{\\color[HTML]{%1} %2}")
+  if count == 0 then
+    return nil
+  end
   el.text = replaced
   return el
 end

--- a/tests/test_docx_latex_preprocess.py
+++ b/tests/test_docx_latex_preprocess.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import io
 import zipfile
 
-from app import DocxColorPreProcess, DocxLatexPreProcess, DocxListLevelPreProcess, DocxParagraphPreProcess, DocxTablePreProcess
+from app import DocxColorPreProcess, DocxLatexPreProcess, DocxListLevelPreProcess, DocxMathColorPreProcess, DocxParagraphPreProcess, DocxTablePreProcess
 
 W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
 STYLES = b'<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"/>'
@@ -43,7 +43,7 @@ _BODY = _doc(
 def test_single_pass_matches_sequential_preprocessors():
     blob = _pack({"word/document.xml": _BODY, "word/styles.xml": STYLES, "word/media/img.png": b"\x89PNG" + b"\x00" * 500})
 
-    sequential = DocxTablePreProcess.preprocess(DocxListLevelPreProcess.preprocess(DocxParagraphPreProcess.preprocess(DocxColorPreProcess.preprocess(blob))))
+    sequential = DocxMathColorPreProcess.preprocess(DocxTablePreProcess.preprocess(DocxListLevelPreProcess.preprocess(DocxParagraphPreProcess.preprocess(DocxColorPreProcess.preprocess(blob)))))
     single = DocxLatexPreProcess.preprocess(blob)
 
     seq_entries, single_entries = _entries(sequential), _entries(single)
@@ -77,8 +77,7 @@ def test_no_body_parts_returned_unchanged():
 def test_single_pass_includes_table_cell_preprocessing():
     """Table cell backgrounds are tagged by the single-pass orchestrator."""
     body_with_table = _doc(
-        '<w:tbl><w:tr><w:tc><w:tcPr><w:shd w:val="clear" w:color="auto" w:fill="D9EAF7"/></w:tcPr>'
-        "<w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>",
+        '<w:tbl><w:tr><w:tc><w:tcPr><w:shd w:val="clear" w:color="auto" w:fill="D9EAF7"/></w:tcPr><w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>',
     )
     blob = _pack({"word/document.xml": body_with_table, "word/styles.xml": STYLES})
 
@@ -91,4 +90,4 @@ def test_single_pass_includes_table_cell_preprocessing():
         assert single_entries[name] == data, f"{name} differs between single-pass and sequential"
 
     # Verify the sentinel is present
-    assert "\uE010bg=D9EAF7\uE011".encode() in single_entries["word/document.xml"]
+    assert "\ue010bg=D9EAF7\ue011".encode() in single_entries["word/document.xml"]

--- a/tests/test_docx_latex_preprocess.py
+++ b/tests/test_docx_latex_preprocess.py
@@ -13,6 +13,7 @@ import zipfile
 from app import DocxColorPreProcess, DocxLatexPreProcess, DocxListLevelPreProcess, DocxMathColorPreProcess, DocxParagraphPreProcess, DocxTablePreProcess
 
 W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+M_NS = "http://schemas.openxmlformats.org/officeDocument/2006/math"
 STYLES = b'<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"/>'
 
 
@@ -63,6 +64,27 @@ def test_media_is_preserved_and_changes_applied():
     # the paragraph carries the alignment style and a list-level sentinel
     assert b"PandocPara__ALIGN_center" in out["word/document.xml"]
     assert "".encode() in out["word/document.xml"]
+
+
+def test_math_colour_applied_without_styles_xml():
+    """A colored equation with no styles.xml: colour/paragraph rewrites skip
+    (has_styles False), but the math-colour rewrite still runs in the single pass."""
+    math_body = (
+        f'<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document xmlns:w="{W_NS}" xmlns:m="{M_NS}"><w:body><w:p><m:oMath><m:r><w:rPr><w:color w:val="FF0000"/></w:rPr><m:t>E</m:t></m:r></m:oMath></w:p></w:body></w:document>'
+    ).encode()
+    blob = _pack({"word/document.xml": math_body})
+    out = _entries(DocxLatexPreProcess.preprocess(blob))["word/document.xml"]
+    # The colour is encoded as markers and the direct <w:color> stripped.
+    assert b"PMCzzzFF0000zzzEzzzPMCENDzzz" in out
+    assert b"<w:color" not in out
+
+
+def test_unchanged_document_returns_original_bytes():
+    """A document nothing rewrites (plain run, no colour/list/table/math) returns
+    the original bytes rather than a re-zipped copy."""
+    plain = _doc("<w:p><w:r><w:t>plain</w:t></w:r></w:p>")
+    blob = _pack({"word/document.xml": plain, "word/styles.xml": STYLES})
+    assert DocxLatexPreProcess.preprocess(blob) == blob
 
 
 def test_non_docx_returned_unchanged():

--- a/tests/test_docx_math_color_preprocess.py
+++ b/tests/test_docx_math_color_preprocess.py
@@ -99,5 +99,26 @@ def test_colored_run_without_text_element_does_not_crash() -> None:
     assert out == blob
 
 
+def test_math_run_with_rpr_but_no_color_is_skipped() -> None:
+    # <w:rPr> present (e.g. bold) but no <w:color> child -> run left untouched.
+    body = "<m:r><w:rPr><w:b/></w:rPr><m:t>x</m:t></m:r>"
+    blob = _pack(_doc(body))
+    assert DocxMathColorPreProcess.preprocess(blob) == blob
+
+
+def test_color_element_without_value_is_skipped() -> None:
+    # <w:color/> with no w:val attribute -> nothing to encode, run left untouched.
+    body = "<m:r><w:rPr><w:color/></w:rPr><m:t>x</m:t></m:r>"
+    blob = _pack(_doc(body))
+    assert DocxMathColorPreProcess.preprocess(blob) == blob
+
+
+def test_unparseable_document_part_is_skipped() -> None:
+    # A valid zip whose word/document.xml is malformed XML -> the part is skipped
+    # (parse returns None) and the package is returned unchanged.
+    blob = _pack(b"<not-well-formed")
+    assert DocxMathColorPreProcess.preprocess(blob) == blob
+
+
 def test_invalid_zip_returned_unchanged() -> None:
     assert DocxMathColorPreProcess.preprocess(b"not a zip") == b"not a zip"

--- a/tests/test_docx_math_color_preprocess.py
+++ b/tests/test_docx_math_color_preprocess.py
@@ -1,0 +1,103 @@
+"""Unit tests for ``app.DocxMathColorPreProcess``.
+
+These verify the *encode* half of the DOCX -> LaTeX/PDF math-color shim: given a DOCX
+whose OMML carries direct ``<w:color>`` on math runs (as ``DocxMathColorPostProcess``
+writes on the HTML -> DOCX path, and as Word renders), the preprocessor wraps each
+colored run's ``<m:t>`` text in ``PMCzzzRRGGBBzzz`` / ``zzzPMCENDzzz`` markers and strips
+the ``<w:color>``. ``filters/docx_math_colors_to_latex.lua`` turns those markers back into
+``\\color`` and is exercised, with pandoc, in the integration test.
+
+Each test builds a minimal DOCX zip in memory containing a single ``word/document.xml``
+and inspects the rewritten OMML.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from xml.etree import ElementTree as ET  # noqa: S405
+
+from app import DocxMathColorPreProcess
+
+W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+M_NS = "http://schemas.openxmlformats.org/officeDocument/2006/math"
+
+
+def _pack(document_xml: bytes) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("word/document.xml", document_xml)
+    return buf.getvalue()
+
+
+def _unpack(blob: bytes) -> bytes:
+    with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+        return zf.read("word/document.xml")
+
+
+def _doc(omath_body: str) -> bytes:
+    return (f'<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document xmlns:w="{W_NS}" xmlns:m="{M_NS}"><w:body><w:p><m:oMath>{omath_body}</m:oMath></w:p></w:body></w:document>').encode()
+
+
+def _run(text: str, *, color: str | None = None, m_rpr: bool = False) -> str:
+    w_rpr = f'<w:rPr><w:color w:val="{color}"/></w:rPr>' if color else ""
+    m_rpr_xml = '<m:rPr><m:sty m:val="p"/></m:rPr>' if m_rpr else ""
+    return f"<m:r>{m_rpr_xml}{w_rpr}<m:t>{text}</m:t></m:r>"
+
+
+def _texts(blob: bytes) -> list[str | None]:
+    root = ET.fromstring(_unpack(blob))  # noqa: S314
+    return [t.text for t in root.iter(f"{{{M_NS}}}t")]
+
+
+def _colors(blob: bytes) -> list[str]:
+    root = ET.fromstring(_unpack(blob))  # noqa: S314
+    return [c.get(f"{{{W_NS}}}val") or "" for c in root.iter(f"{{{W_NS}}}color")]
+
+
+def test_colored_run_is_wrapped_and_color_stripped() -> None:
+    out = DocxMathColorPreProcess.preprocess(_pack(_doc(_run("E", color="FF0000"))))
+    assert _texts(out) == ["PMCzzzFF0000zzzEzzzPMCENDzzz"]
+    assert _colors(out) == []  # <w:color> removed once encoded
+
+
+def test_lowercase_and_hash_hex_normalized_to_uppercase() -> None:
+    out = DocxMathColorPreProcess.preprocess(_pack(_doc(_run("x", color="#00ffcc"))))
+    assert _texts(out) == ["PMCzzz00FFCCzzzxzzzPMCENDzzz"]
+
+
+def test_multiple_runs_each_wrapped_with_own_color() -> None:
+    body = _run("E", color="FF0000") + _run("=", m_rpr=True) + _run("m", color="0000FF")
+    out = DocxMathColorPreProcess.preprocess(_pack(_doc(body)))
+    assert _texts(out) == ["PMCzzzFF0000zzzEzzzPMCENDzzz", "=", "PMCzzz0000FFzzzmzzzPMCENDzzz"]
+
+
+def test_run_without_color_is_untouched() -> None:
+    blob = _pack(_doc(_run("x") + _run("y")))
+    out = DocxMathColorPreProcess.preprocess(blob)
+    assert out == blob  # no colored math -> original bytes returned unchanged
+
+
+def test_auto_and_theme_colors_are_skipped() -> None:
+    body = _run("x", color="auto") + _run("y")
+    blob = _pack(_doc(body))
+    out = DocxMathColorPreProcess.preprocess(blob)
+    assert out == blob  # neither run gets markers
+
+
+def test_non_hex_color_is_skipped() -> None:
+    blob = _pack(_doc(_run("x", color="notacolor")))
+    out = DocxMathColorPreProcess.preprocess(blob)
+    assert out == blob
+
+
+def test_colored_run_without_text_element_does_not_crash() -> None:
+    # A math run with <w:color> but no <m:t> is left as-is (nothing to wrap).
+    body = '<m:r><w:rPr><w:color w:val="FF0000"/></w:rPr></m:r>'
+    blob = _pack(_doc(body))
+    out = DocxMathColorPreProcess.preprocess(blob)
+    assert out == blob
+
+
+def test_invalid_zip_returned_unchanged() -> None:
+    assert DocxMathColorPreProcess.preprocess(b"not a zip") == b"not a zip"


### PR DESCRIPTION
Refs: #191

### Proposed changes

We have to implement a workaround to keep formulas color through DOCX to PDF/LaTeX conversion

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
