### PR TITLE
fix: preserve image sizes

### DIFF
--- a/app/HtmlImagePreProcess.py
+++ b/app/HtmlImagePreProcess.py
@@ -1,0 +1,242 @@
+"""Give un-sized ``<img>`` elements an explicit pixel width/height at 96 dpi.
+
+Pandoc's DOCX writer sizes an image with no explicit ``width``/``height`` from
+the image's pixel dimensions divided by its embedded density (``pHYs`` for PNG,
+JFIF for JPEG). Screenshots and Polarion attachments usually carry *no* density,
+so pandoc falls back to **72 dpi** — while a browser lays the same image out at
+the CSS reference of **96 dpi**. The result is a DOCX image ~96/72 = 1.33x larger
+than it appears in the source (less when pandoc additionally clamps an
+over-wide image to the page text width, which is why the discrepancy varies).
+
+To make images match their browser size we set an explicit pixel ``width`` (and
+``height``) on each ``<img>`` that has none: pandoc converts a ``px`` dimension
+at a fixed 96 dpi, so the physical size becomes ``pixels / 96`` inches
+regardless of the (missing/odd) embedded density. We also honour a CSS
+``max-width`` / ``max-height`` by clamping — an image wider than its max-width is
+scaled down just as the browser would, preserving aspect ratio.
+
+Only images whose bytes we can read are touched: the exporter inlines images as
+``data:`` URIs, so we decode the base64 payload and read the pixel size straight
+from the PNG/JPEG/GIF/BMP header (no image library needed). Anything we can't
+size — a non-``data:`` ``src`` (http/attachment reference), an SVG data URI
+(handled earlier by :mod:`app.svg_processor`, which already sets a width), an
+unknown format, or an image that already carries a ``width``/``height`` attribute
+or CSS ``width``/``height`` (handled by ``filters/inline_styles.lua``) — is left
+untouched.
+
+The transformation is only applied for ``html -> docx`` conversions.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import logging
+import struct
+
+from lxml import etree, html  # type: ignore[import-untyped]
+
+logger = logging.getLogger(__name__)
+
+# CSS px per inch (the browser/CSS reference resolution). Setting an explicit
+# px dimension makes pandoc render the image at this dpi.
+_CSS_DPI = 96
+
+# See HtmlListsPreProcess for why these are named tuples rather than inline
+# except-literals (ruff-format / PEP 758 interaction on Python 3.14).
+_PARSE_FAILURES = (etree.ParseError, etree.ParserError, ValueError)
+_DECODE_FAILURES = (binascii.Error, ValueError)
+
+# CSS length units we can resolve to px for the max-width/max-height clamp.
+# Absolute units use the same 96 px/in reference; a bare number is px. Relative
+# units (%, em, vw, ...) have no fixed px value here, so those clamps are ignored.
+_PX_PER_UNIT = {
+    "": 1.0,
+    "px": 1.0,
+    "in": float(_CSS_DPI),
+    "cm": _CSS_DPI / 2.54,
+    "mm": _CSS_DPI / 25.4,
+    "pt": _CSS_DPI / 72.0,
+    "pc": _CSS_DPI / 6.0,
+}
+
+
+def preprocess(source: bytes) -> bytes:
+    """Set explicit px ``width``/``height`` on un-sized, decodable ``<img>``.
+
+    Returns the input unchanged when parsing fails or no image is rewritten.
+    """
+    try:
+        # document_fromstring (not fragments_fromstring) so a full HTML document
+        # keeps its <head> — the exporter sends <head><title>...</title>, which
+        # pandoc renders with the "Title" style; fragments_fromstring drops the
+        # head and the title would fall back to "First Paragraph". A bare
+        # fragment is harmlessly wrapped in <html><body> (pandoc reads it the
+        # same), and we only re-serialize at all when an image was actually sized.
+        doc = html.document_fromstring(source)
+    except _PARSE_FAILURES:
+        logger.warning("HtmlImagePreProcess: HTML parse failed; passing input through")
+        return source
+
+    if not _size_images(doc):
+        return source
+
+    return html.tostring(doc, encoding="utf-8")
+
+
+def _size_images(root: html.HtmlElement) -> bool:
+    """Set width/height on every eligible ``<img>`` under ``root``."""
+    rewrote = False
+    for img in root.iter("img"):
+        if _size_one_image(img):
+            rewrote = True
+    return rewrote
+
+
+def _size_one_image(img: html.HtmlElement) -> bool:
+    """Size a single ``<img>``; return True if it was modified."""
+    # Already sized via an HTML attribute — leave it (an explicit <img width=..>
+    # or the value app/svg_processor.py sets for rasterised SVGs).
+    if img.get("width") or img.get("height"):
+        return False
+
+    style = _parse_style(img.get("style"))
+    # An explicit CSS width/height is handled by filters/inline_styles.lua; only
+    # the "no intrinsic size given" case is ours.
+    if "width" in style or "height" in style:
+        return False
+
+    size = _decode_image_size(img.get("src"))
+    if size is None:
+        return False
+    width_px, height_px = size
+
+    scale = _clamp_scale(width_px, height_px, style)
+    out_w = max(1, round(width_px * scale))
+    out_h = max(1, round(height_px * scale))
+    img.set("width", f"{out_w}px")
+    img.set("height", f"{out_h}px")
+    return True
+
+
+def _clamp_scale(width_px: int, height_px: int, style: dict[str, str]) -> float:
+    """Largest scale <= 1 that fits both max-width and max-height (px). 1.0 when
+    neither applies or the image already fits."""
+    scale = 1.0
+    max_w = _length_to_px(style.get("max-width"))
+    if max_w is not None and width_px > max_w:
+        scale = min(scale, max_w / width_px)
+    max_h = _length_to_px(style.get("max-height"))
+    if max_h is not None and height_px > max_h:
+        scale = min(scale, max_h / height_px)
+    return scale
+
+
+def _parse_style(style: str | None) -> dict[str, str]:
+    """Split a CSS declaration list into a lowercased ``{prop: value}`` dict."""
+    props: dict[str, str] = {}
+    if not style:
+        return props
+    for decl in style.split(";"):
+        key, sep, value = decl.partition(":")
+        if sep:
+            props[key.strip().lower()] = value.strip().lower()
+    return props
+
+
+def _length_to_px(value: str | None) -> float | None:
+    """Convert a CSS length to px, or None when it isn't an absolute length
+    (missing, ``%``, ``em``, ``vw``, unparseable)."""
+    if not value:
+        return None
+    num = value.rstrip("abcdefghijklmnopqrstuvwxyz%").strip()
+    unit = value[len(num) :].strip()
+    try:
+        magnitude = float(num)
+    except ValueError:
+        return None
+    factor = _PX_PER_UNIT.get(unit)
+    if factor is None or magnitude <= 0:
+        return None
+    return magnitude * factor
+
+
+def _decode_image_size(src: str | None) -> tuple[int, int] | None:
+    """Return (width_px, height_px) for a ``data:`` image URI we can read, else
+    None (non-data URI, SVG, unknown/corrupt format)."""
+    if not src or not src.startswith("data:"):
+        return None
+    header, _, payload = src.partition(",")
+    if "svg" in header:  # SVGs are handled by app.svg_processor
+        return None
+    if "base64" not in header:
+        return None
+    try:
+        raw = base64.b64decode(payload, validate=False)
+    except _DECODE_FAILURES:
+        return None
+    return _read_raster_size(raw)
+
+
+# Smallest header we bother inspecting (a GIF logical-screen descriptor); PNG
+# and BMP need more and are length-checked in their own branch.
+_MIN_HEADER_BYTES = 10
+_PNG_HEADER_BYTES = 24  # 8-byte signature + IHDR through the height field
+_BMP_HEADER_BYTES = 26  # 'BM' + file header + DIB header through height
+
+# JPEG marker bytes. Every marker is prefixed with 0xFF. SOI/EOI and the restart
+# markers (RSTn) are "standalone" — they carry no length field, so we step over
+# them 2 bytes at a time; every other marker has a 2-byte segment length.
+_JPEG_MARKER_PREFIX = 0xFF
+_JPEG_STANDALONE = frozenset({0xD8, 0xD9})  # SOI, EOI
+_JPEG_RST_FIRST, _JPEG_RST_LAST = 0xD0, 0xD7  # RST0..RST7
+_JPEG_MIN_SEGMENT_LEN = 2  # a segment length includes its own 2 bytes
+# SOF markers that carry frame dimensions (baseline/progressive/etc.), excluding
+# the non-SOF markers in the 0xC0-0xCF range (DHT 0xC4, DAC 0xCC, RSTn).
+_JPEG_SOF_MARKERS = frozenset({0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7, 0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF})
+
+
+def _read_raster_size(data: bytes) -> tuple[int, int] | None:
+    """Read pixel dimensions from a PNG/GIF/BMP/JPEG byte header (each branch
+    checks it has enough bytes before unpacking; returns None otherwise)."""
+    if len(data) < _MIN_HEADER_BYTES:
+        return None
+    # PNG: 8-byte signature, then IHDR (width, height as big-endian uint32 at 16).
+    if data[:8] == b"\x89PNG\r\n\x1a\n" and len(data) >= _PNG_HEADER_BYTES:
+        width, height = struct.unpack(">II", data[16:24])
+        return width, height
+    # GIF: 'GIF87a'/'GIF89a', logical screen width/height little-endian uint16.
+    if data[:6] in (b"GIF87a", b"GIF89a"):
+        width, height = struct.unpack("<HH", data[6:10])
+        return width, height
+    # BMP: 'BM', DIB header width/height little-endian int32 at 18/22.
+    if data[:2] == b"BM" and len(data) >= _BMP_HEADER_BYTES:
+        width, height = struct.unpack("<ii", data[18:26])
+        return abs(width), abs(height)
+    # JPEG: scan for a start-of-frame marker carrying the dimensions.
+    if data[:2] == b"\xff\xd8":
+        return _read_jpeg_size(data)
+    return None
+
+
+def _read_jpeg_size(data: bytes) -> tuple[int, int] | None:
+    """Walk JPEG segment markers to the start-of-frame and read its size."""
+    i = 2  # skip the SOI (\xff\xd8)
+    n = len(data)
+    while i + 9 < n:
+        if data[i] != _JPEG_MARKER_PREFIX:
+            i += 1
+            continue
+        marker = data[i + 1]
+        if marker in _JPEG_SOF_MARKERS:
+            # SOF: FF, marker, len(2), precision(1), height(2), width(2)
+            height, width = struct.unpack(">HH", data[i + 5 : i + 9])
+            return width, height
+        if marker in _JPEG_STANDALONE or _JPEG_RST_FIRST <= marker <= _JPEG_RST_LAST:
+            i += 2  # standalone markers (SOI/EOI/RSTn) have no length field
+            continue
+        seg_len = struct.unpack(">H", data[i + 2 : i + 4])[0]
+        if seg_len < _JPEG_MIN_SEGMENT_LEN:
+            return None
+        i += 2 + seg_len
+    return None

--- a/app/HtmlImagePreProcess.py
+++ b/app/HtmlImagePreProcess.py
@@ -172,11 +172,18 @@ def _decode_image_size(src: str | None) -> tuple[int, int] | None:
     if "base64" not in header:
         return None
     try:
-        raw = base64.b64decode(payload, validate=False)
+        # For PNG/GIF/BMP the magic header fits in the first ~26 bytes; only
+        # JPEG may need more (SOF can follow a large APP1/EXIF block). Decode
+        # up to 64 KiB — enough to cover almost all EXIF payloads — so we
+        # avoid allocating a full decoded copy of a multi-megabyte image.
+        raw = base64.b64decode(payload[: _MAX_HEADER_DECODE * 4 // 3 + 4], validate=False)
     except _DECODE_FAILURES:
         return None
     return _read_raster_size(raw)
 
+
+# Cap the base64 we decode when sniffing image dimensions; see _decode_image_size.
+_MAX_HEADER_DECODE = 65536
 
 # Smallest header we bother inspecting (a GIF logical-screen descriptor); PNG
 # and BMP need more and are length-checked in their own branch.
@@ -223,7 +230,7 @@ def _read_jpeg_size(data: bytes) -> tuple[int, int] | None:
     """Walk JPEG segment markers to the start-of-frame and read its size."""
     i = 2  # skip the SOI (\xff\xd8)
     n = len(data)
-    while i + 9 < n:
+    while i + 9 <= n:
         if data[i] != _JPEG_MARKER_PREFIX:
             i += 1
             continue

--- a/app/HtmlListsPreProcess.py
+++ b/app/HtmlListsPreProcess.py
@@ -52,34 +52,22 @@ def preprocess(source: bytes) -> bytes:
     valid HTML is never modified.
     """
     try:
