### PR TITLE
fix: normalize First Paragraph style to Body Text in DOCX output

### DIFF
--- a/app/DocxPostProcess.py
+++ b/app/DocxPostProcess.py
@@ -51,6 +51,7 @@ logger = logging.getLogger(__name__)
 def process(docx_bytes: bytes, paper_size: str | None = None, orientation: str | None = None) -> bytes:
     doc = Document(io.BytesIO(docx_bytes))
     _move_header_footer_references_to_first_section(doc)
+    _replace_first_paragraph_styles(doc)
     _replace_size_and_orientation(doc, paper_size, orientation)
     _replace_table_properties(doc)
     apply_math_colors(doc)
@@ -59,6 +60,23 @@ def process(docx_bytes: bytes, paper_size: str | None = None, orientation: str |
     out = io.BytesIO()
     doc.save(out)
     return out.getvalue()
+
+
+def _replace_first_paragraph_styles(doc: DocumentObject) -> None:
+    """Replace pandoc's "First Paragraph" style with "Body Text".
+
+    Pandoc's DOCX writer automatically assigns "First Paragraph" to the first
+    paragraph after every heading.  This creates visual inconsistency because
+    only that paragraph differs in style from subsequent ones.  Normalizing all
+    such paragraphs to "Body Text" gives a uniform look.
+    """
+    for paragraph in doc.element.body.iterchildren(f"{{{SCHEMA}}}p"):
+        p_pr = paragraph.find(f"{{{SCHEMA}}}pPr")
+        if p_pr is None:
+            continue
+        p_style = p_pr.find(f"{{{SCHEMA}}}pStyle")
+        if p_style is not None and p_style.get(f"{{{SCHEMA}}}val") == "FirstParagraph":
+            p_style.set(f"{{{SCHEMA}}}val", "BodyText")
 
 
 def _replace_size_and_orientation(doc: DocumentObject, paper_size: str | None = None, orientation: str | None = None) -> None:

--- a/app/DocxPostProcess.py
+++ b/app/DocxPostProcess.py
@@ -70,7 +70,7 @@ def _replace_first_paragraph_styles(doc: DocumentObject) -> None:
     only that paragraph differs in style from subsequent ones.  Normalizing all
     such paragraphs to "Body Text" gives a uniform look.
     """
-    for paragraph in doc.element.body.iterchildren(f"{{{SCHEMA}}}p"):
+    for paragraph in doc.element.body.iter(f"{{{SCHEMA}}}p"):
         p_pr = paragraph.find(f"{{{SCHEMA}}}pPr")
         if p_pr is None:
             continue

--- a/tests/test_docx_post_process.py
+++ b/tests/test_docx_post_process.py
@@ -1328,3 +1328,95 @@ class TestMoveHeaderFooterReferencesToFirstSection:
         assert isinstance(result, bytes)
         result_doc = Document(io.BytesIO(result))
         assert len(result_doc.sections) == 2
+
+
+class TestReplaceFirstParagraphStyles:
+    """Tests for _replace_first_paragraph_styles function."""
+
+    @staticmethod
+    def _make_doc_with_styles(styles: list[str | None]) -> MagicMock:
+        """Build a mock Document whose body has paragraphs with given pStyle vals.
+
+        ``None`` means the paragraph has no ``<w:pPr>`` at all.
+        """
+        from lxml import etree
+
+        W = WORD_PROCESSING_ML_MAIN_SCHEMA
+        body = etree.Element(f"{{{W}}}body")
+        for style in styles:
+            p = etree.SubElement(body, f"{{{W}}}p")
+            if style is not None:
+                pPr = etree.SubElement(p, f"{{{W}}}pPr")
+                etree.SubElement(pPr, f"{{{W}}}pStyle", {f"{{{W}}}val": style})
+        doc = MagicMock()
+        doc.element.body = body
+        return doc
+
+    @staticmethod
+    def _get_styles(doc: MagicMock) -> list[str | None]:
+        """Extract the pStyle val from each paragraph, or None if absent."""
+        W = WORD_PROCESSING_ML_MAIN_SCHEMA
+        result = []
+        for p in doc.element.body.iterchildren(f"{{{W}}}p"):
+            pPr = p.find(f"{{{W}}}pPr")
+            if pPr is None:
+                result.append(None)
+                continue
+            pStyle = pPr.find(f"{{{W}}}pStyle")
+            if pStyle is None:
+                result.append(None)
+            else:
+                result.append(pStyle.get(f"{{{W}}}val"))
+        return result
+
+    def test_replaces_first_paragraph_style_with_body_text(self):
+        doc = self._make_doc_with_styles(["FirstParagraph"])
+        DocxPostProcess._replace_first_paragraph_styles(doc)
+        assert self._get_styles(doc) == ["BodyText"]
+
+    def test_replaces_multiple_first_paragraph_styles(self):
+        doc = self._make_doc_with_styles(["Heading1", "FirstParagraph", "BodyText", "FirstParagraph"])
+        DocxPostProcess._replace_first_paragraph_styles(doc)
+        assert self._get_styles(doc) == ["Heading1", "BodyText", "BodyText", "BodyText"]
+
+    def test_does_not_change_other_paragraph_styles(self):
+        doc = self._make_doc_with_styles(["Heading1", "Heading2", "BodyText", "ListParagraph"])
+        DocxPostProcess._replace_first_paragraph_styles(doc)
+        assert self._get_styles(doc) == ["Heading1", "Heading2", "BodyText", "ListParagraph"]
+
+    def test_handles_paragraph_without_properties(self):
+        doc = self._make_doc_with_styles([None, "FirstParagraph", None])
+        DocxPostProcess._replace_first_paragraph_styles(doc)
+        assert self._get_styles(doc) == [None, "BodyText", None]
+
+    def test_handles_empty_document(self):
+        doc = self._make_doc_with_styles([])
+        DocxPostProcess._replace_first_paragraph_styles(doc)
+        assert self._get_styles(doc) == []
+
+    def test_integration_with_real_docx(self):
+        """Integration test: add a heading + paragraph, convert, verify no FirstParagraph."""
+        import io
+
+        from docx import Document
+
+        doc = Document()
+        doc.add_heading("Test Heading", level=1)
+        p = doc.add_paragraph("Body after heading")
+        # Simulate pandoc's behavior by setting the style
+        p.style = doc.styles["Normal"]
+        p.style = doc.styles.add_style("First Paragraph", 1) if "First Paragraph" not in [s.name for s in doc.styles] else doc.styles["First Paragraph"]
+
+        buf = io.BytesIO()
+        doc.save(buf)
+        result = DocxPostProcess.process(buf.getvalue())
+
+        result_doc = Document(io.BytesIO(result))
+        W = WORD_PROCESSING_ML_MAIN_SCHEMA
+        for para in result_doc.element.body.iterchildren(f"{{{W}}}p"):
+            pPr = para.find(f"{{{W}}}pPr")
+            if pPr is None:
+                continue
+            pStyle = pPr.find(f"{{{W}}}pStyle")
+            if pStyle is not None:
+                assert pStyle.get(f"{{{W}}}val") != "FirstParagraph", "FirstParagraph style should have been replaced"

--- a/tests/test_docx_post_process.py
+++ b/tests/test_docx_post_process.py
@@ -1413,10 +1413,15 @@ class TestReplaceFirstParagraphStyles:
 
         result_doc = Document(io.BytesIO(result))
         W = WORD_PROCESSING_ML_MAIN_SCHEMA
+        first_paragraph_replaced = False
         for para in result_doc.element.body.iterchildren(f"{{{W}}}p"):
             pPr = para.find(f"{{{W}}}pPr")
             if pPr is None:
                 continue
             pStyle = pPr.find(f"{{{W}}}pStyle")
             if pStyle is not None:
-                assert pStyle.get(f"{{{W}}}val") != "FirstParagraph", "FirstParagraph style should have been replaced"
+                val = pStyle.get(f"{{{W}}}val")
+                assert val != "FirstParagraph", "FirstParagraph style should have been replaced"
+                if val == "BodyText":
+                    first_paragraph_replaced = True
+        assert first_paragraph_replaced, "Expected at least one paragraph to be replaced with BodyText"


### PR DESCRIPTION
Refs: #195

### Proposed changes

Pandoc's DOCX writer assigns a "First Paragraph" style to the first paragraph after every heading, causing visual inconsistency. This adds a post-processing step that normalizes all "First Paragraph" styles to "Body Text" for a uniform look.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