-        # fragments_fromstring tolerates both full documents and bare
-        # fragments. We get a list of HtmlElements (and possibly a leading
-        # text string) covering everything in the input.
-        fragments = html.fragments_fromstring(source)
+        # document_fromstring (not fragments_fromstring) so a full HTML document
+        # keeps its <head>: the exporter sends <head><title>...</title>, which
+        # pandoc renders with the "Title" style. fragments_fromstring drops the
+        # head, so re-serializing after wrapping an orphan list would lose the
+        # title (it falls back to "First Paragraph"). A bare fragment is
+        # harmlessly wrapped in <html><body> (pandoc reads it the same), and we
+        # only re-serialize at all when an orphan list was actually wrapped.
+        doc = html.document_fromstring(source)
     except _PARSE_FAILURES:
         logger.warning("HtmlListsPreProcess: HTML parse failed; passing input through")
         return source
 
-    rewrote = False
-    for frag in fragments:
-        # Plain leading text is returned as a str; skip those.
-        if not hasattr(frag, "iter"):
-            continue
-        rewrote = _wrap_orphan_lists(frag) or rewrote
-
-    if not rewrote:
+    if not _wrap_orphan_lists(doc):
         return source
 
-    # Serialize each fragment and concatenate. encoding=str returns a Python
-    # string we then re-encode as UTF-8 (matching what pandoc expects when
-    # we hand it the temp file).
-    parts: list[bytes] = []
-    for frag in fragments:
-        if hasattr(frag, "tag"):
-            parts.append(html.tostring(frag, encoding="utf-8"))
-        else:
-            parts.append(frag.encode("utf-8"))
-    return b"".join(parts)
+    return html.tostring(doc, encoding="utf-8")
 
 
 def _wrap_orphan_lists(root: html.HtmlElement) -> bool:

--- a/app/HtmlParagraphPreProcess.py
+++ b/app/HtmlParagraphPreProcess.py
@@ -110,36 +110,23 @@ def preprocess(source: bytes) -> bytes:
     that has nothing to rewrite — returns the original bytes unchanged.
     """
     try:
-        fragments = html.fragments_fromstring(source)
+        # document_fromstring (not fragments_fromstring) so a full HTML document
+        # keeps its <head>: the exporter sends <head><title>...</title>, which
+        # pandoc renders with the "Title" style. fragments_fromstring drops the
+        # head, so re-serializing after wrapping a paragraph would lose the title
+        # (it falls back to "First Paragraph"). It also gives every <p> a real
+        # parent (<body>), so getparent()/insert() work without a synthetic root.
+        # A bare fragment is harmlessly wrapped in <html><body>, and we only
+        # re-serialize at all when a paragraph was actually wrapped.
+        doc = html.document_fromstring(source)
     except _PARSE_FAILURES:
         logger.warning("HtmlParagraphPreProcess: HTML parse failed; passing input through")
         return source
 
-    # Top-level <p> fragments have no parent, so we couldn't reparent them
-    # with their wrapping <div>. Hang every fragment off a synthetic root
-    # while we walk so getparent()/insert() works uniformly — then drop the
-    # root on the way out.
-    synthetic_root = etree.Element("__pandoc_para_root__")
-    leading_text: str | None = None
-    for frag in fragments:
-        if hasattr(frag, "tag"):
-            synthetic_root.append(frag)
-        # fragments_fromstring may emit a leading text node as a plain str.
-        elif leading_text is None:
-            leading_text = frag
-        else:
-            leading_text += frag
-
-    rewrote = _wrap_formatted_paragraphs(synthetic_root)
-    if not rewrote:
+    if not _wrap_formatted_paragraphs(doc):
         return source
 
-    parts: list[bytes] = []
-    if leading_text:
-        parts.append(leading_text.encode("utf-8"))
-    for child in synthetic_root:
-        parts.append(html.tostring(child, encoding="utf-8"))
-    return b"".join(parts)
+    return html.tostring(doc, encoding="utf-8")
 
 
 def _wrap_formatted_paragraphs(root: html.HtmlElement) -> bool:

--- a/app/PandocController.py
+++ b/app/PandocController.py
@@ -23,7 +23,7 @@ from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.schema import VersionSchema
 
-from . import DocxLatexPreProcess, DocxPostProcess, HtmlListsPreProcess, HtmlMathColorPreProcess, HtmlParagraphPreProcess, PptxPostProcess
+from . import DocxLatexPreProcess, DocxPostProcess, HtmlImagePreProcess, HtmlListsPreProcess, HtmlMathColorPreProcess, HtmlParagraphPreProcess, PptxPostProcess
 from .chromium_manager import get_chromium_manager
 from .metrics_server import MetricsServer, get_metrics_port, is_metrics_server_enabled
 from .pandoc_metrics import get_pandoc_metrics
@@ -675,10 +675,15 @@ def run_pandoc_conversion(source_data: str | bytes, source_format: str, target_f
     # reader (which drops <p>'s style attribute outright). See
     # app/HtmlParagraphPreProcess.py and the Div handler in
     # filters/inline_styles.lua for the full pipeline.
+    # Also give un-sized <img> an explicit px width/height read from the inlined
+    # image so pandoc renders it at the 96 dpi CSS reference (not its 72 dpi
+    # no-density fallback), honouring any CSS max-width. See
+    # app/HtmlImagePreProcess.py.
     if source_format == "html" and target_format == "docx":
         source_data = HtmlListsPreProcess.preprocess(source_data)
         source_data = HtmlParagraphPreProcess.preprocess(source_data)
         source_data = HtmlMathColorPreProcess.preprocess(source_data)
+        source_data = HtmlImagePreProcess.preprocess(source_data)
 
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as source_file, tempfile.NamedTemporaryFile(delete=False) as output_file:
         try:

--- a/filters/inline_styles.lua
+++ b/filters/inline_styles.lua
@@ -52,6 +52,46 @@ local function parse_style(style)
   return props
 end
 
+-- Validate a CSS image dimension (the value of `width:`/`height:` in an
+-- <img style="...">). Returns the value unchanged when it is a number with a
+-- unit pandoc's image-size parser understands (px, in, cm, mm, pt, pc, % — or
+-- unitless, which pandoc treats as px), else nil. Font-relative/viewport units
+-- (em, ex, vw, vh, ...) are rejected: pandoc can't turn them into a concrete
+-- <wp:extent>, so we leave the image unsized rather than emit garbage. Only a
+-- validated value ever reaches the node attribute (never raw style text).
+local SUPPORTED_IMG_UNITS = { [""] = true, px = true, ["in"] = true, cm = true, mm = true, pt = true, pc = true, ["%"] = true }
+local function image_dim(value)
+  if not value then return nil end
+  -- A number (optional decimals) followed by an optional unit: either letters
+  -- (px, in, cm, ...) or a literal "%". Surrounding whitespace is tolerated.
+  local num, unit = value:match("^%s*(%d+%.?%d*)%s*([%a%%]*)%s*$")
+  if num and SUPPORTED_IMG_UNITS[unit] then
+    return num .. unit
+  end
+  return nil
+end
+
+-- Pandoc's HTML reader leaves <img style="width:..;height:.."> as an opaque
+-- `style` attribute, and the DOCX writer sizes images only from the node's
+-- `width`/`height` attributes — so CSS-sized images come out at native size.
+-- Copy validated CSS width/height onto those attributes (a node-attribute tweak,
+-- not the writer's unreachable embedding pipeline). Never overwrite an existing
+-- width/height attribute (an <img width=..> or the value app/svg_processor.py
+-- sets for rasterised SVGs); set only the side(s) given so the writer keeps the
+-- aspect ratio when just one is present. Mutates the Image in place.
+local function apply_image_style_dimensions(img)
+  local style = img.attributes and img.attributes.style
+  if not style then return end
+  local props = parse_style(style)
+  for _, dim in ipairs({ "width", "height" }) do
+    local cur = img.attributes[dim]
+    if not cur or cur == "" then
+      local v = image_dim(props[dim])
+      if v then img.attributes[dim] = v end
+    end
+  end
+end
+
 -- Accept "#RRGGBB", "RRGGBB", "#RGB", "RGB", or "rgb(r,g,b)" and return
 -- the canonical 6-char uppercase hex string Word expects ("FF0000"), or
 -- nil when the value can't be parsed.
@@ -410,6 +450,13 @@ walk = function(inlines, props, vert_align)
       -- accessible from a Lua filter, so we MUST pass the node through
       -- untouched. Stringifying would silently drop the image (alt text
       -- only) and is exactly the bug we just fixed.
+      --
+      -- ...but we still copy CSS width/height onto the node's width/height
+      -- attributes so the writer sizes it (see apply_image_style_dimensions).
+      -- filter.Image does this for standalone images; doing it here too covers
+      -- images that sit inside a styled span (idempotent — it never overwrites
+      -- an already-set dimension).
+      apply_image_style_dimensions(inline)
       result[#result + 1] = inline
     else
       -- Anything else (Note, Cite, Math, Quoted, SmallCaps, ...) needs
@@ -454,6 +501,13 @@ function filter.Span(el)
   if not el.attributes.style then return nil end
   local props = merge_css({}, parse_style(el.attributes.style))
   return walk(el.content, props, nil)
+end
+
+-- Standalone images (the common case — an <img style="width:.."> not wrapped in
+-- a styled span) never enter walk(), so size them here from their CSS style.
+function filter.Image(el)
+  apply_image_style_dimensions(el)
+  return el
 end
 
 -- True if any descendant inline is a Span carrying a `style` attribute.

--- a/tests/test_html_image_preprocess.py
+++ b/tests/test_html_image_preprocess.py
@@ -1,0 +1,178 @@
+"""Unit tests for ``app.HtmlImagePreProcess``.
+
+The preprocessor gives un-sized ``<img>`` elements an explicit px width/height
+read from their inlined image bytes, so pandoc renders them at the 96 dpi CSS
+reference (not its 72 dpi no-density fallback), honouring any CSS max-width.
+Each test feeds an HTML snippet in and asserts on the returned bytes.
+"""
+
+from __future__ import annotations
+
+import base64
+import struct
+import zlib
+
+from app import HtmlImagePreProcess
+
+# --- helpers --------------------------------------------------------------
+
+
+def _png(width: int, height: int, *, dpi: int | None = None) -> bytes:
+    """A minimal valid PNG of the given pixel size (optionally with a pHYs
+    density chunk), so the header parser has something real to read."""
+
+    def chunk(typ: bytes, data: bytes) -> bytes:
+        body = typ + data
+        return struct.pack(">I", len(data)) + body + struct.pack(">I", zlib.crc32(body) & 0xFFFFFFFF)
+
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    chunks = [chunk(b"IHDR", ihdr)]
+    if dpi is not None:
+        ppm = round(dpi / 0.0254)
+        chunks.append(chunk(b"pHYs", struct.pack(">IIB", ppm, ppm, 1)))
+    raw = b"".join(b"\x00" + b"\xcc\xcc\xcc" * width for _ in range(height))
+    chunks.append(chunk(b"IDAT", zlib.compress(raw)))
+    chunks.append(chunk(b"IEND", b""))
+    return b"\x89PNG\r\n\x1a\n" + b"".join(chunks)
+
+
+def _data_uri(png: bytes) -> str:
+    return "data:image/png;base64," + base64.b64encode(png).decode()
+
+
+def _img(png: bytes, style: str = "", extra: str = "") -> bytes:
+    style_attr = f' style="{style}"' if style else ""
+    return f'<p><img src="{_data_uri(png)}"{style_attr}{extra}></p>'.encode()
+
+
+# --- native-size sizing ---------------------------------------------------
+
+
+def test_unsized_image_gets_native_px_dimensions():
+    """No style at all: width/height set to the image's pixel size (rendered at
+    96 dpi by pandoc)."""
+    out = HtmlImagePreProcess.preprocess(_img(_png(300, 150)))
+    assert b'width="300px"' in out
+    assert b'height="150px"' in out
+
+
+def test_density_metadata_is_ignored():
+    """A pHYs density must NOT change the emitted px size — we normalise on the
+    pixel count so the physical size is pixels/96in regardless of embedded dpi."""
+    out = HtmlImagePreProcess.preprocess(_img(_png(300, 150, dpi=72)))
+    assert b'width="300px"' in out and b'height="150px"' in out
+
+
+# --- max-width / max-height clamp -----------------------------------------
+
+
+def test_max_width_wider_than_image_does_not_clamp():
+    """max-width above the image's native width leaves it at native size."""
+    out = HtmlImagePreProcess.preprocess(_img(_png(512, 512), "max-width:650px;"))
+    assert b'width="512px"' in out and b'height="512px"' in out
+
+
+def test_max_width_narrower_than_image_clamps_keeping_ratio():
+    """A 400x200 image with max-width:200px scales to 200x100 (ratio kept)."""
+    out = HtmlImagePreProcess.preprocess(_img(_png(400, 200), "max-width:200px;"))
+    assert b'width="200px"' in out and b'height="100px"' in out
+
+
+def test_max_height_clamps():
+    """max-height constrains too, keeping aspect ratio."""
+    out = HtmlImagePreProcess.preprocess(_img(_png(400, 200), "max-height:50px;"))
+    assert b'width="100px"' in out and b'height="50px"' in out
+
+
+def test_relative_max_width_is_ignored():
+    """A % / em max-width has no fixed px value here, so no clamp is applied —
+    the image keeps its native size."""
+    out = HtmlImagePreProcess.preprocess(_img(_png(300, 150), "max-width:80%;"))
+    assert b'width="300px"' in out and b'height="150px"' in out
+
+
+# --- pass-through cases ---------------------------------------------------
+
+
+def test_existing_width_attribute_is_untouched():
+    """An explicit width attribute wins; we do not add our own."""
+    out = HtmlImagePreProcess.preprocess(_img(_png(300, 150), extra=' width="99"'))
+    assert b'width="99"' in out
+    assert b'width="300px"' not in out
+
+
+def test_explicit_css_width_left_to_lua_filter():
+    """A CSS width/height is handled by filters/inline_styles.lua; this
+    preprocessor must not also set an attribute for it."""
+    out = HtmlImagePreProcess.preprocess(_img(_png(300, 150), "width:120px;"))
+    # style is preserved, and no width/height *attribute* was injected.
+    assert b"width:120px" in out
+    assert b'width="' not in out.split(b"<img")[1].split(b">")[0]
+
+
+def test_non_data_uri_src_is_untouched():
+    """We can't read a remote/attachment reference, so leave it alone."""
+    src = b'<p><img src="http://example.com/x.png"></p>'
+    assert HtmlImagePreProcess.preprocess(src) == src
+
+
+def test_svg_data_uri_is_left_to_svg_processor():
+    """SVG data URIs are handled earlier by app.svg_processor; skip them."""
+    src = b'<p><img src="data:image/svg+xml;base64,PHN2Zy8+"></p>'
+    assert HtmlImagePreProcess.preprocess(src) == src
+
+
+def test_corrupt_base64_is_passed_through():
+    src = b'<p><img src="data:image/png;base64,@@@not-base64@@@"></p>'
+    assert HtmlImagePreProcess.preprocess(src) == src
+
+
+def test_unparseable_input_passed_through():
+    assert HtmlImagePreProcess.preprocess(b"\xff\xfe not html") == b"\xff\xfe not html"
+
+
+def test_image_free_html_unchanged():
+    src = b"<p>no images here</p>"
+    assert HtmlImagePreProcess.preprocess(src) == src
+
+
+def test_full_document_head_is_preserved_when_sizing():
+    """Regression: when the input is a full HTML document, sizing an image must
+    NOT drop the <head>. The exporter sends <head><title>..</title>, which pandoc
+    renders with the "Title" style; losing the head made the title fall back to
+    "First Paragraph"."""
+    png = _png(300, 150)
+    src = ("<html><head><title>Document Title</title></head><body><p>intro</p>" + _img(png).decode() + "</body></html>").encode()
+    out = HtmlImagePreProcess.preprocess(src)
+    assert b"<title>Document Title</title>" in out, f"head/title dropped: {out[:120]!r}"
+    assert b'width="300px"' in out and b'height="150px"' in out  # image still sized
+
+
+def test_idempotent():
+    """Running twice yields the same output (the second pass sees width/height
+    attributes already set and skips)."""
+    once = HtmlImagePreProcess.preprocess(_img(_png(300, 150)))
+    twice = HtmlImagePreProcess.preprocess(once)
+    assert once == twice
+
+
+# --- header parsing across formats ----------------------------------------
+
+
+def test_reads_gif_dimensions():
+    gif = b"GIF89a" + struct.pack("<HH", 20, 10) + b"\x00" * 7
+    assert HtmlImagePreProcess._read_raster_size(gif) == (20, 10)
+
+
+def test_reads_bmp_dimensions():
+    bmp = b"BM" + b"\x00" * 16 + struct.pack("<ii", 25, 15) + b"\x00" * 4
+    assert HtmlImagePreProcess._read_raster_size(bmp) == (25, 15)
+
+
+def test_reads_jpeg_dimensions():
+    jpeg = b"\xff\xd8" + b"\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00" + b"\xff\xc0\x00\x11\x08" + struct.pack(">HH", 30, 40) + b"\x03\x01\x22\x00\x02\x11\x01\x03\x11\x01"
+    assert HtmlImagePreProcess._read_raster_size(jpeg) == (40, 30)
+
+
+def test_unknown_format_returns_none():
+    assert HtmlImagePreProcess._read_raster_size(b"not an image at all!!") is None

--- a/tests/test_html_lists_preprocess.py
+++ b/tests/test_html_lists_preprocess.py
@@ -144,7 +144,7 @@ def test_parse_failure_passes_input_through(mocker):
     """If lxml raises, we MUST return the input bytes unchanged so the
     conversion pipeline doesn't 500 on malformed HTML."""
     mocker.patch(
-        "app.HtmlListsPreProcess.html.fragments_fromstring",
+        "app.HtmlListsPreProcess.html.document_fromstring",
         side_effect=ValueError("synthetic parse failure"),
     )
     src = b"<ol><ol><li>x</li></ol></ol>"
@@ -157,7 +157,7 @@ def test_parse_failure_logs_warning(mocker, caplog):
     import logging  # noqa: PLC0415
 
     mocker.patch(
-        "app.HtmlListsPreProcess.html.fragments_fromstring",
+        "app.HtmlListsPreProcess.html.document_fromstring",
         side_effect=ValueError("boom"),
     )
     caplog.set_level(logging.WARNING, logger="app.HtmlListsPreProcess")
@@ -178,7 +178,9 @@ def test_leading_text_before_orphan_list_is_preserved_when_rewriting():
     Polarion-style fragments that begin with prose."""
     src = b"preamble text <ol><ol><li>x</li></ol></ol>"
     out = HtmlListsPreProcess.preprocess(src)
-    assert out.startswith(b"preamble text"), f"leading text not preserved: {out!r}"
+    # Output is a full document now (head preserved), so the text is inside
+    # <body> rather than at byte 0 — what matters is it isn't dropped.
+    assert b"preamble text" in out, f"leading text not preserved: {out!r}"
     assert SENTINEL in out  # rewriting did happen
 
 

--- a/tests/test_html_paragraph_preprocess.py
+++ b/tests/test_html_paragraph_preprocess.py
@@ -203,7 +203,7 @@ def test_parse_failure_passes_input_through(mocker):
     # extra imports here; the assertion is "any caught exception returns the
     # original source untouched".
     mocker.patch(
-        "app.HtmlParagraphPreProcess.html.fragments_fromstring",
+        "app.HtmlParagraphPreProcess.html.document_fromstring",
         side_effect=ValueError("synthetic parse failure"),
     )
     src = b'<p style="margin-left: 40px">x</p>'
@@ -218,7 +218,7 @@ def test_parse_failure_logs_warning(mocker, caplog):
     import logging  # noqa: PLC0415
 
     mocker.patch(
-        "app.HtmlParagraphPreProcess.html.fragments_fromstring",
+        "app.HtmlParagraphPreProcess.html.document_fromstring",
         side_effect=ValueError("boom"),
     )
     caplog.set_level(logging.WARNING, logger="app.HtmlParagraphPreProcess")
@@ -242,7 +242,9 @@ def test_leading_text_before_indented_p_is_preserved_when_rewriting():
     """
     src = b'hello there <p style="margin-left: 40px">indented</p>'
     out = HtmlParagraphPreProcess.preprocess(src)
-    assert out.startswith(b"hello there"), f"leading text not preserved: {out!r}"
+    # Output is a full document now (head preserved), so the text is inside
+    # <body> rather than at byte 0 — what matters is it isn't dropped.
+    assert b"hello there" in out, f"leading text not preserved: {out!r}"
     assert b'class="pandoc-para"' in out
 
 

--- a/tests/test_inline_styles_filter_integration.py
+++ b/tests/test_inline_styles_filter_integration.py
@@ -14,7 +14,10 @@ Why an integration test (vs. mocked unit tests):
     file plugs that gap with a single, focused round-trip assertion.
 """
 
+import base64
+import struct
 import zipfile
+import zlib
 from io import BytesIO
 from xml.etree import ElementTree as ET
 
@@ -530,3 +533,67 @@ def test_valid_integer_twips_values_still_work(test_parameters: TestParameters):
         doc = ET.fromstring(doc_xml)
         p = _w_p_with_text(doc, f"val_{raw}")
         assert _ind_left(p) == expected, f"valid twips {raw!r} did not produce <w:ind w:left='{expected}'/>"
+
+
+# ---------------------------------------------------------------------------
+# Image sizing — end to end through the whole html->docx pipeline
+# ---------------------------------------------------------------------------
+#
+# Two cooperating pieces size images so a DOCX matches the browser:
+#   * filters/inline_styles.lua (Image handler) copies a CSS width/height from
+#     an <img style="..."> onto the node's width/height attributes, which the
+#     DOCX writer honours.
+#   * app/HtmlImagePreProcess.py sizes images that have NO explicit width/height
+#     from their intrinsic pixels at 96 dpi (honouring max-width), so pandoc
+#     doesn't fall back to its 72 dpi no-density guess (~1.33x too large).
+# The per-unit / format details are unit-tested in tests/test_html_image_preprocess.py;
+# here we prove the extent (EMU) comes out right through the real container.
+
+WP_NS = "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+EMU_PER_PX = 9525  # 1px @96dpi
+
+
+def _png_data_uri(width: int, height: int) -> str:
+    """A minimal valid PNG of the given pixel size as a base64 data URI."""
+
+    def chunk(typ: bytes, data: bytes) -> bytes:
+        body = typ + data
+        return struct.pack(">I", len(data)) + body + struct.pack(">I", zlib.crc32(body) & 0xFFFFFFFF)
+
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    raw = b"".join(b"\x00" + b"\xcc\xcc\xcc" * width for _ in range(height))
+    png = b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) + chunk(b"IDAT", zlib.compress(raw)) + chunk(b"IEND", b"")
+    return "data:image/png;base64," + base64.b64encode(png).decode()
+
+
+def _drawing_extent(docx_bytes: bytes) -> tuple[int, int]:
+    """Return (cx, cy) EMU of the first image drawing in the DOCX."""
+    with zipfile.ZipFile(BytesIO(docx_bytes)) as zf:
+        doc = ET.fromstring(zf.read("word/document.xml"))
+    extent = doc.find(f".//{{{WP_NS}}}extent")
+    assert extent is not None, "no <wp:extent> — image was not embedded/sized"
+    return int(extent.get("cx")), int(extent.get("cy"))
+
+
+def test_image_css_px_dimensions_size_the_docx_extent(test_parameters: TestParameters):
+    """<img style="width:200px;height:100px"> -> extent of exactly 200x100 px in
+    EMU (px * 9525). Exercises the inline_styles.lua Image handler."""
+    html = f'<p><img src="{_png_data_uri(40, 20)}" style="width:200px;height:100px;"></p>'
+    cx, cy = _drawing_extent(_convert_html_to_docx(test_parameters, html))
+    assert (cx, cy) == (200 * EMU_PER_PX, 100 * EMU_PER_PX), f"got {(cx, cy)}"
+
+
+def test_unsized_image_renders_at_96dpi_native(test_parameters: TestParameters):
+    """An image with only max-width (no width/height) must render at its pixel
+    size at 96 dpi, not pandoc's 72 dpi fallback. A 400x200 png under
+    max-width:650px stays native (400px < 650px)."""
+    html = f'<p><img src="{_png_data_uri(400, 200)}" style="max-width:650px;"></p>'
+    cx, cy = _drawing_extent(_convert_html_to_docx(test_parameters, html))
+    assert (cx, cy) == (400 * EMU_PER_PX, 200 * EMU_PER_PX), f"got {(cx, cy)}"
+
+
+def test_unsized_image_wider_than_max_width_is_clamped(test_parameters: TestParameters):
+    """A 400x200 png under max-width:100px is clamped to 100x50 px (ratio kept)."""
+    html = f'<p><img src="{_png_data_uri(400, 200)}" style="max-width:100px;"></p>'
+    cx, cy = _drawing_extent(_convert_html_to_docx(test_parameters, html))
+    assert (cx, cy) == (100 * EMU_PER_PX, 50 * EMU_PER_PX), f"got {(cx, cy)}"


### PR DESCRIPTION
### Proposed changes

At the moment images sizes specified in HTML as inlined styles are not preserved when converting to DOCX. This change fixes this.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
