### PR TITLE
fix: preserve table sizes when converting HTML to DOCX and DOCX to PDF

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,6 +125,8 @@ COPY filters/docx_paragraphs_to_latex.lua "/usr/local/share/pandoc/filters/docx_
 COPY filters/docx_lists_to_latex.lua "/usr/local/share/pandoc/filters/docx_lists_to_latex.lua"
 COPY filters/docx_tables_to_latex.lua "/usr/local/share/pandoc/filters/docx_tables_to_latex.lua"
 COPY filters/html_lists.lua "/usr/local/share/pandoc/filters/html_lists.lua"
+COPY filters/html_tables_to_latex.lua "/usr/local/share/pandoc/filters/html_tables_to_latex.lua"
+COPY filters/html_captions.lua "/usr/local/share/pandoc/filters/html_captions.lua"
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD curl -fsS http://localhost:9082/health || exit 1

--- a/app/DocxPostProcess.py
+++ b/app/DocxPostProcess.py
@@ -11,9 +11,13 @@ from docx.oxml.ns import nsdecls
 from lxml import etree  # type: ignore
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from docx.document import Document as DocumentObject
     from docx.section import Section
     from docx.table import Table, _Cell
+
+    from app.HtmlTableLayout import TableLayout
 
 from app.DocxMathColorPostProcess import apply_math_colors
 from app.DocxReferencesPostProcess import add_table_of_contents_entries, enable_auto_update_fields
@@ -47,13 +51,37 @@ PAPER_SIZES = {
 }
 logger = logging.getLogger(__name__)
 
+# OOXML tblPr child element order (subset of CT_TblPrBase we touch). Used to
+# insert new properties at a schema-valid position so both Word and the
+# stricter LibreOffice accept the output regardless of which children pandoc
+# (or the inline_styles.lua table rebuild) already emitted.
+_TBLPR_CHILD_ORDER = [
+    "tblStyle",
+    "tblpPr",
+    "tblOverlap",
+    "bidiVisual",
+    "tblStyleRowBandSize",
+    "tblStyleColBandSize",
+    "tblW",
+    "jc",
+    "tblCellSpacing",
+    "tblInd",
+    "tblBorders",
+    "shd",
+    "tblLayout",
+    "tblCellMar",
+    "tblLook",
+    "tblCaption",
+    "tblDescription",
+]
 
-def process(docx_bytes: bytes, paper_size: str | None = None, orientation: str | None = None) -> bytes:
+
+def process(docx_bytes: bytes, paper_size: str | None = None, orientation: str | None = None, table_layouts: list[TableLayout] | None = None) -> bytes:
     doc = Document(io.BytesIO(docx_bytes))
     _move_header_footer_references_to_first_section(doc)
     _replace_first_paragraph_styles(doc)
     _replace_size_and_orientation(doc, paper_size, orientation)
-    _replace_table_properties(doc)
+    _replace_table_properties(doc, table_layouts)
     apply_math_colors(doc)
     add_table_of_contents_entries(doc)
     enable_auto_update_fields(doc)
@@ -211,7 +239,22 @@ def _move_header_footer_references_to_first_section(doc: DocumentObject) -> None
         first_sect_pr.append(title_pg)
 
 
-def _replace_table_properties(doc: DocumentObject) -> None:  # NOSONAR  # needed by design
+def _replace_table_properties(doc: DocumentObject, table_layouts: list[TableLayout] | None = None) -> None:  # NOSONAR  # needed by design
+    # Per-table width/alignment recovered from the HTML source (see
+    # app/HtmlTableLayout.py). The list is one entry per <table> in document
+    # order (depth-first, nested included) — the same order this function walks
+    # tables in — so a shared iterator lines them up index-for-index. Guard on
+    # an exact count match: if pandoc dropped or added a table the alignment
+    # would be off, so we skip applying layouts entirely and fall back to the
+    # previous 100 %/autofit default rather than mislabel tables.
+    layout_iter: Iterator[TableLayout] | None = None
+    if table_layouts:
+        table_count = len(doc.element.body.findall(".//w:tbl", namespaces={"w": SCHEMA}))
+        if table_count == len(table_layouts):
+            layout_iter = iter(table_layouts)
+        else:
+            logger.warning("HtmlTableLayout: %d layouts for %d tables; skipping width/alignment (fallback to defaults)", len(table_layouts), table_count)
+
     # Group tables by their section
     for target_index, section in enumerate(doc.sections):
         max_width = _get_available_content_width_for_section(section)
@@ -233,37 +276,103 @@ def _replace_table_properties(doc: DocumentObject) -> None:  # NOSONAR  # needed
 
         # Note: This gets all tables in the document section
         for table in tables_in_section:
-            _process_table(table, 0, max_width)
+            _process_table(table, 0, max_width, layout_iter)
 
 
-def _process_table(table: Table, parent_columns_count: int, max_width: int) -> None:
+def _process_table(table: Table, parent_columns_count: int, max_width: int, layout_iter: Iterator[TableLayout] | None = None) -> None:
     tbl = table._element
+    # Pull this table's layout first, before recursing into nested tables, so
+    # consumption order stays depth-first and matches HtmlTableLayout.extract.
+    layout = next(layout_iter, None) if layout_iter is not None else None
     columns_count = parent_columns_count + len(table.columns)
     table_properties = tbl.find(".//w:tblPr", namespaces={"w": SCHEMA})
     if table_properties is None:
         table_properties = parse_xml(f"<w:tblPr {nsdecls('w')}/>")
         tbl.insert(0, table_properties)
 
-    # Set table width (5000 = 100%)
-    table_width = parse_xml(f'<w:tblW {nsdecls("w")} w:w="5000" w:type="pct"/>')
-    old_table_width = table_properties.find(".//w:tblW", namespaces={"w": SCHEMA})
-    if old_table_width is not None:
-        table_properties.remove(old_table_width)
-    table_properties.append(table_width)
-
-    # Set table layout to autofit
-    table_layout = parse_xml(f'<w:tblLayout {nsdecls("w")} w:type="autofit"/>')
-    old_table_layout = table_properties.find(".//w:tblLayout", namespaces={"w": SCHEMA})
-    if old_table_layout is not None:
-        table_properties.remove(old_table_layout)
-    table_properties.append(table_layout)
+    _apply_table_layout(tbl, table_properties, layout)
 
     # Process nested tables
     for row in table.rows:
         for cell in row.cells:
             _resize_images_in_cell(cell, max_width / columns_count)
             for sub_table in cell.tables:
-                _process_table(sub_table, columns_count, max_width)
+                _process_table(sub_table, columns_count, max_width, layout_iter)
+
+
+def _apply_table_layout(tbl: Any, table_properties: Any, layout: TableLayout | None) -> None:
+    """Write width, alignment and indent onto a table's <w:tblPr>.
+
+    Default (no layout, or a layout carrying no width): 100 % width with
+    autofit layout — the historical behaviour that keeps every existing table
+    filling the text column. A percentage width keeps autofit (Word renders the
+    table at that fraction of the text column). An absolute width switches to
+    fixed layout and rescales the column grid so Word honours the exact size.
+    Alignment (<w:jc>) and left indent (<w:tblInd>) are applied when present.
+    """
+    # Width: pct keeps autofit; dxa needs fixed layout + a rescaled grid.
+    width_type, width_value, use_fixed_layout = "pct", 5000, False
+    if layout is not None and layout.width_type is not None and layout.width_value is not None:
+        width_type, width_value = layout.width_type, layout.width_value
+        use_fixed_layout = width_type == "dxa"
+        if use_fixed_layout:
+            _rescale_table_grid(tbl, width_value)
+
+    _set_tblpr_child(table_properties, parse_xml(f'<w:tblW {nsdecls("w")} w:w="{width_value}" w:type="{width_type}"/>'))
+
+    layout_type = "fixed" if use_fixed_layout else "autofit"
+    _set_tblpr_child(table_properties, parse_xml(f'<w:tblLayout {nsdecls("w")} w:type="{layout_type}"/>'))
+
+    if layout is not None and layout.jc is not None:
+        _set_tblpr_child(table_properties, parse_xml(f'<w:jc {nsdecls("w")} w:val="{layout.jc}"/>'))
+
+    if layout is not None and layout.indent_twips is not None:
+        _set_tblpr_child(table_properties, parse_xml(f'<w:tblInd {nsdecls("w")} w:w="{layout.indent_twips}" w:type="dxa"/>'))
+
+
+def _set_tblpr_child(table_properties: Any, new_child: Any) -> None:
+    """Replace any existing child with the same tag and insert at a schema-valid position."""
+    local_name = etree.QName(new_child).localname
+    for existing in table_properties.findall(f"w:{local_name}", namespaces={"w": SCHEMA}):
+        table_properties.remove(existing)
+
+    order = _TBLPR_CHILD_ORDER.index(local_name)
+    for child in table_properties:
+        child_local = etree.QName(child).localname
+        if child_local in _TBLPR_CHILD_ORDER and _TBLPR_CHILD_ORDER.index(child_local) > order:
+            child.addprevious(new_child)
+            return
+    table_properties.append(new_child)
+
+
+def _rescale_table_grid(tbl: Any, target_twips: int) -> None:
+    """Scale the <w:tblGrid> column widths so they sum to target_twips.
+
+    Under fixed layout Word derives the rendered table width from the grid
+    column widths (not <w:tblW>), so an absolute table width only takes effect
+    once the grid is rescaled to match it. Proportional scaling preserves the
+    relative column sizing pandoc emitted; a zero/absent grid is distributed
+    evenly.
+    """
+    grid = tbl.find("w:tblGrid", namespaces={"w": SCHEMA})
+    if grid is None:
+        return
+    columns = grid.findall("w:gridCol", namespaces={"w": SCHEMA})
+    if not columns:
+        return
+
+    width_attr = f"{{{SCHEMA}}}w"
+    widths = [int(col.get(width_attr) or 0) for col in columns]
+    total = sum(widths)
+
+    if total <= 0:
+        even = max(1, target_twips // len(columns))
+        for col in columns:
+            col.set(width_attr, str(even))
+        return
+
+    for col, width in zip(columns, widths, strict=False):
+        col.set(width_attr, str(max(1, round(width * target_twips / total))))
 
 
 def _get_available_content_width_for_section(section: Section) -> int:

--- a/app/DocxReferencesPostProcess.py
+++ b/app/DocxReferencesPostProcess.py
@@ -13,6 +13,15 @@ SCHEMA = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"  # NOSON
 # Common XPath expressions
 XPATH_P_PR = ".//w:pPr"
 XPATH_P_STYLE = ".//w:pStyle"
+
+# Paragraph style id that marks a genuine caption. filters/html_captions.lua
+# sets it (only) on paragraphs that carry Polarion's <span data-sequence=...>
+# caption counter, so it is a reliable, language-independent signal. Keying off
+# it — rather than "does the text start with Table/Figure" — is what stops
+# headings ("Table test III"), cross-references ("Table 1 shows ...") and
+# labels ("Table 50px") from being mistaken for captions.
+CAPTION_STYLE_ID = "Caption"
+
 logger = logging.getLogger(__name__)
 
 
@@ -68,17 +77,25 @@ def _find_and_process_captions(body: Any) -> tuple[list, list]:
     table_paragraphs = []
 
     for para in body.findall(".//w:p", namespaces={"w": SCHEMA}):
-        text = _get_paragraph_text(para)
-        text_stripped = text.strip()
+        # Only real captions are considered: filters/html_captions.lua has
+        # already stamped the "Caption" style on paragraphs that carry the
+        # Polarion caption counter span. Prose, headings and labels that merely
+        # start with "Table"/"Figure" never get that style, so they are ignored.
+        if _get_paragraph_style(para) != CAPTION_STYLE_ID:
+            continue
 
+        text_stripped = _get_paragraph_text(para).strip()
+
+        # Classify Table vs Figure from the caption's leading word (the counter
+        # span's sequence keyword surfaces there). Default to Table.
         if text_stripped.startswith("Figure"):
             figure_paragraphs.append((para, text_stripped))
             _add_caption_style_and_tc_field(para, text_stripped, field_flag="F")
-            logger.debug(f"Added Caption style and TC field to figure: {text_stripped}")
-        elif text_stripped.startswith("Table"):
+            logger.debug(f"Added TC field to figure caption: {text_stripped}")
+        else:
             table_paragraphs.append((para, text_stripped))
             _add_caption_style_and_tc_field(para, text_stripped, field_flag="T")
-            logger.debug(f"Added Caption style and TC field to table: {text_stripped}")
+            logger.debug(f"Added TC field to table caption: {text_stripped}")
 
     logger.info(f"Found {len(figure_paragraphs)} figure captions and {len(table_paragraphs)} table captions")
     return figure_paragraphs, table_paragraphs

--- a/app/DocxReferencesPostProcess.py
+++ b/app/DocxReferencesPostProcess.py
@@ -15,12 +15,15 @@ XPATH_P_PR = ".//w:pPr"
 XPATH_P_STYLE = ".//w:pStyle"
 
 # Paragraph style id that marks a genuine caption. filters/html_captions.lua
-# sets it (only) on paragraphs that carry Polarion's <span data-sequence=...>
-# caption counter, so it is a reliable, language-independent signal. Keying off
-# it — rather than "does the text start with Table/Figure" — is what stops
-# headings ("Table test III"), cross-references ("Table 1 shows ...") and
-# labels ("Table 50px") from being mistaken for captions.
-CAPTION_STYLE_ID = "Caption"
+# sets it on paragraphs that carry Polarion's <span data-sequence=...> caption
+# counter. Non-HTML inputs bring their own caption styles: pandoc emits
+# "TableCaption"/"ImageCaption" for markdown/docx table & figure captions, and
+# Word uses "Caption". Keying off this set of caption STYLES — rather than "does
+# the text start with Table/Figure" — captures real captions from every source
+# while still excluding headings ("Table test III"), cross-references
+# ("Table 1 shows ...") and labels ("Table 50px"), which never carry a caption
+# style.
+CAPTION_STYLE_IDS = frozenset({"Caption", "TableCaption", "ImageCaption"})
 
 logger = logging.getLogger(__name__)
 
@@ -77,18 +80,22 @@ def _find_and_process_captions(body: Any) -> tuple[list, list]:
     table_paragraphs = []
 
     for para in body.findall(".//w:p", namespaces={"w": SCHEMA}):
-        # Only real captions are considered: filters/html_captions.lua has
-        # already stamped the "Caption" style on paragraphs that carry the
-        # Polarion caption counter span. Prose, headings and labels that merely
-        # start with "Table"/"Figure" never get that style, so they are ignored.
-        if _get_paragraph_style(para) != CAPTION_STYLE_ID:
+        # Only real captions are considered — those carrying a caption STYLE
+        # (Polarion's "Caption" from filters/html_captions.lua, Word's "Caption",
+        # or pandoc's own "TableCaption"/"ImageCaption"). Prose, headings and
+        # labels that merely start with "Table"/"Figure" never carry one, so
+        # they are ignored.
+        style = _get_paragraph_style(para)
+        if style not in CAPTION_STYLE_IDS:
             continue
 
         text_stripped = _get_paragraph_text(para).strip()
 
-        # Classify Table vs Figure from the caption's leading word (the counter
-        # span's sequence keyword surfaces there). Default to Table.
-        if text_stripped.startswith("Figure"):
+        # Classify Figure vs Table from the caption style, falling back to the
+        # leading word for the generic "Caption" style (Polarion/Word captions
+        # open with the "Figure"/"Table" sequence keyword). Default to Table.
+        is_figure = style == "ImageCaption" or (style != "TableCaption" and text_stripped.startswith("Figure"))
+        if is_figure:
             figure_paragraphs.append((para, text_stripped))
             _add_caption_style_and_tc_field(para, text_stripped, field_flag="F")
             logger.debug(f"Added TC field to figure caption: {text_stripped}")

--- a/app/DocxTablePreProcess.py
+++ b/app/DocxTablePreProcess.py
@@ -69,6 +69,9 @@ _PPR_TAG = f"{{{W_NS}}}pPr"
 _PSTYLE_TAG = f"{{{W_NS}}}pStyle"
 _R_TAG = f"{{{W_NS}}}r"
 _T_TAG = f"{{{W_NS}}}t"
+_FLDSIMPLE_TAG = f"{{{W_NS}}}fldSimple"
+_INSTRTEXT_TAG = f"{{{W_NS}}}instrText"
+_INSTR_ATTR = f"{{{W_NS}}}instr"
 _W_ATTR = f"{{{W_NS}}}w"
 _TYPE_ATTR = f"{{{W_NS}}}type"
 _VAL_ATTR = f"{{{W_NS}}}val"
@@ -202,11 +205,11 @@ def _make_sentinel_run(sentinel_text: str) -> ET.Element:
 
 
 def _is_positive_int(value: str | None) -> bool:
-    """True when *value* parses as a positive integer."""
-    try:
-        return int(value) > 0  # type: ignore[arg-type]
-    except TypeError, ValueError:
+    """True when *value* is a positive integer string (e.g. a ``w:w`` width)."""
+    if value is None:
         return False
+    stripped = value.strip()
+    return stripped.isdigit() and int(stripped) > 0
 
 
 def _row_column_count(tr: ET.Element) -> int:
@@ -428,16 +431,34 @@ def _tag_table_layout(tbl: ET.Element) -> bool:
     return True
 
 
-def _neutralize_caption_paragraphs(tree: ET.Element) -> bool:
-    """Strip the ``Caption`` style from paragraphs so pandoc does not turn them
-    into auto-numbered LaTeX ``\\caption`` blocks.
+def _has_sequence_field(para: ET.Element) -> bool:
+    """True when the paragraph numbers itself with a Word ``SEQ`` field.
 
-    A Polarion caption's text already contains its number ("Table 1 ..."); left
-    as a ``Caption``-styled paragraph, pandoc's DOCX reader attaches it to the
-    adjacent table and LaTeX prints "Table N: Table N ..." — the counter twice.
-    Dropping the style makes it a normal paragraph that renders its text once
-    (matching how the DOCX shows it). Only ``Caption`` is touched, not pandoc's
-    own ``TableCaption``/``ImageCaption`` (whose text has no embedded number).
+    A genuine Word caption carries its number as a ``SEQ`` field, so pandoc can
+    strip that label and re-number it (keeping it in a List of Tables/Figures).
+    A Polarion caption instead has the number as literal text, so there is no
+    field to find.
+    """
+    if any("SEQ" in (fld.get(_INSTR_ATTR) or "").upper() for fld in para.iter(_FLDSIMPLE_TAG)):
+        return True
+    return any(instr.text and "SEQ" in instr.text.upper() for instr in para.iter(_INSTRTEXT_TAG))
+
+
+def _neutralize_caption_paragraphs(tree: ET.Element) -> bool:
+    """Strip the ``Caption`` style from *Polarion* captions so pandoc does not
+    turn them into auto-numbered LaTeX ``\\caption`` blocks.
+
+    A Polarion caption's text already contains its number as literal text
+    ("Table 1 ..."); left as a ``Caption``-styled paragraph, pandoc's DOCX
+    reader attaches it to the adjacent table and LaTeX prints
+    "Table N: Table N ..." — the counter twice. Dropping the style makes it a
+    normal paragraph that renders its text once (matching how the DOCX shows it).
+
+    A genuine Word caption is left untouched: it numbers itself with a ``SEQ``
+    field, so pandoc re-numbers it correctly and can still list it in a
+    generated List of Tables/Figures. We therefore only neutralise captions
+    that have no ``SEQ`` field (i.e. the literal-numbered Polarion ones), and
+    never pandoc's own ``TableCaption``/``ImageCaption`` styles.
 
     Returns True when any paragraph was changed.
     """
@@ -447,7 +468,7 @@ def _neutralize_caption_paragraphs(tree: ET.Element) -> bool:
         if ppr is None:
             continue
         pstyle = ppr.find(_PSTYLE_TAG)
-        if pstyle is not None and pstyle.get(_VAL_ATTR) == _CAPTION_STYLE_VAL:
+        if pstyle is not None and pstyle.get(_VAL_ATTR) == _CAPTION_STYLE_VAL and not _has_sequence_field(para):
             ppr.remove(pstyle)
             changed = True
     return changed

--- a/app/DocxTablePreProcess.py
+++ b/app/DocxTablePreProcess.py
@@ -1,6 +1,6 @@
 """Rewrite table properties in a DOCX so tables survive into LaTeX/PDF.
 
-Pandoc's DOCX reader has two table-related problems this preprocessor fixes:
+Pandoc's DOCX reader has three table-related problems this preprocessor fixes:
 
 1. **Missing grid-column widths**: ``<w:gridCol/>`` elements without a
    ``w:w`` attribute cause pandoc to produce an empty ``ColSpec`` list,
@@ -15,9 +15,23 @@ Pandoc's DOCX reader has two table-related problems this preprocessor fixes:
    (``filters/docx_tables_to_latex.lua``) can inject ``\\cellcolor`` into
    the LaTeX output.
 
-Sentinel format (PUA delimiters U+E010 / U+E011)::
+3. **Dropped table width & alignment**: pandoc normalises the column widths
+   to sum to 1.0 (losing the table's ``<w:tblW>`` share of the page) and
+   discards the table's ``<w:jc>`` alignment entirely, so every table renders
+   full-width and centered in the PDF.  This preprocessor records the table's
+   width fraction and alignment on the first cell's sentinel; the Lua filter
+   scales the ``ColSpec`` widths back down and emits longtable ``\\LTleft``/
+   ``\\LTright`` glue.  Every table with an explicit ``<w:tblW>`` is tagged,
+   including 100% ones (pandoc may otherwise render them content-width and
+   centered when the DOCX carries no usable column widths).
 
-    <U+E010>bg=RRGGBB<U+E011>
+Sentinel format (PUA delimiters U+E010 / U+E011), a ``;``-separated key map::
+
+    <U+E010>bg=RRGGBB;tw=0.4000;ta=left<U+E011>
+
+``bg`` is per coloured cell; ``tw`` (0..1 line fraction) and ``ta``
+(left/center/right) are table-level and live on the first cell (merged into
+its sentinel if it also carries ``bg``).
 
 This is the table companion to :mod:`app.DocxColorPreProcess` /
 :mod:`app.DocxParagraphPreProcess`; it runs on the same docx->latex path
@@ -40,18 +54,42 @@ SENTINEL_OPEN = "\ue010"
 SENTINEL_CLOSE = "\ue011"
 
 _TBL_TAG = f"{{{W_NS}}}tbl"
+_TBLPR_TAG = f"{{{W_NS}}}tblPr"
 _TBLGRID_TAG = f"{{{W_NS}}}tblGrid"
 _GRIDCOL_TAG = f"{{{W_NS}}}gridCol"
+_TBLW_TAG = f"{{{W_NS}}}tblW"
+_JC_TAG = f"{{{W_NS}}}jc"
+_TR_TAG = f"{{{W_NS}}}tr"
 _TC_TAG = f"{{{W_NS}}}tc"
 _TCPR_TAG = f"{{{W_NS}}}tcPr"
+_GRIDSPAN_TAG = f"{{{W_NS}}}gridSpan"
 _SHD_TAG = f"{{{W_NS}}}shd"
 _P_TAG = f"{{{W_NS}}}p"
 _PPR_TAG = f"{{{W_NS}}}pPr"
+_PSTYLE_TAG = f"{{{W_NS}}}pStyle"
 _R_TAG = f"{{{W_NS}}}r"
 _T_TAG = f"{{{W_NS}}}t"
 _W_ATTR = f"{{{W_NS}}}w"
+_TYPE_ATTR = f"{{{W_NS}}}type"
+_VAL_ATTR = f"{{{W_NS}}}val"
 _FILL_ATTR = f"{{{W_NS}}}fill"
 _SPACE_ATTR = "{http://www.w3.org/XML/1998/namespace}space"
+
+# OOXML table width of 100% == 5000 fiftieths of a percent.
+_MAX_PCT = 5000.0
+# Reference text width in twips for turning an absolute (dxa) table width into a
+# line fraction: Letter (8.5in) minus 1in margins each side = 6.5in = 9360 twips.
+# Matches the Letter assumption in app/DocxPostProcess.py and the 468pt used by
+# filters/html_tables_to_latex.lua. Best-effort for absolute widths (same caveat).
+_REFERENCE_WIDTH_TWIPS = 9360.0
+# Map an OOXML <w:jc w:val> to a canonical alignment token.
+_JC_TO_ALIGN = {"left": "left", "center": "center", "right": "right", "start": "left", "end": "right"}
+
+# Paragraph style id that HTML->DOCX assigns to Polarion captions (see
+# filters/html_captions.lua). Their text already carries the sequence number
+# ("Table 1 ..."), so if pandoc's DOCX reader turns them into a LaTeX
+# \caption it prepends its OWN "Table N:" counter, printing the number twice.
+_CAPTION_STYLE_VAL = "Caption"
 
 # Default column width (twips) assigned when <w:gridCol> lacks a w:w
 # attribute.  The exact value is unimportant — pandoc only uses the
@@ -117,23 +155,42 @@ def _extract_cell_bg(tcpr: ET.Element) -> str | None:
     return _normalize_hex(shd.get(_FILL_ATTR))
 
 
-def _build_sentinel_text(bg: str) -> str:
-    """Encode cell properties as a sentinel string."""
-    return f"{SENTINEL_OPEN}bg={bg}{SENTINEL_CLOSE}"
+def _build_sentinel_text(kv: dict[str, str]) -> str:
+    """Encode a property map as a ``<OPEN>k1=v1;k2=v2<CLOSE>`` sentinel string."""
+    payload = ";".join(f"{key}={value}" for key, value in kv.items())
+    return f"{SENTINEL_OPEN}{payload}{SENTINEL_CLOSE}"
 
 
-def _already_tagged(para: ET.Element) -> bool:
-    """True when the paragraph's first run already carries a table-cell
-    sentinel (idempotency guard for repeated preprocessing passes).
+def _parse_sentinel_text(text: str) -> tuple[dict[str, str], str]:
+    """Split a leading sentinel into ``({k: v}, rest)``.
+
+    Returns ``({}, text)`` when *text* does not start with a complete sentinel.
+    """
+    if not text.startswith(SENTINEL_OPEN):
+        return {}, text
+    close = text.find(SENTINEL_CLOSE)
+    if close == -1:
+        return {}, text
+    payload = text[len(SENTINEL_OPEN) : close]
+    rest = text[close + len(SENTINEL_CLOSE) :]
+    kv: dict[str, str] = {}
+    for segment in payload.split(";"):
+        key, sep, value = segment.partition("=")
+        if sep:
+            kv[key] = value
+    return kv, rest
+
+
+def _first_run_text_element(para: ET.Element) -> ET.Element | None:
+    """Return the ``<w:t>`` of the paragraph's first run (skipping ``<w:pPr>``),
+    or None when the paragraph does not begin with a run.
     """
     for child in para:
         if child.tag == _R_TAG:
-            text_el = child.find(_T_TAG)
-            text = text_el.text if text_el is not None else None
-            return bool(text and text.startswith(SENTINEL_OPEN))
+            return child.find(_T_TAG)
         if child.tag != _PPR_TAG:
-            return False
-    return False
+            return None
+    return None
 
 
 def _make_sentinel_run(sentinel_text: str) -> ET.Element:
@@ -144,32 +201,76 @@ def _make_sentinel_run(sentinel_text: str) -> ET.Element:
     return run
 
 
-def _fix_grid_col_widths(tbl: ET.Element) -> bool:
-    """Add ``w:w`` to ``<w:gridCol>`` elements that lack it.
-
-    Pandoc's DOCX reader needs ``w:w`` to compute ``ColSpec`` proportions;
-    without it the column list is empty and every cell is silently dropped.
-
-    Returns True when any ``<w:gridCol>`` was modified.
-    """
-    tblgrid = tbl.find(_TBLGRID_TAG)
-    if tblgrid is None:
+def _is_positive_int(value: str | None) -> bool:
+    """True when *value* parses as a positive integer."""
+    try:
+        return int(value) > 0  # type: ignore[arg-type]
+    except TypeError, ValueError:
         return False
 
-    grid_cols = tblgrid.findall(_GRIDCOL_TAG)
-    if not grid_cols:
+
+def _row_column_count(tr: ET.Element) -> int:
+    """Number of grid columns a row spans (summing each cell's ``w:gridSpan``)."""
+    total = 0
+    for tc in tr.findall(_TC_TAG):
+        span = 1
+        tcpr = tc.find(_TCPR_TAG)
+        if tcpr is not None:
+            gridspan = tcpr.find(_GRIDSPAN_TAG)
+            if gridspan is not None and _is_positive_int(gridspan.get(_VAL_ATTR)):
+                span = int(gridspan.get(_VAL_ATTR))  # type: ignore[arg-type]
+        total += span
+    return total
+
+
+def _table_column_count(tbl: ET.Element) -> int:
+    """Widest row's column count — how many ``<w:gridCol>`` the table needs."""
+    return max((_row_column_count(tr) for tr in tbl.findall(_TR_TAG)), default=0)
+
+
+def _fix_grid_col_widths(tbl: ET.Element) -> bool:
+    """Ensure the table has a ``<w:tblGrid>`` with one positive-width
+    ``<w:gridCol>`` per column.
+
+    Pandoc's DOCX reader derives ``ColSpec`` proportions from the grid columns.
+    If the grid is missing, has too few columns, or carries missing/zero/invalid
+    widths (some editors emit ``w:w="0"``), pandoc ends up with an empty or
+    partial column list and the LaTeX writer renders the table content-width
+    and centered — ignoring its ``<w:tblW>``. This normalises the grid so every
+    column has a positive width (the ratios are all pandoc uses), which keeps
+    the cells and lets the width/alignment recovery place the table correctly.
+
+    Returns True when the grid was created or modified.
+    """
+    num_cols = _table_column_count(tbl)
+    if num_cols == 0:
         return False
 
     changed = False
+    tblgrid = tbl.find(_TBLGRID_TAG)
+    if tblgrid is None:
+        tblgrid = ET.Element(_TBLGRID_TAG)
+        tblpr = tbl.find(_TBLPR_TAG)
+        insert_at = list(tbl).index(tblpr) + 1 if tblpr is not None else 0
+        tbl.insert(insert_at, tblgrid)
+        changed = True
+
+    grid_cols = tblgrid.findall(_GRIDCOL_TAG)
     for col in grid_cols:
-        if col.get(_W_ATTR) is None:
+        if not _is_positive_int(col.get(_W_ATTR)):
             col.set(_W_ATTR, _DEFAULT_GRIDCOL_WIDTH)
             changed = True
+
+    # Add any missing columns so pandoc sees the full width, not a subset.
+    for _ in range(len(grid_cols), num_cols):
+        col = ET.SubElement(tblgrid, _GRIDCOL_TAG)
+        col.set(_W_ATTR, _DEFAULT_GRIDCOL_WIDTH)
+        changed = True
 
     return changed
 
 
-def _find_or_create_first_para(tc: ET.Element, tcpr: ET.Element) -> ET.Element:
+def _find_or_create_first_para(tc: ET.Element, tcpr: ET.Element | None) -> ET.Element:
     """Return the first ``<w:p>`` before any nested ``<w:tbl>`` in *tc*.
 
     A cell containing a nested table has structure ``[tcPr, tbl, p]`` where the
@@ -189,11 +290,24 @@ def _find_or_create_first_para(tc: ET.Element, tcpr: ET.Element) -> ET.Element:
     return para
 
 
-def _inject_sentinel(para: ET.Element, bg: str) -> None:
-    """Insert a sentinel run encoding *bg* into *para*."""
+def _ensure_sentinel(para: ET.Element, kv: dict[str, str]) -> None:
+    """Merge *kv* into the paragraph's leading sentinel, creating one if absent.
+
+    Merging (rather than prepending a second sentinel) keeps a single parseable
+    ``<OPEN>...<CLOSE>`` at the very start, so table-level keys (``tw``/``ta``)
+    and a cell background (``bg``) can share one sentinel on the first cell.
+    Idempotent: re-applying the same keys leaves the text unchanged.
+    """
+    text_el = _first_run_text_element(para)
+    if text_el is not None and text_el.text and text_el.text.startswith(SENTINEL_OPEN):
+        existing, rest = _parse_sentinel_text(text_el.text)
+        existing.update(kv)
+        text_el.text = _build_sentinel_text(existing) + rest
+        return
+
     ppr = para.find(_PPR_TAG)
     insert_at = 1 if ppr is not None and next(iter(para), None) is ppr else 0
-    para.insert(insert_at, _make_sentinel_run(_build_sentinel_text(bg)))
+    para.insert(insert_at, _make_sentinel_run(_build_sentinel_text(kv)))
 
 
 def _tag_cell_backgrounds(tbl: ET.Element) -> bool:
@@ -213,17 +327,135 @@ def _tag_cell_backgrounds(tbl: ET.Element) -> bool:
             continue
 
         first_para = _find_or_create_first_para(tc, tcpr)
-        if _already_tagged(first_para):
-            continue
+        text_el = _first_run_text_element(first_para)
+        if text_el is not None and text_el.text:
+            existing, _ = _parse_sentinel_text(text_el.text)
+            if existing.get("bg") == bg:
+                continue  # already tagged with this background (idempotency)
 
-        _inject_sentinel(first_para, bg)
+        _ensure_sentinel(first_para, {"bg": bg})
         changed = True
 
     return changed
 
 
+def _extract_table_layout(tbl: ET.Element) -> tuple[float | None, str | None, bool]:
+    """Return ``(width_fraction, alignment, is_absolute)`` from ``<w:tblPr>``.
+
+    ``width_fraction`` is the table's share of the line width: ``pct`` -> value
+    / 5000; ``dxa`` -> twips / reference text width; both clamped to 1.0. It is
+    None when there is no usable ``<w:tblW>``. ``alignment`` is left/center/right
+    from ``<w:jc>``, or None. ``is_absolute`` is True when the width came from a
+    ``dxa`` (absolute) value — such tables are usually deliberately narrow, so
+    the filter tightens their inter-column padding to keep them close to the
+    requested size. These are the properties pandoc's DOCX reader discards (it
+    keeps only column-relative widths and no table jc).
+    """
+    tblpr = tbl.find(_TBLPR_TAG)
+    if tblpr is None:
+        return None, None, False
+
+    fraction: float | None = None
+    is_absolute = False
+    tblw = tblpr.find(_TBLW_TAG)
+    if tblw is not None:
+        raw = tblw.get(_W_ATTR)
+        try:
+            value = float(raw) if raw is not None else 0.0
+        except ValueError:
+            value = 0.0
+        if value > 0:
+            width_type = tblw.get(_TYPE_ATTR)
+            if width_type == "pct":
+                fraction = min(value / _MAX_PCT, 1.0)
+            elif width_type == "dxa":
+                fraction = min(value / _REFERENCE_WIDTH_TWIPS, 1.0)
+                is_absolute = True
+
+    align: str | None = None
+    jc = tblpr.find(_JC_TAG)
+    if jc is not None:
+        align = _JC_TO_ALIGN.get((jc.get(_VAL_ATTR) or "").lower())
+
+    return fraction, align, is_absolute
+
+
+def _first_own_cell(tbl: ET.Element) -> ET.Element | None:
+    """Return this table's first cell (first ``<w:tc>`` of its first ``<w:tr>``),
+    ignoring cells of nested tables.
+    """
+    for child in tbl:
+        if child.tag == _TR_TAG:
+            for cell in child:
+                if cell.tag == _TC_TAG:
+                    return cell
+            return None
+    return None
+
+
+def _tag_table_layout(tbl: ET.Element) -> bool:
+    """Tag the first cell with the table's width fraction and/or alignment.
+
+    Every table with an explicit ``<w:tblW>`` is tagged, **including 100 %**:
+    pandoc's DOCX reader may still emit a table with no usable column widths,
+    which the LaTeX writer then renders content-width (and, with no alignment
+    glue, centered) instead of filling the line. The companion filter forces
+    the recovered fraction onto the columns and re-applies the alignment, so a
+    100 % table fills the text width flush-left rather than floating centered.
+    (This matches how the HTML path in filters/html_tables_to_latex.lua already
+    handles full-width tables.) Returns True when a sentinel was written.
+    """
+    fraction, align, is_absolute = _extract_table_layout(tbl)
+    kv: dict[str, str] = {}
+    if fraction is not None:
+        kv["tw"] = f"{min(fraction, 1.0):.4f}"
+        if is_absolute:
+            # Absolute (px/pt) widths are usually deliberately narrow; flag them
+            # so the filter tightens inter-column padding, which otherwise adds
+            # a fixed minimum that leaves a small table wider than requested.
+            kv["aw"] = "1"
+    if align is not None:
+        kv["ta"] = align
+    if not kv:
+        return False
+
+    first_tc = _first_own_cell(tbl)
+    if first_tc is None:
+        return False
+
+    first_para = _find_or_create_first_para(first_tc, first_tc.find(_TCPR_TAG))
+    _ensure_sentinel(first_para, kv)
+    return True
+
+
+def _neutralize_caption_paragraphs(tree: ET.Element) -> bool:
+    """Strip the ``Caption`` style from paragraphs so pandoc does not turn them
+    into auto-numbered LaTeX ``\\caption`` blocks.
+
+    A Polarion caption's text already contains its number ("Table 1 ..."); left
+    as a ``Caption``-styled paragraph, pandoc's DOCX reader attaches it to the
+    adjacent table and LaTeX prints "Table N: Table N ..." — the counter twice.
+    Dropping the style makes it a normal paragraph that renders its text once
+    (matching how the DOCX shows it). Only ``Caption`` is touched, not pandoc's
+    own ``TableCaption``/``ImageCaption`` (whose text has no embedded number).
+
+    Returns True when any paragraph was changed.
+    """
+    changed = False
+    for para in tree.iter(_P_TAG):
+        ppr = para.find(_PPR_TAG)
+        if ppr is None:
+            continue
+        pstyle = ppr.find(_PSTYLE_TAG)
+        if pstyle is not None and pstyle.get(_VAL_ATTR) == _CAPTION_STYLE_VAL:
+            ppr.remove(pstyle)
+            changed = True
+    return changed
+
+
 def _rewrite_part(xml_bytes: bytes) -> tuple[bytes, bool]:
-    """Fix grid-column widths and tag styled table cells in one body part.
+    """Fix grid-column widths, tag styled table cells, carry table width/
+    alignment, and neutralise caption styles in one body part.
 
     Returns ``(new_bytes, changed)``.
     """
@@ -237,8 +469,13 @@ def _rewrite_part(xml_bytes: bytes) -> tuple[bytes, bool]:
     for tbl in tree.iter(_TBL_TAG):
         if _fix_grid_col_widths(tbl):
             changed = True
+        if _tag_table_layout(tbl):
+            changed = True
         if _tag_cell_backgrounds(tbl):
             changed = True
+
+    if _neutralize_caption_paragraphs(tree):
+        changed = True
 
     if not changed:
         return xml_bytes, False

--- a/app/HtmlTableLayout.py
+++ b/app/HtmlTableLayout.py
@@ -1,0 +1,212 @@
+"""Extract table width and alignment from HTML source for DOCX post-processing.
+
+Pandoc's HTML reader keeps the ``<table style="...">`` declaration in the
+Table node's ``Attr`` key-value list, but the DOCX writer discards it: every
+table comes out with ``<w:tblW w:type="auto"/>`` and no alignment. On top of
+that, :mod:`app.DocxPostProcess` used to force every table to
+``<w:tblW w:w="5000" w:type="pct"/>`` (100 %) with autofit layout, so a table
+authored at ``width: 40%`` or ``margin-left: auto`` still rendered full-width
+and left-aligned in Word.
+
+This module recovers the layout intent *before* pandoc runs by parsing the
+same HTML pandoc will convert. It returns one :class:`TableLayout` per
+``<table>`` **in document order (depth-first, nested tables included)** — the
+same order in which pandoc emits ``<w:tbl>`` elements and in which
+:func:`app.DocxPostProcess._replace_table_properties` walks them, so the two
+lists line up index-for-index. The DOCX post-processor consumes the list and
+writes real ``<w:tblW>``/``<w:jc>``/``<w:tblInd>`` properties.
+
+Only the properties that survive meaningfully into Word are extracted:
+
+* **width** — ``width: N%`` becomes a percentage (OOXML ``pct`` type, where
+  100 % == 5000 fiftieths of a percent); an absolute length (``width: 50px``,
+  ``pt``/``cm``/…) becomes twips (OOXML ``dxa`` type). ``width: auto`` or a
+  missing/unparseable width yields no width (the post-processor keeps its
+  100 % default).
+* **alignment** — derived from the ``margin-left``/``margin-right`` pair the
+  way a browser centres/right-aligns a block: ``0``/``auto`` → left,
+  ``auto``/``auto`` → center, ``auto``/``0`` → right.
+* **indent** — a positive ``margin-left`` length on an otherwise left-aligned
+  table becomes a left table indent (twips), mirroring the paragraph-indent
+  handling in :mod:`app.HtmlParagraphPreProcess`.
+
+Everything is best-effort: any parse failure returns an empty list so the
+caller falls back to the previous behaviour rather than breaking a conversion.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+
+from lxml import etree, html  # type: ignore[import-untyped]
+
+logger = logging.getLogger(__name__)
+
+# OOXML: a table width of 100 % is expressed as 5000 fiftieths of a percent.
+MAX_PCT = 5000
+
+# CSS unit -> twips conversion factor. 1 twip = 1/1440 inch; CSS reference DPI
+# is 96, so 1 px = 15 twips. Mirrors app/HtmlParagraphPreProcess.py so table
+# and paragraph indents use one consistent conversion.
+_UNIT_TO_TWIPS: dict[str, float] = {
+    "px": 1440 / 96,
+    "pt": 1440 / 72,
+    "in": 1440.0,
+    "cm": 1440 / 2.54,
+    "mm": 1440 / 25.4,
+    "pc": 1440 / 6,
+    "em": 240.0,
+    "rem": 240.0,
+}
+
+# A numeric value followed by an optional unit (letters or %). Keyword values
+# such as "auto" have no leading digit and simply fail to match. The pattern is
+# free of variable-width whitespace quantifiers to avoid SonarCloud's S5852
+# "regex could backtrack" warning (see app/HtmlParagraphPreProcess.py).
+_VALUE_RE = re.compile(r"^([+-]?\d+(?:\.\d+)?)([a-z%]*)$", re.IGNORECASE)
+
+# Exceptions that mean "input isn't parseable HTML, give up quietly". Bound to
+# a name rather than an inline tuple for the same reason as
+# app/HtmlParagraphPreProcess.py (ruff/PEP 758 except-tuple rewrite).
+_PARSE_FAILURES = (etree.ParseError, etree.ParserError, ValueError)
+
+
+@dataclass(frozen=True)
+class TableLayout:
+    """Layout intent recovered from a single HTML ``<table>``.
+
+    ``width_type`` is ``"pct"`` (``width_value`` in fiftieths of a percent),
+    ``"dxa"`` (``width_value`` in twips) or ``None`` (no explicit width).
+    ``jc`` is ``"left"``/``"center"``/``"right"`` or ``None``.
+    ``indent_twips`` is a positive left table indent or ``None``.
+    """
+
+    width_type: str | None = None
+    width_value: int | None = None
+    jc: str | None = None
+    indent_twips: int | None = None
+
+    @property
+    def is_empty(self) -> bool:
+        """True when nothing worth applying was recovered."""
+        return self.width_type is None and self.jc is None and self.indent_twips is None
+
+
+def extract(source: bytes | str) -> list[TableLayout]:
+    """Return one :class:`TableLayout` per ``<table>`` in document order.
+
+    Depth-first, so a nested table appears immediately after its parent — the
+    order pandoc's DOCX writer and :mod:`app.DocxPostProcess` both use. Returns
+    an empty list when the input has no tables or cannot be parsed.
+    """
+    # Feed lxml bytes, never a decoded str: lxml rejects a Unicode string that
+    # carries an XML/HTML encoding declaration ("<?xml ... encoding=...?>"),
+    # which is exactly what the exporter emits. Encoding a str back to bytes
+    # sidesteps that (same approach as app/HtmlParagraphPreProcess.py).
+    data = source if isinstance(source, bytes) else source.encode("utf-8")
+    try:
+        doc = html.document_fromstring(data)
+    except _PARSE_FAILURES:
+        logger.warning("HtmlTableLayout: HTML parse failed; no table layouts extracted")
+        return []
+
+    # iter("table") yields elements in document order (depth-first), matching
+    # both pandoc's <w:tbl> emission order and the post-processor's traversal.
+    return [_parse_table_style(table.get("style") or "") for table in doc.iter("table")]
+
+
+def _parse_table_style(style: str) -> TableLayout:
+    """Build a :class:`TableLayout` from a table's inline ``style`` string."""
+    declarations = _split_declarations(style)
+    width_type, width_value = _parse_width(declarations.get("width"))
+    margin_left = declarations.get("margin-left")
+    margin_right = declarations.get("margin-right")
+    jc = _resolve_alignment(margin_left, margin_right)
+    # A positive left margin on a left-aligned table is a real indent; for
+    # centered/right-aligned tables the margins are the alignment mechanism
+    # (auto), not an indent, so we never treat them as one.
+    indent_twips = _positive_length_twips(margin_left) if jc == "left" else None
+    return TableLayout(width_type=width_type, width_value=width_value, jc=jc, indent_twips=indent_twips)
+
+
+def _split_declarations(style: str) -> dict[str, str]:
+    """Parse ``"k1: v1; k2: v2"`` into ``{k1: v1, k2: v2}`` (lowercased keys).
+
+    Later declarations win, matching CSS cascade order. ``partition(":")``
+    keeps ``max-width`` and ``width`` distinct — only an exact ``width`` key is
+    ever read as the table width.
+    """
+    result: dict[str, str] = {}
+    for declaration in style.split(";"):
+        prop, sep, value = declaration.partition(":")
+        if sep:
+            result[prop.strip().lower()] = value.strip()
+    return result
+
+
+def _parse_width(value: str | None) -> tuple[str | None, int | None]:
+    """Return ``(width_type, width_value)`` for a CSS ``width`` value.
+
+    ``N%`` -> ``("pct", fiftieths)`` clamped to (0, 5000]; an absolute length
+    -> ``("dxa", twips)``; ``auto``/missing/unparseable/zero -> ``(None, None)``.
+    """
+    if not value:
+        return None, None
+    match = _VALUE_RE.match(value)
+    if not match:
+        return None, None
+    number = float(match.group(1))
+    unit = match.group(2).lower()
+
+    if unit == "%":
+        pct = round(number * 50)
+        pct = min(pct, MAX_PCT)
+        return ("pct", pct) if pct > 0 else (None, None)
+
+    # A bare number is an invalid CSS width; treat missing-unit as px to match
+    # emitters that drop the unit (same convention as HtmlParagraphPreProcess).
+    factor = _UNIT_TO_TWIPS.get(unit or "px")
+    if factor is None:
+        return None, None
+    twips = round(number * factor)
+    return ("dxa", twips) if twips > 0 else (None, None)
+
+
+def _resolve_alignment(margin_left: str | None, margin_right: str | None) -> str | None:
+    """Map the ``margin-left``/``margin-right`` pair to a table justification.
+
+    Follows how a browser positions a fixed-width block: an ``auto`` margin
+    absorbs the free space on that side. ``auto``/``auto`` centres,
+    ``auto``/fixed pushes right, fixed/``auto`` keeps it left. Returns ``None``
+    when neither margin is ``auto`` (no alignment intent to record).
+    """
+    left_auto = margin_left is not None and margin_left.strip().lower() == "auto"
+    right_auto = margin_right is not None and margin_right.strip().lower() == "auto"
+
+    if left_auto and right_auto:
+        return "center"
+    if left_auto:
+        return "right"
+    if right_auto:
+        return "left"
+    return None
+
+
+def _positive_length_twips(value: str | None) -> int | None:
+    """Return positive twips for a CSS length, or ``None`` for zero/auto/bad input."""
+    if not value:
+        return None
+    match = _VALUE_RE.match(value)
+    if not match:
+        return None
+    number = float(match.group(1))
+    unit = match.group(2).lower()
+    if unit == "%":
+        return None
+    factor = _UNIT_TO_TWIPS.get(unit or "px")
+    if factor is None:
+        return None
+    twips = round(number * factor)
+    return twips if twips > 0 else None

--- a/app/PandocController.py
+++ b/app/PandocController.py
@@ -23,7 +23,7 @@ from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.schema import VersionSchema
 
-from . import DocxLatexPreProcess, DocxPostProcess, HtmlImagePreProcess, HtmlListsPreProcess, HtmlMathColorPreProcess, HtmlParagraphPreProcess, PptxPostProcess
+from . import DocxLatexPreProcess, DocxPostProcess, HtmlImagePreProcess, HtmlListsPreProcess, HtmlMathColorPreProcess, HtmlParagraphPreProcess, HtmlTableLayout, PptxPostProcess
 from .chromium_manager import get_chromium_manager
 from .metrics_server import MetricsServer, get_metrics_port, is_metrics_server_enabled
 from .pandoc_metrics import get_pandoc_metrics
@@ -60,6 +60,8 @@ FILTERS = {
     "docx_lists_to_latex": f"{FILTER_BASE_PATH}/docx_lists_to_latex.lua",
     "docx_tables_to_latex": f"{FILTER_BASE_PATH}/docx_tables_to_latex.lua",
     "html_lists": f"{FILTER_BASE_PATH}/html_lists.lua",
+    "html_tables_to_latex": f"{FILTER_BASE_PATH}/html_tables_to_latex.lua",
+    "html_captions": f"{FILTER_BASE_PATH}/html_captions.lua",
 }
 
 # List of allowed pandoc options for security
@@ -75,6 +77,8 @@ ALLOWED_PANDOC_OPTIONS = [
     f"--lua-filter={FILTERS['docx_lists_to_latex']}",
     f"--lua-filter={FILTERS['docx_tables_to_latex']}",
     f"--lua-filter={FILTERS['html_lists']}",
+    f"--lua-filter={FILTERS['html_tables_to_latex']}",
+    f"--lua-filter={FILTERS['html_captions']}",
     "--track-changes=all",
     "--reference-doc=",  # Prefix for reference-doc option
     "--pdf-engine=tectonic",
@@ -541,10 +545,25 @@ def _build_pandoc_command(  # noqa: PLR0913
         # filter strips the marker paragraph that pandoc would otherwise emit
         # for those synthetic list items.
         cmd.append(f"--lua-filter={FILTERS['html_lists']}")
+        # Mark genuine Polarion captions (paragraphs carrying the
+        # <span data-sequence=...> counter) with the "Caption" style so
+        # DocxReferencesPostProcess recognises them structurally instead of by
+        # a leaky "text starts with Table/Figure" check. See
+        # filters/html_captions.lua.
+        cmd.append(f"--lua-filter={FILTERS['html_captions']}")
         # Opt-in: preserve CSS table cell styles (background-color, borders)
         # by rebuilding styled tables as raw OOXML via the Lua filter.
         if preserve_table_styles:
             cmd.extend(["-M", "preserve_table_styles=true"])
+
+    # html -> pdf/latex: recover table width and horizontal alignment from the
+    # <table style> that pandoc's HTML reader keeps in the Table Attr but the
+    # LaTeX writer ignores (every table would otherwise render content-width and
+    # centered). This is the LaTeX counterpart to the DOCX post-processing in
+    # DocxPostProcess/HtmlTableLayout. The filter emits raw LaTeX (longtable
+    # glue), so it is gated on the latex-producing targets.
+    if source_format == "html" and target_format in _LATEX_TARGET_FORMATS:
+        cmd.append(f"--lua-filter={FILTERS['html_tables_to_latex']}")
 
     # Companion filters to the DOCX color and paragraph-format preprocessors.
     # Both only emit raw LaTeX, so they are gated on the docx->latex path. Div
@@ -795,6 +814,12 @@ async def convert_docx_with_ref(  # noqa: PLR0913, C901
         if temp_template_filename is not None:
             options.append(f"--reference-doc={temp_template_filename}")
 
+        # Recover per-table width/alignment from the HTML before pandoc drops
+        # it, so the DOCX post-processor can restore it (pandoc keeps only an
+        # auto width and no alignment). Read from the original source: SVG
+        # rasterization below never touches tables.
+        table_layouts = HtmlTableLayout.extract(source) if source_format == "html" else None
+
         # Rasterize any embedded SVGs to PNG so Word gets a usable image
         # instead of the draw.io "Text is not SVG - cannot display" fallback.
         if source_format == "html":
@@ -803,7 +828,7 @@ async def convert_docx_with_ref(  # noqa: PLR0913, C901
         # Convert using subprocess instead of pandoc module
         output = run_pandoc_conversion(source, source_format, "docx", options, preserve_table_styles=preserve_table_styles)
 
-        response = postprocess_and_build_response(output, "docx", file_name, paper_size, orientation)
+        response = postprocess_and_build_response(output, "docx", file_name, paper_size, orientation, table_layouts)
 
         # Record success metrics
         duration_seconds = time.time() - conversion_start_time
@@ -968,6 +993,12 @@ async def convert(  # noqa: PLR0913
         if target_format == "pdf":
             options.append("--pdf-engine=tectonic")
 
+        # Recover per-table width/alignment from the HTML before pandoc drops
+        # it (only relevant when producing DOCX; other writers handle table
+        # width natively). Read from the original source: SVG rasterization
+        # below never touches tables.
+        table_layouts = HtmlTableLayout.extract(source) if source_format == "html" and target_format == "docx" else None
+
         # Rasterize any embedded SVGs to PNG so renderers without full SVG
         # support (e.g. Word) get a usable image instead of a fallback warning.
         if source_format == "html":
@@ -976,7 +1007,7 @@ async def convert(  # noqa: PLR0913
         # Convert using subprocess instead of pandoc module
         output = run_pandoc_conversion(source, source_format, target_format, options, preserve_table_styles=preserve_table_styles)
 
-        response = postprocess_and_build_response(output, target_format, file_name, paper_size, orientation)
+        response = postprocess_and_build_response(output, target_format, file_name, paper_size, orientation, table_layouts)
 
         # Record success metrics
         duration_seconds = time.time() - conversion_start_time
@@ -1000,10 +1031,10 @@ async def get_docx_source_data(source_content: starlette.datastructures.UploadFi
     return source_content
 
 
-def postprocess_and_build_response(output: bytes, target_format: str, file_name: str, paper_size: str | None = None, orientation: str | None = None) -> Response:
+def postprocess_and_build_response(output: bytes, target_format: str, file_name: str, paper_size: str | None = None, orientation: str | None = None, table_layouts: list[HtmlTableLayout.TableLayout] | None = None) -> Response:  # noqa: PLR0913
     if target_format == "docx":
         post_process_start = time.time()
-        output = DocxPostProcess.process(output, paper_size, orientation)
+        output = DocxPostProcess.process(output, paper_size, orientation, table_layouts)
         observe_post_processing_duration("docx", time.time() - post_process_start)
     elif target_format == "pptx":
         # For PPTX, paper_size parameter is repurposed as slide_size

--- a/filters/docx_tables_to_latex.lua
+++ b/filters/docx_tables_to_latex.lua
@@ -39,15 +39,25 @@ local function valid_hex(s)
   return s and #s == 6 and s:match("^%x%x%x%x%x%x$") ~= nil
 end
 
--- Parse the sentinel payload into a properties table.
--- Currently only "bg=RRGGBB" is supported; additional segments (borders,
--- vAlign) can be added by extending this parser and the preprocessor.
+-- Parse the sentinel payload into a properties table. Supported segments:
+--   bg=RRGGBB  cell background colour (per cell)
+--   tw=<0..1>  table width as a fraction of the line (table-level, first cell)
+--   ta=left|center|right  table horizontal alignment (table-level, first cell)
 local function parse_payload(payload)
   local props = {}
   for segment in payload:gmatch("[^;]+") do
     local key, value = segment:match("^(%a+)=(.+)$")
     if key == "bg" and valid_hex(value:upper()) then
       props.bg = value:upper()
+    elseif key == "tw" then
+      local n = tonumber(value)
+      if n and n > 0 and n <= 1 then
+        props.tw = n
+      end
+    elseif key == "ta" and (value == "left" or value == "center" or value == "right") then
+      props.ta = value
+    elseif key == "aw" and value == "1" then
+      props.aw = true
     end
   end
   return props
@@ -102,15 +112,22 @@ local function inject_cellcolor(cell_blocks, hex)
 end
 
 -- Walk all rows in a row-set (head, body, foot) and process sentinels.
--- Returns true when at least one cell was modified.
-local function process_rows(rows)
+-- Injects cell background colour and captures any table-level width/alignment
+-- (carried on the first cell) into `layout`. Returns true when at least one
+-- cell background was modified.
+local function process_rows(rows, layout)
   local modified = false
   for _, row in ipairs(rows) do
     for _, cell in ipairs(row.cells) do
       local props = consume_sentinel(cell.contents)
-      if props and props.bg then
-        inject_cellcolor(cell.contents, props.bg)
-        modified = true
+      if props then
+        if props.bg then
+          inject_cellcolor(cell.contents, props.bg)
+          modified = true
+        end
+        if props.tw then layout.tw = props.tw end
+        if props.ta then layout.ta = props.ta end
+        if props.aw then layout.aw = true end
       end
     end
   end
@@ -121,22 +138,86 @@ end
 
 local has_cellcolor = false  -- set when at least one cell gets \cellcolor
 
+-- longtable positions itself via the \LTleft/\LTright glue read at \begin;
+-- both \fill is centered (pandoc's default). Pinning one side to 0pt flushes
+-- the table to that edge. Mirrors filters/html_tables_to_latex.lua.
+local ALIGN_GLUE = {
+  left = "\\setlength{\\LTleft}{0pt}\\setlength{\\LTright}{\\fill}",
+  center = "\\setlength{\\LTleft}{\\fill}\\setlength{\\LTright}{\\fill}",
+  right = "\\setlength{\\LTleft}{\\fill}\\setlength{\\LTright}{0pt}",
+}
+local RESET_GLUE = "\\setlength{\\LTleft}{\\fill}\\setlength{\\LTright}{\\fill}"
+
 local table_pass = {}
 
 function table_pass.Table(tbl)
   if not FORMAT:match("latex") then return nil end
 
   local modified = false
+  local layout = {}
 
-  if process_rows(tbl.head.rows) then modified = true end
+  if process_rows(tbl.head.rows, layout) then modified = true end
   for _, body in ipairs(tbl.bodies) do
-    if process_rows(body.body) then modified = true end
-    if process_rows(body.head) then modified = true end
+    if process_rows(body.body, layout) then modified = true end
+    if process_rows(body.head, layout) then modified = true end
   end
-  if process_rows(tbl.foot.rows) then modified = true end
+  if process_rows(tbl.foot.rows, layout) then modified = true end
 
-  if not modified then return nil end
-  has_cellcolor = true
+  if modified then has_cellcolor = true end
+
+  -- Table width: pandoc's DOCX reader normalises column widths to sum to 1.0
+  -- (discarding the table's <w:tblW> share of the line) OR, when the DOCX
+  -- carries no usable column widths, emits none at all — in which case the
+  -- LaTeX writer sizes the table to its content and centers it. Force an
+  -- explicit width on every column: a column with no width falls back to an
+  -- equal share, then all are scaled to the recovered fraction. This makes a
+  -- 40% table render at 40% and a 100% table fill the full line (flush-left
+  -- via the glue below) instead of floating content-width in the middle.
+  if layout.tw then
+    local num_cols = #tbl.colspecs
+    if num_cols > 0 then
+      -- Read each column's relative width (a column with none gets an equal
+      -- share) and total them. Normalising by this total — rather than just
+      -- multiplying each width by tw — guarantees the columns sum to EXACTLY
+      -- tw of the line, so a 100% table fills the full text column even if
+      -- pandoc handed us widths that summed to less than 1.0.
+      local bases, total = {}, 0
+      for i, colspec in ipairs(tbl.colspecs) do
+        bases[i] = colspec[2] or (1.0 / num_cols)
+        total = total + bases[i]
+      end
+      if total <= 0 then
+        total = 1.0
+      end
+      for i, colspec in ipairs(tbl.colspecs) do
+        tbl.colspecs[i] = { colspec[1], (bases[i] / total) * layout.tw }
+      end
+    end
+  end
+
+  -- Raw-LaTeX prologue/epilogue around the table, resetting afterwards so
+  -- nothing leaks into a later table:
+  --  * absolute-width (px/pt) tables get a tightened \tabcolsep — LaTeX's fixed
+  --    inter-column padding otherwise leaves a small table (e.g. 50px, 3 cols)
+  --    noticeably wider than requested; the epilogue restores the 6pt default.
+  --  * the recovered horizontal alignment is applied via longtable
+  --    \LTleft/\LTright glue (pandoc drops <w:jc>, defaulting to centered).
+  local before, after = {}, {}
+  if layout.aw then
+    before[#before + 1] = "\\setlength{\\tabcolsep}{3pt}"
+    after[#after + 1] = "\\setlength{\\tabcolsep}{6pt}"
+  end
+  local glue = layout.ta and ALIGN_GLUE[layout.ta]
+  if glue then
+    before[#before + 1] = glue
+    after[#after + 1] = RESET_GLUE
+  end
+
+  if #before > 0 then
+    return { pandoc.RawBlock("latex", table.concat(before)), tbl, pandoc.RawBlock("latex", table.concat(after)) }
+  end
+
+  if not modified and not layout.tw then return nil end
   return tbl
 end
 

--- a/filters/html_captions.lua
+++ b/filters/html_captions.lua
@@ -1,0 +1,71 @@
+-- html_captions.lua
+--
+-- Mark genuine Polarion captions so DOCX post-processing can find them
+-- precisely, instead of guessing from the paragraph text.
+--
+-- Polarion emits every figure/table caption as an ordinary paragraph whose
+-- sequence counter is wrapped in a dedicated span:
+--
+--     <p class="polarion-rte-caption-paragraph">
+--        Table <span data-sequence="Table" class="polarion-rte-caption">1</span> My caption
+--     </p>
+--
+-- Pandoc's HTML reader keeps that span (class "polarion-rte-caption" + the
+-- "sequence" attribute) in the AST, but the DOCX writer drops it and the
+-- paragraph comes out as plain body text. app/DocxReferencesPostProcess.py used
+-- to recover captions by checking whether the text starts with "Table"/"Figure"
+-- — which also matched headings ("Table test III"), cross-references
+-- ("Table 1 shows ...") and labels ("Table 50px"), wrongly restyling them as
+-- captions and listing them in the Table of Figures/Tables.
+--
+-- This filter detects the caption span (the one reliable, language-independent
+-- signal) and wraps the paragraph in a Div carrying custom-style="Caption", so
+-- pandoc emits the paragraph with the "Caption" style. The post-processor then
+-- treats exactly those paragraphs as captions — nothing else.
+--
+-- Only runs for the DOCX writer (the controller gates it on html->docx; the
+-- FORMAT check is defensive).
+
+local CAPTION_SPAN_CLASS = "polarion-rte-caption"
+local CAPTION_STYLE = "Caption"
+
+-- True when `inlines` contains (at any depth) a Span carrying the Polarion
+-- caption class. Recurses into inline containers (Span/Emph/Strong/Link/...);
+-- leaf inlines such as Str expose `.text`, not a `.content` list, so the
+-- type guard keeps the walk safe.
+local function contains_caption_span(inlines)
+  for _, il in ipairs(inlines) do
+    if il.t == "Span" and il.classes then
+      for _, class in ipairs(il.classes) do
+        if class == CAPTION_SPAN_CLASS then
+          return true
+        end
+      end
+    end
+    if type(il.content) == "table" and contains_caption_span(il.content) then
+      return true
+    end
+  end
+  return false
+end
+
+-- Wrap a caption paragraph in a Div that applies the "Caption" style. A
+-- custom-style Div adds no extra element to the DOCX — pandoc just stamps the
+-- style onto the contained paragraph.
+local function as_caption(block)
+  if not FORMAT:match("docx") then
+    return nil
+  end
+  if contains_caption_span(block.content) then
+    return pandoc.Div({ block }, pandoc.Attr("", {}, { ["custom-style"] = CAPTION_STYLE }))
+  end
+  return nil
+end
+
+function Para(el)
+  return as_caption(el)
+end
+
+function Plain(el)
+  return as_caption(el)
+end

--- a/filters/html_tables_to_latex.lua
+++ b/filters/html_tables_to_latex.lua
@@ -1,0 +1,138 @@
+-- html_tables_to_latex.lua
+--
+-- Preserve table WIDTH and horizontal ALIGNMENT from an HTML source when the
+-- target writer is LaTeX/PDF. Pandoc's HTML reader keeps the table's inline
+-- `style` in the Table node's Attr, but the LaTeX writer ignores it: every
+-- table comes out content-width and CENTERED (longtable's default LTleft/
+-- LTright glue is `\fill` on both sides), so a table authored at `width: 40%`
+-- or `margin-left: 0` still renders centered at its natural width.
+--
+-- This is the LaTeX/PDF counterpart to the DOCX post-processing in
+-- app/DocxPostProcess.py + app/HtmlTableLayout.py. It reads the same
+-- properties from the same `style` attribute:
+--
+--   * width  — `N%` sets the table to that fraction of the line width by
+--              distributing the fraction across the column widths (pandoc's
+--              LaTeX writer renders columns with an explicit width as a
+--              fraction of \linewidth, so their sum becomes the table width).
+--              An absolute length (`50px`, `pt`, `cm`, ...) is converted to a
+--              fraction of a reference text width (Letter 8.5in minus 1in
+--              margins each side = 6.5in), matching the Letter assumption in
+--              app/DocxPostProcess.py; exact absolute widths are not
+--              expressible through pandoc's fraction-only column model, so this
+--              is best-effort (same caveat as the DOCX px path).
+--   * align  — derived from `margin-left`/`margin-right` the way a browser
+--              positions a block: 0/auto -> left, auto/auto -> center,
+--              auto/0 -> right. Emitted as longtable \LTleft/\LTright glue.
+--
+-- Only runs for LaTeX/PDF targets (the controller gates it on html->pdf/latex,
+-- and the FORMAT check is defensive).
+
+-- Reference text width in points for converting absolute widths to a line
+-- fraction: Letter (8.5in) minus 1in margins on each side = 6.5in = 468pt.
+local REFERENCE_TEXT_WIDTH_PT = 468.0
+
+-- CSS unit -> points. 1px = 0.75pt at the 96dpi CSS reference; 1pt = 1pt;
+-- 1in = 72pt; 1pc = 12pt; 1cm = 28.3465pt; 1mm = 2.83465pt.
+local UNIT_TO_PT = {
+  px = 0.75,
+  pt = 1.0,
+  ["in"] = 72.0,
+  pc = 12.0,
+  cm = 28.3465,
+  mm = 2.83465,
+}
+
+-- Split "k1: v1; k2: v2" into a table {k1=v1, k2=v2} with trimmed, lowercased
+-- keys. Later declarations win (CSS cascade). `max-width` stays distinct from
+-- `width` so only an exact `width` is read as the table width.
+local function parse_declarations(style)
+  local decls = {}
+  for segment in style:gmatch("[^;]+") do
+    local key, value = segment:match("^%s*([^:]-)%s*:%s*(.-)%s*$")
+    if key then
+      decls[key:lower()] = value
+    end
+  end
+  return decls
+end
+
+-- Return the line fraction (0..1] for a CSS width value, or nil when it is
+-- absent, `auto`, unparseable or non-positive. `N%` -> N/100 (clamped to 1);
+-- an absolute length -> length_pt / reference_text_width (clamped to 1).
+local function width_fraction(value)
+  if not value then return nil end
+  local number, unit = value:match("^%s*([%d%.]+)%s*(%a*%%?)%s*$")
+  if not number then return nil end
+  number = tonumber(number)
+  if not number or number <= 0 then return nil end
+
+  if unit == "%" then
+    return math.min(number / 100.0, 1.0)
+  end
+
+  local factor = UNIT_TO_PT[unit ~= "" and unit or "px"]
+  if not factor then return nil end
+  return math.min((number * factor) / REFERENCE_TEXT_WIDTH_PT, 1.0)
+end
+
+-- Map the margin-left/margin-right pair to a table alignment, mirroring
+-- app/HtmlTableLayout.py: an `auto` margin absorbs the free space on that side.
+local function resolve_align(margin_left, margin_right)
+  local left_auto = margin_left ~= nil and margin_left:lower():match("^%s*auto%s*$") ~= nil
+  local right_auto = margin_right ~= nil and margin_right:lower():match("^%s*auto%s*$") ~= nil
+  if left_auto and right_auto then return "center" end
+  if left_auto then return "right" end
+  if right_auto then return "left" end
+  return nil
+end
+
+-- longtable positions itself with the \LTleft/\LTright glue lengths, read when
+-- the environment begins. Both `\fill` is centered (pandoc's default); 0pt on
+-- one side pins the table to that edge.
+local ALIGN_GLUE = {
+  left = "\\setlength{\\LTleft}{0pt}\\setlength{\\LTright}{\\fill}",
+  center = "\\setlength{\\LTleft}{\\fill}\\setlength{\\LTright}{\\fill}",
+  right = "\\setlength{\\LTleft}{\\fill}\\setlength{\\LTright}{0pt}",
+}
+-- Reset to longtable's centered default after each table we touched, so the
+-- glue never leaks into a later table that carries no alignment of its own.
+local RESET_GLUE = "\\setlength{\\LTleft}{\\fill}\\setlength{\\LTright}{\\fill}"
+
+function Table(tbl)
+  if not FORMAT:match("latex") then return nil end
+
+  local attrs = tbl.attr and tbl.attr.attributes
+  local style = attrs and attrs.style
+  if not style then return nil end
+
+  local decls = parse_declarations(style)
+  local fraction = width_fraction(decls["width"])
+  local align = resolve_align(decls["margin-left"], decls["margin-right"])
+  if not fraction and not align then return nil end
+
+  -- Width: distribute the target line fraction evenly across the columns. The
+  -- source tables carry no per-column widths, so an even split is faithful and
+  -- makes the column widths sum to the requested fraction of \linewidth.
+  if fraction then
+    local num_cols = #tbl.colspecs
+    if num_cols > 0 then
+      local per_column = fraction / num_cols
+      for i = 1, num_cols do
+        tbl.colspecs[i] = { tbl.colspecs[i][1], per_column }
+      end
+    end
+  end
+
+  -- Alignment: wrap the table in the matching \LTleft/\LTright glue and reset
+  -- afterwards. When no alignment was recovered we leave pandoc's centered
+  -- default untouched.
+  if align then
+    return {
+      pandoc.RawBlock("latex", ALIGN_GLUE[align]),
+      tbl,
+      pandoc.RawBlock("latex", RESET_GLUE),
+    }
+  end
+  return tbl
+end

--- a/filters/inline_styles.lua
+++ b/filters/inline_styles.lua
@@ -583,6 +583,28 @@ local function inlines_to_openxml(inlines)
   return table.concat(parts)
 end
 
+-- True when `inlines` contains (at any depth) Polarion's caption counter span
+-- (<span data-sequence=... class="polarion-rte-caption">). This is the reliable
+-- signal that a paragraph is a real figure/table caption. A caption <p> also
+-- carries text-align, so it reaches this filter as a pandoc-para wrapper and
+-- would otherwise lose any paragraph style in the raw-OOXML rewrite below —
+-- leaving app/DocxReferencesPostProcess.py unable to recognise it structurally.
+-- (Captions without an alignment are handled separately by
+-- filters/html_captions.lua, which runs on the un-wrapped Para.)
+local function contains_caption_span(inlines)
+  for _, il in ipairs(inlines) do
+    if il.t == "Span" and il.classes then
+      for _, class in ipairs(il.classes) do
+        if class == "polarion-rte-caption" then return true end
+      end
+    end
+    if type(il.content) == "table" and contains_caption_span(il.content) then
+      return true
+    end
+  end
+  return false
+end
+
 -- Build the single OOXML <w:p> for a formatted paragraph, or nil to signal
 -- "fall back to the original Para". Both `twips` and `jc` are trusted here:
 -- callers MUST pass an already-validated non-negative integer (Lua number, not
@@ -598,6 +620,11 @@ local function build_para_w_p(inlines, twips, jc)
   -- dependent about out-of-order children (silent reorder, recovery warning,
   -- or dropping the child), so we emit them in canonical order.
   local ppr = {}
+  -- <w:pStyle> comes first in the CT_PPr sequence. Stamp "Caption" on genuine
+  -- captions so DocxReferencesPostProcess recognises them by style, not text.
+  if contains_caption_span(inlines) then
+    ppr[#ppr + 1] = '<w:pStyle w:val="Caption"/>'
+  end
   -- string.format("%d", n) round-trips a validated integer through Lua's
   -- printf, which emits only decimal digits (and an optional leading '-' we
   -- already ruled out). Concatenating the raw attribute string here instead

--- a/tests/test_docx_post_process.py
+++ b/tests/test_docx_post_process.py
@@ -365,8 +365,9 @@ def test_resize_images_in_cell():
         mock_extent.set.assert_any_call("cy", "2400")  # New height (aspect ratio maintained)
 
 
+@patch("app.DocxPostProcess._apply_table_layout")
 @patch("app.DocxPostProcess._resize_images_in_cell")
-def test_process_table_with_nested_tables(mock_resize_images):
+def test_process_table_with_nested_tables(mock_resize_images, mock_apply_layout):
     """Test that nested tables are processed correctly."""
 
     # Create mock tables and cells
@@ -462,8 +463,8 @@ def test_replace_table_properties(mock_get_width, mock_process_table):
 
     # Verify _process_table was called for tables in correct sections
     assert mock_process_table.call_count == 2
-    mock_process_table.assert_any_call(table1, 0, max_width)
-    mock_process_table.assert_any_call(table2, 0, max_width)
+    mock_process_table.assert_any_call(table1, 0, max_width, None)
+    mock_process_table.assert_any_call(table2, 0, max_width, None)
 
 
 def test_replace_size_and_orientation_both_none():

--- a/tests/test_docx_references_post_process.py
+++ b/tests/test_docx_references_post_process.py
@@ -548,6 +548,37 @@ def test_caption_styled_paragraph_next_to_lookalike_is_detected(caplog):
     assert styles == ["Heading1", "Caption"]
 
 
+def test_pandoc_native_caption_styles_are_detected(caplog):
+    """Non-HTML sources bring pandoc's own caption styles — a markdown/docx
+    table caption is "TableCaption" and a figure caption is "ImageCaption".
+    Both must be found and get TC fields (the counter word need not appear in
+    the text, so classification comes from the style)."""
+    mock_doc = MagicMock(spec=DocumentObject)
+    body = parse_xml(f'''
+    <w:body xmlns:w="{SCHEMA}">
+        <w:p>
+            <w:pPr><w:pStyle w:val="TableCaption"/></w:pPr>
+            <w:r><w:t>Demo table caption</w:t></w:r>
+        </w:p>
+        <w:p>
+            <w:pPr><w:pStyle w:val="ImageCaption"/></w:pPr>
+            <w:r><w:t>Demo figure caption</w:t></w:r>
+        </w:p>
+    </w:body>
+    ''')
+    mock_doc.element.body = body
+
+    with caplog.at_level(logging.INFO):
+        add_table_of_contents_entries(mock_doc)
+
+    assert "Found 1 figure captions and 1 table captions" in caplog.text
+    # Both got TC field runs appended.
+    instr_texts = " ".join(t.text or "" for t in body.iter(f"{{{SCHEMA}}}instrText"))
+    assert instr_texts.count(" TC ") == 2
+    assert "\\f T" in instr_texts  # table caption
+    assert "\\f F" in instr_texts  # figure caption
+
+
 def test_add_toc_entries_inserts_toc_field_with_placeholder(caplog):
     """Test that TOC field is inserted when TOC_PLACEHOLDER is found."""
     mock_doc = MagicMock(spec=DocumentObject)

--- a/tests/test_docx_references_post_process.py
+++ b/tests/test_docx_references_post_process.py
@@ -440,12 +440,16 @@ def test_enable_auto_update_fields_handles_exception(caplog):
 def test_add_toc_entries_finds_figure_captions(caplog):
     """Test that figure captions are found and processed."""
     mock_doc = MagicMock(spec=DocumentObject)
+    # Captions are identified by the "Caption" style (set upstream by
+    # filters/html_captions.lua from the Polarion caption span), not by text.
     body = parse_xml(f'''
     <w:body xmlns:w="{SCHEMA}">
         <w:p>
+            <w:pPr><w:pStyle w:val="Caption"/></w:pPr>
             <w:r><w:t>Figure 1: Test figure</w:t></w:r>
         </w:p>
         <w:p>
+            <w:pPr><w:pStyle w:val="Caption"/></w:pPr>
             <w:r><w:t>Figure 2: Another figure</w:t></w:r>
         </w:p>
     </w:body>
@@ -465,6 +469,7 @@ def test_add_toc_entries_finds_table_captions(caplog):
     body = parse_xml(f'''
     <w:body xmlns:w="{SCHEMA}">
         <w:p>
+            <w:pPr><w:pStyle w:val="Caption"/></w:pPr>
             <w:r><w:t>Table 1: Test table</w:t></w:r>
         </w:p>
     </w:body>
@@ -476,6 +481,71 @@ def test_add_toc_entries_finds_table_captions(caplog):
 
     # Verify logging indicates tables were found
     assert "Found 0 figure captions and 1 table captions" in caplog.text
+
+
+def test_paragraphs_that_only_start_with_table_or_figure_are_not_captions(caplog):
+    """Only paragraphs carrying the "Caption" style (set upstream from the
+    Polarion caption span) are captions. A heading ("Table test III"), a
+    cross-reference ("Table 1 shows ...") and a label ("Table 50px") all merely
+    start with the word — and even include a number — but must be left alone."""
+    mock_doc = MagicMock(spec=DocumentObject)
+    body = parse_xml(f'''
+    <w:body xmlns:w="{SCHEMA}">
+        <w:p>
+            <w:pPr><w:pStyle w:val="Heading1"/></w:pPr>
+            <w:r><w:t>Table test III</w:t></w:r>
+        </w:p>
+        <w:p>
+            <w:pPr><w:pStyle w:val="BodyText"/></w:pPr>
+            <w:r><w:t>Table 1 shows the results discussed above.</w:t></w:r>
+        </w:p>
+        <w:p>
+            <w:pPr><w:pStyle w:val="BodyText"/></w:pPr>
+            <w:r><w:t>Table 50px</w:t></w:r>
+        </w:p>
+        <w:p>
+            <w:pPr><w:pStyle w:val="Title"/></w:pPr>
+            <w:r><w:t>Figure skating results</w:t></w:r>
+        </w:p>
+    </w:body>
+    ''')
+    mock_doc.element.body = body
+
+    with caplog.at_level(logging.INFO):
+        add_table_of_contents_entries(mock_doc)
+
+    # None are captioned...
+    assert "Found 0 figure captions and 0 table captions" in caplog.text
+    # ...and every paragraph keeps its original style (nothing downgraded to Caption).
+    styles = [s.get(f"{{{SCHEMA}}}val") for s in body.findall(".//w:pStyle", namespaces={"w": SCHEMA})]
+    assert styles == ["Heading1", "BodyText", "BodyText", "Title"]
+
+
+def test_caption_styled_paragraph_next_to_lookalike_is_detected(caplog):
+    """A genuine caption (marked with the "Caption" style) is processed, while a
+    heading with the same 'Table' prefix sitting next to it is not."""
+    mock_doc = MagicMock(spec=DocumentObject)
+    body = parse_xml(f'''
+    <w:body xmlns:w="{SCHEMA}">
+        <w:p>
+            <w:pPr><w:pStyle w:val="Heading1"/></w:pPr>
+            <w:r><w:t>Table test III</w:t></w:r>
+        </w:p>
+        <w:p>
+            <w:pPr><w:pStyle w:val="Caption"/></w:pPr>
+            <w:r><w:t>Table 1: real caption</w:t></w:r>
+        </w:p>
+    </w:body>
+    ''')
+    mock_doc.element.body = body
+
+    with caplog.at_level(logging.INFO):
+        add_table_of_contents_entries(mock_doc)
+
+    assert "Found 0 figure captions and 1 table captions" in caplog.text
+    # The heading keeps Heading1; the caption keeps Caption.
+    styles = [s.get(f"{{{SCHEMA}}}val") for s in body.findall(".//w:pStyle", namespaces={"w": SCHEMA})]
+    assert styles == ["Heading1", "Caption"]
 
 
 def test_add_toc_entries_inserts_toc_field_with_placeholder(caplog):
@@ -516,9 +586,11 @@ def test_add_toc_entries_processes_both_figures_and_tables(caplog):
     body = parse_xml(f'''
     <w:body xmlns:w="{SCHEMA}">
         <w:p>
+            <w:pPr><w:pStyle w:val="Caption"/></w:pPr>
             <w:r><w:t>Figure 1: Test figure</w:t></w:r>
         </w:p>
         <w:p>
+            <w:pPr><w:pStyle w:val="Caption"/></w:pPr>
             <w:r><w:t>Table 1: Test table</w:t></w:r>
         </w:p>
     </w:body>
@@ -536,24 +608,25 @@ def test_full_workflow_with_figures_and_toc():
     """Integration test: document with figures and TOC_PLACEHOLDER."""
     from docx import Document
 
-    # Create a real document
+    # Create a real document. Captions are marked with the "Caption" style
+    # upstream (by filters/html_captions.lua); the post-processor keys off it.
     doc = Document()
     doc.add_paragraph("TOC_PLACEHOLDER")
-    doc.add_paragraph("Figure 1: Test figure caption")
-    doc.add_paragraph("Figure 2: Another figure")
+    doc.add_paragraph("Figure 1: Test figure caption", style="Caption")
+    doc.add_paragraph("Figure 2: Another figure", style="Caption")
 
     # Run the function
     add_table_of_contents_entries(doc)
 
-    # Verify Caption styles were added to figure paragraphs
+    # Verify the figure captions kept the Caption style and got TC fields.
     body = doc.element.body
     paras = body.findall(".//w:p", namespaces={"w": SCHEMA})
     figure_paras = [p for p in paras if "Figure" in _get_paragraph_text(p)]
 
     for para in figure_paras:
         p_style = para.find(".//w:pStyle", namespaces={"w": SCHEMA})
-        if p_style is not None:
-            assert p_style.get(f"{{{SCHEMA}}}val") == "Caption"
+        assert p_style is not None
+        assert p_style.get(f"{{{SCHEMA}}}val") == "Caption"
 
 
 def test_full_workflow_with_tables_only():
@@ -561,21 +634,21 @@ def test_full_workflow_with_tables_only():
     from docx import Document
 
     doc = Document()
-    doc.add_paragraph("Table 1: Test table caption")
-    doc.add_paragraph("Table 2: Another table")
+    doc.add_paragraph("Table 1: Test table caption", style="Caption")
+    doc.add_paragraph("Table 2: Another table", style="Caption")
 
     # Run the function
     add_table_of_contents_entries(doc)
 
-    # Verify table captions got Caption style
+    # Verify table captions kept the Caption style and got TC fields.
     body = doc.element.body
     paras = body.findall(".//w:p", namespaces={"w": SCHEMA})
     table_paras = [p for p in paras if "Table" in _get_paragraph_text(p)]
 
     for para in table_paras:
         p_style = para.find(".//w:pStyle", namespaces={"w": SCHEMA})
-        if p_style is not None:
-            assert p_style.get(f"{{{SCHEMA}}}val") == "Caption"
+        assert p_style is not None
+        assert p_style.get(f"{{{SCHEMA}}}val") == "Caption"
 
 
 def test_full_workflow_empty_document():

--- a/tests/test_docx_table_layout_to_latex.py
+++ b/tests/test_docx_table_layout_to_latex.py
@@ -1,0 +1,100 @@
+"""End-to-end test for DOCX table width/alignment surviving into LaTeX.
+
+Builds a real DOCX with a table carrying ``<w:tblW>`` / ``<w:jc>`` (what the
+HTML->DOCX post-processing writes), runs it through the docx->latex
+preprocessing + ``filters/docx_tables_to_latex.lua``, and checks that:
+
+* pandoc's DOCX reader would normalise the column widths to sum to 1.0, but the
+  filter scales them back to the table's real page fraction (``\\real{...}``);
+* the table's alignment is re-applied as longtable ``\\LTleft``/``\\LTright`` glue.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import shutil
+import subprocess
+
+import pytest
+from docx import Document
+from docx.oxml import parse_xml
+from docx.oxml.ns import nsdecls
+
+from app import DocxLatexPreProcess
+
+_PANDOC = shutil.which("pandoc")
+pytestmark = pytest.mark.skipif(_PANDOC is None, reason="pandoc binary not available")
+
+_FILTER = "filters/docx_tables_to_latex.lua"
+
+
+def _docx_with_table(width_pct: int, jc: str, cols: int = 3) -> bytes:
+    """A one-row DOCX table with the given tblW (pct) and jc alignment."""
+    doc = Document()
+    table = doc.add_table(rows=1, cols=cols)
+    for i, cell in enumerate(table.rows[0].cells):
+        cell.text = f"c{i}"
+    tblpr = table._tbl.tblPr
+    # python-docx already emits a <w:tblW>; replace it (and any jc) so the table
+    # has exactly one of each — mirroring app/DocxPostProcess.py's output.
+    ns = {"w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main"}
+    for tag in ("w:tblW", "w:jc"):
+        for existing in tblpr.findall(tag, ns):
+            tblpr.remove(existing)
+    tblpr.append(parse_xml(f'<w:tblW {nsdecls("w")} w:w="{width_pct}" w:type="pct"/>'))
+    tblpr.append(parse_xml(f'<w:jc {nsdecls("w")} w:val="{jc}"/>'))
+    buf = io.BytesIO()
+    doc.save(buf)
+    return buf.getvalue()
+
+
+def _to_latex(docx_bytes: bytes) -> str:
+    pre = DocxLatexPreProcess.preprocess(docx_bytes)
+    completed = subprocess.run(  # noqa: S603
+        [_PANDOC, "-f", "docx+styles", "-t", "latex", "--lua-filter", _FILTER, "-o", "-"],
+        input=pre,
+        capture_output=True,
+        check=True,
+    )
+    return completed.stdout.decode()
+
+
+def _real_widths(latex: str) -> list[float]:
+    return [float(x) for x in re.findall(r"\\real\{([0-9.]+)\}", latex)]
+
+
+def test_40pct_left_table_scaled_and_left_aligned():
+    latex = _to_latex(_docx_with_table(2000, "left", cols=3))
+    widths = _real_widths(latex)
+    assert widths, "expected \\real{} column widths"
+    assert abs(sum(widths) - 0.40) < 0.02  # 3 cols summing to ~40%
+    assert "\\setlength{\\LTleft}{0pt}" in latex
+    assert "\\setlength{\\LTright}{\\fill}" in latex
+
+
+def test_25pct_right_table_right_aligned():
+    latex = _to_latex(_docx_with_table(1250, "right", cols=1))
+    widths = _real_widths(latex)
+    assert abs(sum(widths) - 0.25) < 0.02
+    assert "\\setlength{\\LTright}{0pt}" in latex
+
+
+def test_25pct_center_table_centered():
+    latex = _to_latex(_docx_with_table(1250, "center", cols=1))
+    assert abs(sum(_real_widths(latex)) - 0.25) < 0.02
+    # Centered uses \fill on both sides (also the reset value) and is never
+    # pinned to an edge.
+    assert "\\setlength{\\LTleft}{0pt}" not in latex
+    assert "\\setlength{\\LTright}{0pt}" not in latex
+
+
+def test_full_width_table_fills_line_and_is_left_aligned():
+    """A 100% table keeps full width (columns sum to ~1.0) and is pinned
+    flush-left, so it fills the text column from the left edge rather than
+    floating content-width in the centre."""
+    latex = _to_latex(_docx_with_table(5000, "left", cols=3))
+    widths = _real_widths(latex)
+    assert widths
+    assert abs(sum(widths) - 1.0) < 0.05
+    assert "\\setlength{\\LTleft}{0pt}" in latex

--- a/tests/test_docx_table_preprocess.py
+++ b/tests/test_docx_table_preprocess.py
@@ -497,3 +497,25 @@ def test_absolute_width_table_flagged_for_tight_padding():
     pct = '<w:tblW w:w="2000" w:type="pct"/><w:jc w:val="left"/>'
     kv = _first_cell_sentinel_kv(_body(DocxTablePreProcess.preprocess(_pack({"word/document.xml": _doc(_table_with_pr(pct, _table_cell(None, "a"), grid_widths=["4800"]))}))))
     assert "aw" not in kv
+
+
+def test_word_caption_with_seq_field_keeps_style():
+    """A genuine Word caption (numbered via a SEQ field) keeps its Caption style
+    so pandoc still numbers it and lists it; only literal-numbered Polarion
+    captions are neutralised."""
+    # Polarion-style: literal number, no field -> style stripped.
+    polarion = '<w:p><w:pPr><w:pStyle w:val="Caption"/></w:pPr><w:r><w:t>Table 1 My caption</w:t></w:r></w:p>'
+    root = _body(DocxTablePreProcess.preprocess(_pack({"word/document.xml": _doc(polarion)})))
+    assert "Caption" not in [s.get(f"{{{W_NS}}}val") for s in root.iter(f"{{{W_NS}}}pStyle")]
+
+    # Word-style: SEQ field for the number -> style preserved.
+    word = (
+        '<w:p><w:pPr><w:pStyle w:val="Caption"/></w:pPr>'
+        "<w:r><w:t>Table </w:t></w:r>"
+        '<w:r><w:fldChar w:fldCharType="begin"/></w:r>'
+        '<w:r><w:instrText xml:space="preserve"> SEQ Table \\* ARABIC </w:instrText></w:r>'
+        '<w:r><w:fldChar w:fldCharType="end"/></w:r>'
+        "<w:r><w:t>: My caption</w:t></w:r></w:p>"
+    )
+    root = _body(DocxTablePreProcess.preprocess(_pack({"word/document.xml": _doc(word)})))
+    assert "Caption" in [s.get(f"{{{W_NS}}}val") for s in root.iter(f"{{{W_NS}}}pStyle")]

--- a/tests/test_docx_table_preprocess.py
+++ b/tests/test_docx_table_preprocess.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 import io
 import zipfile
 from pathlib import Path
+from xml.etree import ElementTree as ET  # noqa: S405
 
 import pytest
-from xml.etree import ElementTree as ET  # noqa: S405
 
 from app import DocxTablePreProcess
 from app.DocxTablePreProcess import SENTINEL_CLOSE, SENTINEL_OPEN
@@ -31,9 +31,7 @@ def _pack(parts: dict[str, bytes]) -> bytes:
 
 def _doc(*fragments: str) -> bytes:
     body = "".join(fragments)
-    return ('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
-            '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">'
-            "<w:body>" + body + "</w:body></w:document>").encode("utf-8")
+    return ('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>' + body + "</w:body></w:document>").encode("utf-8")
 
 
 def _table_cell(fill: str | None, text: str = "cell") -> str:
@@ -87,9 +85,13 @@ def _sentinel(bg: str) -> str:
 
 def test_gridcol_without_width_gets_default_width():
     """<w:gridCol/> without w:w gets a default width so pandoc reads cells."""
-    blob = _pack({"word/document.xml": _doc(
-        _table_with_bare_grid(_table_cell(None, "a"), _table_cell(None, "b"), num_cols=2),
-    )})
+    blob = _pack(
+        {
+            "word/document.xml": _doc(
+                _table_with_bare_grid(_table_cell(None, "a"), _table_cell(None, "b"), num_cols=2),
+            )
+        }
+    )
     result = DocxTablePreProcess.preprocess(blob)
     root = _body(result)
     grid_cols = root.findall(f".//{{{W_NS}}}gridCol")
@@ -102,17 +104,19 @@ def test_gridcol_without_width_gets_default_width():
 
 def test_gridcol_with_existing_width_is_not_changed():
     """<w:gridCol w:w="4500"/> keeps its original width."""
-    blob = _pack({"word/document.xml": _doc(
-        _table(_table_cell(None, "a"), _table_cell(None, "b"), grid_widths=["4500", "4500"]),
-    )})
+    blob = _pack(
+        {
+            "word/document.xml": _doc(
+                _table(_table_cell(None, "a"), _table_cell(None, "b"), grid_widths=["4500", "4500"]),
+            )
+        }
+    )
     assert DocxTablePreProcess.preprocess(blob) == blob
 
 
 def test_mixed_gridcol_widths_only_fills_missing():
     """Only gridCols without w:w get the default; existing widths are kept."""
-    tbl_xml = '<w:tbl><w:tblGrid><w:gridCol w:w="3000"/><w:gridCol/></w:tblGrid>' \
-              '<w:tr><w:tc><w:p><w:r><w:t>a</w:t></w:r></w:p></w:tc>' \
-              '<w:tc><w:p><w:r><w:t>b</w:t></w:r></w:p></w:tc></w:tr></w:tbl>'
+    tbl_xml = '<w:tbl><w:tblGrid><w:gridCol w:w="3000"/><w:gridCol/></w:tblGrid><w:tr><w:tc><w:p><w:r><w:t>a</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>b</w:t></w:r></w:p></w:tc></w:tr></w:tbl>'
     blob = _pack({"word/document.xml": _doc(tbl_xml)})
     result = DocxTablePreProcess.preprocess(blob)
     root = _body(result)
@@ -121,21 +125,44 @@ def test_mixed_gridcol_widths_only_fills_missing():
     assert grid_cols[1].get(f"{{{W_NS}}}w") is not None  # was filled in
 
 
-def test_table_without_tblgrid_is_not_changed():
-    """Tables without <w:tblGrid> at all — nothing to fix."""
-    blob = _pack({"word/document.xml": _doc(
-        _table(_table_cell(None, "a"), _table_cell(None, "b")),
-    )})
-    assert DocxTablePreProcess.preprocess(blob) == blob
+def test_table_without_tblgrid_gets_one_created():
+    """A table with no <w:tblGrid> at all gets a grid with one positive-width
+    column per cell, so pandoc keeps the cells and computes column widths
+    (without a grid it drops the cells entirely and the table renders empty)."""
+    blob = _pack(
+        {
+            "word/document.xml": _doc(
+                _table(_table_cell(None, "a"), _table_cell(None, "b")),
+            )
+        }
+    )
+    root = _body(DocxTablePreProcess.preprocess(blob))
+    grid_cols = root.findall(f".//{{{W_NS}}}gridCol")
+    assert len(grid_cols) == 2
+    assert all(int(c.get(f"{{{W_NS}}}w")) > 0 for c in grid_cols)
+
+
+def test_grid_is_padded_to_column_count():
+    """A grid with fewer <w:gridCol> than the row's cells is padded so pandoc
+    sees every column (a short grid otherwise yields a partial, narrow table)."""
+    tbl = '<w:tbl><w:tblGrid><w:gridCol w:w="4800"/></w:tblGrid><w:tr><w:tc><w:p><w:r><w:t>a</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>b</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>c</w:t></w:r></w:p></w:tc></w:tr></w:tbl>'
+    root = _body(DocxTablePreProcess.preprocess(_pack({"word/document.xml": _doc(tbl)})))
+    grid_cols = root.findall(f".//{{{W_NS}}}gridCol")
+    assert len(grid_cols) == 3
+    assert all(int(c.get(f"{{{W_NS}}}w")) > 0 for c in grid_cols)
 
 
 # --- cell background tagging ------------------------------------------------
 
 
 def test_cell_with_background_gets_sentinel():
-    blob = _pack({"word/document.xml": _doc(
-        _table(_table_cell("D9EAF7", "Hello"), grid_widths=["4800"]),
-    )})
+    blob = _pack(
+        {
+            "word/document.xml": _doc(
+                _table(_table_cell("D9EAF7", "Hello"), grid_widths=["4800"]),
+            )
+        }
+    )
     result = DocxTablePreProcess.preprocess(blob)
     para = _body(result).find(f".//{{{W_NS}}}p")
     assert _first_run_text(para) == _sentinel("D9EAF7")
@@ -144,19 +171,29 @@ def test_cell_with_background_gets_sentinel():
 
 
 def test_lowercase_hex_is_uppercased():
-    blob = _pack({"word/document.xml": _doc(
-        _table(_table_cell("d9eaf7", "x"), grid_widths=["4800"]),
-    )})
+    blob = _pack(
+        {
+            "word/document.xml": _doc(
+                _table(_table_cell("d9eaf7", "x"), grid_widths=["4800"]),
+            )
+        }
+    )
     para = _body(DocxTablePreProcess.preprocess(blob)).find(f".//{{{W_NS}}}p")
     assert _first_run_text(para) == _sentinel("D9EAF7")
 
 
 def test_multiple_cells_tagged_independently():
-    blob = _pack({"word/document.xml": _doc(_table(
-        _table_cell("F4CCCC", "a"),
-        _table_cell("D9EAD3", "b"),
-        grid_widths=["4800", "4800"],
-    ))})
+    blob = _pack(
+        {
+            "word/document.xml": _doc(
+                _table(
+                    _table_cell("F4CCCC", "a"),
+                    _table_cell("D9EAD3", "b"),
+                    grid_widths=["4800", "4800"],
+                )
+            )
+        }
+    )
     paras = _body(DocxTablePreProcess.preprocess(blob)).findall(f".//{{{W_NS}}}p")
     assert _first_run_text(paras[0]) == _sentinel("F4CCCC")
     assert _first_run_text(paras[1]) == _sentinel("D9EAD3")
@@ -178,17 +215,25 @@ def test_sentinel_inserted_after_ppr():
 
 def test_cell_without_tcpr_is_untouched():
     """Table with grid widths but no cell formatting — no change needed."""
-    blob = _pack({"word/document.xml": _doc(
-        _table(_table_cell(None, "plain"), grid_widths=["4800"]),
-    )})
+    blob = _pack(
+        {
+            "word/document.xml": _doc(
+                _table(_table_cell(None, "plain"), grid_widths=["4800"]),
+            )
+        }
+    )
     assert DocxTablePreProcess.preprocess(blob) == blob
 
 
 def test_white_background_is_skipped():
     """FFFFFF is the page colour — treat as no background."""
-    blob = _pack({"word/document.xml": _doc(
-        _table(_table_cell("FFFFFF", "x"), grid_widths=["4800"]),
-    )})
+    blob = _pack(
+        {
+            "word/document.xml": _doc(
+                _table(_table_cell("FFFFFF", "x"), grid_widths=["4800"]),
+            )
+        }
+    )
     assert DocxTablePreProcess.preprocess(blob) == blob
 
 
@@ -210,10 +255,14 @@ def test_document_without_tables_returned_unchanged():
 
 
 def test_mixed_doc_only_tags_styled_cells():
-    blob = _pack({"word/document.xml": _doc(
-        _plain_para("intro"),
-        _table(_table_cell("F4CCCC", "colored"), _table_cell(None, "plain"), grid_widths=["4800", "4800"]),
-    )})
+    blob = _pack(
+        {
+            "word/document.xml": _doc(
+                _plain_para("intro"),
+                _table(_table_cell("F4CCCC", "colored"), _table_cell(None, "plain"), grid_widths=["4800", "4800"]),
+            )
+        }
+    )
     result = DocxTablePreProcess.preprocess(blob)
     root = _body(result)
     paras = root.findall(f".//{{{W_NS}}}p")
@@ -226,9 +275,13 @@ def test_mixed_doc_only_tags_styled_cells():
 
 
 def test_preprocess_is_idempotent():
-    blob = _pack({"word/document.xml": _doc(
-        _table(_table_cell("AABBCC", "x"), grid_widths=["4800"]),
-    )})
+    blob = _pack(
+        {
+            "word/document.xml": _doc(
+                _table(_table_cell("AABBCC", "x"), grid_widths=["4800"]),
+            )
+        }
+    )
     once = DocxTablePreProcess.preprocess(blob)
     assert DocxTablePreProcess.preprocess(once) == once
     para = _body(once).find(f".//{{{W_NS}}}p")
@@ -236,9 +289,13 @@ def test_preprocess_is_idempotent():
 
 
 def test_gridcol_fix_is_idempotent():
-    blob = _pack({"word/document.xml": _doc(
-        _table_with_bare_grid(_table_cell(None, "x"), num_cols=1),
-    )})
+    blob = _pack(
+        {
+            "word/document.xml": _doc(
+                _table_with_bare_grid(_table_cell(None, "x"), num_cols=1),
+            )
+        }
+    )
     once = DocxTablePreProcess.preprocess(blob)
     assert DocxTablePreProcess.preprocess(once) == once
 
@@ -266,9 +323,13 @@ def test_invalid_hex_fill_is_ignored():
 
 def test_both_gridcol_fix_and_sentinel_applied():
     """Bare gridCols + coloured cell: both fixes applied in one pass."""
-    blob = _pack({"word/document.xml": _doc(
-        _table_with_bare_grid(_table_cell("AABBCC", "x"), _table_cell(None, "y"), num_cols=2),
-    )})
+    blob = _pack(
+        {
+            "word/document.xml": _doc(
+                _table_with_bare_grid(_table_cell("AABBCC", "x"), _table_cell(None, "y"), num_cols=2),
+            )
+        }
+    )
     result = DocxTablePreProcess.preprocess(blob)
     root = _body(result)
     # Grid widths filled in
@@ -296,8 +357,143 @@ def test_real_docx_with_table_styles():
         assert col.get(f"{{{W_NS}}}w") is not None
 
     # At least one sentinel was injected
-    sentinel_found = any(
-        t.text and SENTINEL_OPEN in t.text
-        for t in root.iter(f"{{{W_NS}}}t")
-    )
+    sentinel_found = any(t.text and SENTINEL_OPEN in t.text for t in root.iter(f"{{{W_NS}}}t"))
     assert sentinel_found, "Expected at least one table-cell sentinel in the preprocessed DOCX"
+
+
+# --- table width & alignment tagging (DOCX -> PDF) --------------------------
+
+
+def _table_with_pr(tblpr_inner: str, *cells_xml: str, grid_widths: list[str] | None = None) -> str:
+    """Single-row table with a ``<w:tblPr>`` (tblW/jc live here)."""
+    cells = "".join(cells_xml)
+    grid = ""
+    if grid_widths is not None:
+        cols = "".join(f'<w:gridCol w:w="{w}"/>' for w in grid_widths)
+        grid = f"<w:tblGrid>{cols}</w:tblGrid>"
+    return f"<w:tbl><w:tblPr>{tblpr_inner}</w:tblPr>{grid}<w:tr>{cells}</w:tr></w:tbl>"
+
+
+def _first_cell_sentinel_kv(root: ET.Element) -> dict[str, str]:
+    """Parse the leading sentinel of the table's first cell into a key map."""
+    tc = root.find(f".//{{{W_NS}}}tc")
+    assert tc is not None
+    para = tc.find(f"{{{W_NS}}}p")
+    text = _first_run_text(para)
+    if not text or not text.startswith(SENTINEL_OPEN):
+        return {}
+    payload = text[len(SENTINEL_OPEN) : text.find(SENTINEL_CLOSE)]
+    return dict(seg.split("=", 1) for seg in payload.split(";") if "=" in seg)
+
+
+def test_percentage_width_tagged_on_first_cell():
+    tblpr = '<w:tblW w:w="2000" w:type="pct"/><w:jc w:val="left"/>'
+    blob = _pack({"word/document.xml": _doc(_table_with_pr(tblpr, _table_cell(None, "a"), grid_widths=["4800"]))})
+    kv = _first_cell_sentinel_kv(_body(DocxTablePreProcess.preprocess(blob)))
+    assert kv.get("tw") == "0.4000"
+    assert kv.get("ta") == "left"
+
+
+def test_full_width_table_is_tagged():
+    """A 100% table IS tagged (tw=1.0): pandoc can still render it content-width
+    and centered when the DOCX has no usable column widths, so the filter must
+    force it full-width and flush-left."""
+    tblpr = '<w:tblW w:w="5000" w:type="pct"/><w:jc w:val="left"/>'
+    blob = _pack({"word/document.xml": _doc(_table_with_pr(tblpr, _table_cell(None, "a"), grid_widths=["4800"]))})
+    kv = _first_cell_sentinel_kv(_body(DocxTablePreProcess.preprocess(blob)))
+    assert kv.get("tw") == "1.0000"
+    assert kv.get("ta") == "left"
+
+
+def test_center_and_right_alignment_carried():
+    for val, expected in (("center", "center"), ("right", "right")):
+        tblpr = f'<w:tblW w:w="1250" w:type="pct"/><w:jc w:val="{val}"/>'
+        blob = _pack({"word/document.xml": _doc(_table_with_pr(tblpr, _table_cell(None, "a"), grid_widths=["4800"]))})
+        kv = _first_cell_sentinel_kv(_body(DocxTablePreProcess.preprocess(blob)))
+        assert kv.get("tw") == "0.2500"
+        assert kv.get("ta") == expected
+
+
+def test_absolute_dxa_width_becomes_fraction():
+    """50px == 750 twips against the 9360-twip reference ~= 0.08 of the line."""
+    tblpr = '<w:tblW w:w="750" w:type="dxa"/><w:jc w:val="left"/>'
+    blob = _pack({"word/document.xml": _doc(_table_with_pr(tblpr, _table_cell(None, "a"), grid_widths=["4800"]))})
+    kv = _first_cell_sentinel_kv(_body(DocxTablePreProcess.preprocess(blob)))
+    assert kv.get("tw") == "0.0801"
+
+
+def test_table_width_merges_with_cell_background():
+    """A narrow table whose first cell is also shaded gets one merged sentinel."""
+    tblpr = '<w:tblW w:w="2000" w:type="pct"/><w:jc w:val="left"/>'
+    blob = _pack({"word/document.xml": _doc(_table_with_pr(tblpr, _table_cell("F0F0F0", "a"), grid_widths=["4800"]))})
+    kv = _first_cell_sentinel_kv(_body(DocxTablePreProcess.preprocess(blob)))
+    assert kv.get("tw") == "0.4000"
+    assert kv.get("ta") == "left"
+    assert kv.get("bg") == "F0F0F0"
+
+
+def test_table_without_tblw_carries_alignment_only():
+    """No <w:tblW> -> no width fraction, but the alignment is still carried so a
+    left/right table is not left to pandoc's centered default."""
+    blob = _pack({"word/document.xml": _doc(_table_with_pr('<w:jc w:val="left"/>', _table_cell(None, "a"), grid_widths=["4800"]))})
+    kv = _first_cell_sentinel_kv(_body(DocxTablePreProcess.preprocess(blob)))
+    assert "tw" not in kv
+    assert kv.get("ta") == "left"
+
+
+def test_table_with_no_layout_at_all_is_not_tagged():
+    """A table with neither <w:tblW> nor <w:jc> gets no layout sentinel."""
+    blob = _pack({"word/document.xml": _doc(_table_with_pr("", _table_cell(None, "a"), grid_widths=["4800"]))})
+    assert _first_cell_sentinel_kv(_body(DocxTablePreProcess.preprocess(blob))) == {}
+
+
+def test_zero_width_gridcols_are_normalised():
+    """<w:gridCol w:w="0"/> is treated as missing and given a positive width, so
+    pandoc keeps column widths (and the table renders at its tblW width) instead
+    of collapsing to a content-width, centered table."""
+    tbl = (
+        '<w:tbl><w:tblPr><w:tblW w:w="5000" w:type="pct"/><w:jc w:val="left"/></w:tblPr>'
+        '<w:tblGrid><w:gridCol w:w="0"/><w:gridCol w:w="0"/></w:tblGrid>'
+        "<w:tr><w:tc><w:p><w:r><w:t>a</w:t></w:r></w:p></w:tc>"
+        "<w:tc><w:p><w:r><w:t>b</w:t></w:r></w:p></w:tc></w:tr></w:tbl>"
+    )
+    root = _body(DocxTablePreProcess.preprocess(_pack({"word/document.xml": _doc(tbl)})))
+    widths = [int(c.get(f"{{{W_NS}}}w")) for c in root.iter(f"{{{W_NS}}}gridCol")]
+    assert all(w > 0 for w in widths)
+
+
+# --- caption style neutralisation (avoid double numbering in PDF) -----------
+
+
+def test_caption_paragraph_style_is_stripped():
+    """A ``Caption``-styled paragraph loses its style so pandoc won't turn it
+    into an auto-numbered LaTeX \\caption (its text already has the number)."""
+    para = '<w:p><w:pPr><w:pStyle w:val="Caption"/></w:pPr><w:r><w:t>Table 1 My caption</w:t></w:r></w:p>'
+    blob = _pack({"word/document.xml": _doc(para)})
+    root = _body(DocxTablePreProcess.preprocess(blob))
+    styles = [s.get(f"{{{W_NS}}}val") for s in root.iter(f"{{{W_NS}}}pStyle")]
+    assert "Caption" not in styles
+    # The text is preserved.
+    assert any(t.text == "Table 1 My caption" for t in root.iter(f"{{{W_NS}}}t"))
+
+
+def test_non_caption_paragraph_styles_are_left_alone():
+    """Pandoc's own caption styles (with no embedded number) keep their style."""
+    for style in ("TableCaption", "ImageCaption", "BodyText"):
+        para = f'<w:p><w:pPr><w:pStyle w:val="{style}"/></w:pPr><w:r><w:t>x</w:t></w:r></w:p>'
+        blob = _pack({"word/document.xml": _doc(para)})
+        root = _body(DocxTablePreProcess.preprocess(blob))
+        styles = [s.get(f"{{{W_NS}}}val") for s in root.iter(f"{{{W_NS}}}pStyle")]
+        assert style in styles
+
+
+def test_absolute_width_table_flagged_for_tight_padding():
+    """A dxa (absolute px/pt) width carries aw=1 so the filter tightens its
+    inter-column padding; a percentage width does not."""
+    dxa = '<w:tblW w:w="750" w:type="dxa"/><w:jc w:val="left"/>'
+    kv = _first_cell_sentinel_kv(_body(DocxTablePreProcess.preprocess(_pack({"word/document.xml": _doc(_table_with_pr(dxa, _table_cell(None, "a"), grid_widths=["4800"]))}))))
+    assert kv.get("aw") == "1"
+
+    pct = '<w:tblW w:w="2000" w:type="pct"/><w:jc w:val="left"/>'
+    kv = _first_cell_sentinel_kv(_body(DocxTablePreProcess.preprocess(_pack({"word/document.xml": _doc(_table_with_pr(pct, _table_cell(None, "a"), grid_widths=["4800"]))}))))
+    assert "aw" not in kv

--- a/tests/test_html_captions_filter.py
+++ b/tests/test_html_captions_filter.py
@@ -1,0 +1,94 @@
+"""Integration tests for ``filters/html_captions.lua``.
+
+Runs the real ``pandoc`` binary (html -> docx) with the filter and inspects the
+paragraph styles in the produced ``document.xml``. The filter marks a paragraph
+with the "Caption" style iff it carries Polarion's caption counter span
+(``<span data-sequence=... class="polarion-rte-caption">``); everything else —
+headings, cross-references, size labels — must be left unstyled so
+``DocxReferencesPostProcess`` never mistakes them for captions.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import shutil
+import subprocess
+import zipfile
+
+import pytest
+
+_PANDOC = shutil.which("pandoc")
+pytestmark = pytest.mark.skipif(_PANDOC is None, reason="pandoc binary not available")
+
+_FILTER = "filters/html_captions.lua"
+
+
+def _styles_by_text(body: str) -> dict[str, str | None]:
+    html = f"<html><head><title>t</title></head><body>{body}</body></html>"
+    completed = subprocess.run(  # noqa: S603
+        [_PANDOC, "-f", "html", "-t", "docx", "--lua-filter", _FILTER, "-o", "-"],
+        input=html.encode(),
+        capture_output=True,
+        check=True,
+    )
+    document_xml = zipfile.ZipFile(io.BytesIO(completed.stdout)).read("word/document.xml").decode()
+    result: dict[str, str | None] = {}
+    for match in re.finditer(r"<w:p\b.*?</w:p>", document_xml, re.S):
+        para = match.group(0)
+        style = re.search(r'<w:pStyle w:val="([^"]+)"', para)
+        text = "".join(re.findall(r"<w:t[^>]*>([^<]*)</w:t>", para)).strip()
+        if text:
+            result[text] = style.group(1) if style else None
+    return result
+
+
+_CAPTION_P = '<p class="polarion-rte-caption-paragraph">Table <span data-sequence="Table" class="polarion-rte-caption">1</span> Real caption</p>'
+_FIGURE_CAPTION_P = '<p class="polarion-rte-caption-paragraph">Figure <span data-sequence="Figure" class="polarion-rte-caption">2</span> A figure</p>'
+
+
+def test_real_caption_gets_caption_style():
+    styles = _styles_by_text(_CAPTION_P)
+    assert styles["Table 1 Real caption"] == "Caption"
+
+
+def test_figure_caption_gets_caption_style():
+    styles = _styles_by_text(_FIGURE_CAPTION_P)
+    assert styles["Figure 2 A figure"] == "Caption"
+
+
+def test_prose_starting_with_table_and_number_is_not_captioned():
+    """The exact false positive the text heuristic produced: a cross-reference."""
+    styles = _styles_by_text("<p>Table 1 shows the results discussed above.</p>")
+    assert styles["Table 1 shows the results discussed above."] != "Caption"
+
+
+def test_size_label_is_not_captioned():
+    styles = _styles_by_text("<p>Table 50px</p>")
+    assert styles["Table 50px"] != "Caption"
+
+
+def test_heading_div_title_is_not_captioned():
+    styles = _styles_by_text('<div class="title">Table test III</div>')
+    assert styles["Table test III"] != "Caption"
+
+
+def test_only_the_caption_is_marked_among_lookalikes():
+    body = _CAPTION_P + "<p>Table 1 is described below.</p>" + '<div class="title">Table overview</div>'
+    styles = _styles_by_text(body)
+    assert styles["Table 1 Real caption"] == "Caption"
+    assert styles["Table 1 is described below."] != "Caption"
+    assert styles["Table overview"] != "Caption"
+
+
+def test_non_docx_target_is_untouched():
+    """The filter only acts for the docx writer (defensive FORMAT gate)."""
+    html = f"<html><body>{_CAPTION_P}</body></html>"
+    completed = subprocess.run(  # noqa: S603
+        [_PANDOC, "-f", "html", "-t", "latex", "--lua-filter", _FILTER],
+        input=html.encode(),
+        capture_output=True,
+        check=True,
+    )
+    # No custom-style Div wrapping leaks into LaTeX output.
+    assert "Caption" not in completed.stdout.decode()

--- a/tests/test_html_table_layout.py
+++ b/tests/test_html_table_layout.py
@@ -1,0 +1,211 @@
+"""Unit tests for :mod:`app.HtmlTableLayout`.
+
+Each test feeds a small HTML fragment to :func:`HtmlTableLayout.extract` and
+checks the recovered :class:`TableLayout` list, plus a couple of tests that run
+the extracted layouts through :func:`app.DocxPostProcess.process` end-to-end to
+confirm the width/alignment lands in the resulting ``<w:tblPr>``.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import shutil
+import subprocess
+import zipfile
+
+import pytest
+
+from app import DocxPostProcess, HtmlTableLayout
+from app.HtmlTableLayout import MAX_PCT, TableLayout, extract
+
+
+def _table(style: str) -> str:
+    return f'<html><body><table style="{style}"><tr><td>x</td></tr></table></body></html>'
+
+
+# ----------------------- width extraction -----------------------
+
+
+@pytest.mark.parametrize(
+    ("style", "expected_type", "expected_value"),
+    [
+        ("width: 100%;", "pct", MAX_PCT),
+        ("width: 40%;", "pct", 2000),
+        ("width: 80%;", "pct", 4000),
+        ("width: 25%;", "pct", 1250),
+        ("width: 50px;", "dxa", 750),
+        ("width: 100px;", "dxa", 1500),
+        ("width: 1in;", "dxa", 1440),
+        ("width: auto;", None, None),
+        ("width: 0%;", None, None),
+        ("width: 0px;", None, None),
+        ("border: 1px solid #ccc;", None, None),  # no width declared
+    ],
+)
+def test_width_parsing(style, expected_type, expected_value):
+    layout = extract(_table(style))[0]
+    assert layout.width_type == expected_type
+    assert layout.width_value == expected_value
+
+
+def test_percentage_over_100_clamped_to_max():
+    layout = extract(_table("width: 150%;"))[0]
+    assert layout.width_type == "pct"
+    assert layout.width_value == MAX_PCT
+
+
+def test_max_width_is_not_confused_with_width():
+    """``max-width`` must not be read as the table width."""
+    layout = extract(_table("max-width: 512px;"))[0]
+    assert layout.width_type is None
+    assert layout.width_value is None
+
+
+# ----------------------- alignment extraction -----------------------
+
+
+@pytest.mark.parametrize(
+    ("style", "expected_jc"),
+    [
+        ("margin-left: 0px; margin-right: auto;", "left"),
+        ("margin-left: auto; margin-right: auto;", "center"),
+        ("margin-left: auto; margin-right: 0px;", "right"),
+        ("margin-left: 0px; margin-right: 0px;", None),  # no auto -> no intent
+        ("border: 1px solid #ccc;", None),  # no margins at all
+    ],
+)
+def test_alignment_parsing(style, expected_jc):
+    assert extract(_table(style))[0].jc == expected_jc
+
+
+def test_left_margin_becomes_indent_when_left_aligned():
+    layout = extract(_table("margin-left: 48px; margin-right: auto;"))[0]
+    assert layout.jc == "left"
+    assert layout.indent_twips == 720  # 48px * 15 twips
+
+
+def test_auto_margin_is_never_an_indent():
+    """Centered/right-aligned tables use auto margins as the alignment
+    mechanism, so no indent should be recorded."""
+    centered = extract(_table("margin-left: auto; margin-right: auto;"))[0]
+    assert centered.indent_twips is None
+
+
+# ----------------------- document-order & robustness -----------------------
+
+
+def test_extract_returns_one_layout_per_table_in_document_order():
+    html = "<html><body>" + _inner_tables() + "</body></html>"
+    layouts = extract(html)
+    assert [layout.width_value for layout in layouts] == [2000, 4000]
+
+
+def _inner_tables() -> str:
+    return '<table style="width: 40%;"><tr><td>a</td></tr></table><table style="width: 80%;"><tr><td>b</td></tr></table>'
+
+
+def test_nested_table_follows_its_parent_depth_first():
+    html = '<html><body><table style="width: 100%;"><tr><td><table style="width: 25%;"><tr><td>n</td></tr></table></td></tr></table></body></html>'
+    layouts = extract(html)
+    assert [layout.width_value for layout in layouts] == [MAX_PCT, 1250]
+
+
+def test_accepts_bytes_with_xml_encoding_declaration():
+    """The exporter sends an ``<?xml ... encoding=...?>`` prologue; lxml rejects
+    that on a decoded str, so extract must feed it bytes."""
+    source = b"<?xml version='1.0' encoding='UTF-8'?><html><body>" + _table("width: 40%;").encode() + b"</body></html>"
+    layouts = extract(source)
+    assert any(layout.width_value == 2000 for layout in layouts)
+
+
+def test_no_tables_returns_empty_list():
+    assert extract("<html><body><p>no tables here</p></body></html>") == []
+
+
+def test_unparseable_input_returns_empty_list():
+    assert extract(b"\xff\xfe not html at all") == []
+
+
+def test_table_layout_is_empty_helper():
+    assert TableLayout().is_empty is True
+    assert TableLayout(jc="center").is_empty is False
+
+
+# ----------------------- end-to-end through DocxPostProcess -----------------------
+
+# Resolve pandoc to an absolute path (satisfies ruff S607) and skip the
+# end-to-end tests when the binary isn't installed; the extraction tests above
+# need no external tools.
+_PANDOC = shutil.which("pandoc")
+requires_pandoc = pytest.mark.skipif(_PANDOC is None, reason="pandoc binary not available")
+
+
+def _pandoc_html_to_docx(html: str) -> bytes:
+    completed = subprocess.run(  # noqa: S603
+        [_PANDOC, "-f", "html", "-t", "docx", "-o", "-"],
+        input=html.encode(),
+        capture_output=True,
+        check=True,
+    )
+    return completed.stdout
+
+
+def _tbl_props_xml(html_body: str) -> str:
+    html = f"<html><head><title>t</title></head><body>{html_body}</body></html>"
+    layouts = HtmlTableLayout.extract(html)
+    processed = DocxPostProcess.process(_pandoc_html_to_docx(html), None, None, layouts)
+    return zipfile.ZipFile(io.BytesIO(processed)).read("word/document.xml").decode()
+
+
+@requires_pandoc
+def test_end_to_end_percentage_width_applied():
+    body = '<table style="width: 40%; margin-left: 0px; margin-right: auto;"><tr><td>x</td></tr></table>'
+    document_xml = _tbl_props_xml(body)
+    props = re.search(r"<w:tblPr>.*?</w:tblPr>", document_xml, re.S).group(0)
+    assert '<w:tblW w:w="2000" w:type="pct"/>' in props
+    assert '<w:jc w:val="left"/>' in props
+    assert '<w:tblLayout w:type="autofit"/>' in props
+
+
+@requires_pandoc
+def test_end_to_end_centered_table():
+    body = '<table style="width: 25%; margin-left: auto; margin-right: auto;"><tr><td>x</td></tr></table>'
+    props = re.search(r"<w:tblPr>.*?</w:tblPr>", _tbl_props_xml(body), re.S).group(0)
+    assert '<w:tblW w:w="1250" w:type="pct"/>' in props
+    assert '<w:jc w:val="center"/>' in props
+
+
+@requires_pandoc
+def test_end_to_end_absolute_width_uses_fixed_layout_and_rescaled_grid():
+    body = '<table style="width: 100px; margin-left: 0px; margin-right: auto;"><tr><td>a</td><td>b</td></tr></table>'
+    document_xml = _tbl_props_xml(body)
+    props = re.search(r"<w:tblPr>.*?</w:tblPr>", document_xml, re.S).group(0)
+    assert '<w:tblW w:w="1500" w:type="dxa"/>' in props
+    assert '<w:tblLayout w:type="fixed"/>' in props
+    grid = re.search(r"<w:tblGrid>.*?</w:tblGrid>", document_xml, re.S).group(0)
+    col_widths = [int(w) for w in re.findall(r'w:w="(\d+)"', grid)]
+    assert sum(col_widths) == 1500  # 100px * 15 twips, distributed across columns
+
+
+@requires_pandoc
+def test_end_to_end_default_when_no_layouts_keeps_full_width():
+    """A table with no style still fills the column (backwards-compatible)."""
+    body = "<table><tr><td>x</td></tr></table>"
+    props = re.search(r"<w:tblPr>.*?</w:tblPr>", _tbl_props_xml(body), re.S).group(0)
+    assert '<w:tblW w:w="5000" w:type="pct"/>' in props
+    assert '<w:tblLayout w:type="autofit"/>' in props
+
+
+@requires_pandoc
+def test_count_mismatch_falls_back_to_defaults():
+    """When the number of layouts doesn't match the number of tables, no
+    width/alignment is applied and every table keeps the 100% default."""
+    docx = _pandoc_html_to_docx("<html><head><title>t</title></head><body><table><tr><td>x</td></tr></table></body></html>")
+    # Deliberately pass too many layouts (2 for 1 table).
+    bogus = [TableLayout(width_type="pct", width_value=2000), TableLayout(width_type="pct", width_value=1000)]
+    processed = DocxPostProcess.process(docx, None, None, bogus)
+    document_xml = zipfile.ZipFile(io.BytesIO(processed)).read("word/document.xml").decode()
+    props = re.search(r"<w:tblPr>.*?</w:tblPr>", document_xml, re.S).group(0)
+    assert '<w:tblW w:w="5000" w:type="pct"/>' in props
+    assert "w:jc" not in props

--- a/tests/test_html_tables_to_latex_filter.py
+++ b/tests/test_html_tables_to_latex_filter.py
@@ -1,0 +1,96 @@
+"""Integration tests for ``filters/html_tables_to_latex.lua``.
+
+Runs the real ``pandoc`` binary (html -> latex) with the filter and inspects
+the generated LaTeX. The filter recovers table width and horizontal alignment
+from the ``<table style>`` that pandoc's LaTeX writer would otherwise ignore
+(every table renders content-width and centered).
+
+Contract checked here:
+* ``margin`` pair -> longtable ``\\LTleft``/``\\LTright`` glue (left/center/right).
+* ``width: N%`` -> column widths summing to ~N% of the line (pandoc emits
+  ``\\real{fraction}`` column widths).
+* tables with no style are left untouched.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+
+import pytest
+
+_PANDOC = shutil.which("pandoc")
+pytestmark = pytest.mark.skipif(_PANDOC is None, reason="pandoc binary not available")
+
+_FILTER = "filters/html_tables_to_latex.lua"
+
+
+def _html_to_latex(body: str) -> str:
+    html = f"<html><head><title>t</title></head><body>{body}</body></html>"
+    completed = subprocess.run(  # noqa: S603
+        [_PANDOC, "-f", "html", "-t", "latex", "--lua-filter", _FILTER],
+        input=html.encode(),
+        capture_output=True,
+        check=True,
+    )
+    return completed.stdout.decode()
+
+
+def _table(style: str, cols: str = "<td>a</td><td>b</td><td>c</td>") -> str:
+    return f'<table style="{style}"><tr>{cols}</tr></table>'
+
+
+def test_left_aligned_table_pins_ltleft_to_zero():
+    latex = _html_to_latex(_table("width: 100%; margin-left: 0px; margin-right: auto;"))
+    assert "\\setlength{\\LTleft}{0pt}" in latex
+    assert "\\setlength{\\LTright}{\\fill}" in latex
+
+
+def test_right_aligned_table_pins_ltright_to_zero():
+    latex = _html_to_latex(_table("width: 25%; margin-left: auto; margin-right: 0px;"))
+    assert "\\setlength{\\LTleft}{\\fill}" in latex
+    assert "\\setlength{\\LTright}{0pt}" in latex
+
+
+def test_centered_table_uses_fill_on_both_sides():
+    latex = _html_to_latex(_table("width: 25%; margin-left: auto; margin-right: auto;"))
+    # The alignment block sets both to \fill (also the reset value), so just
+    # assert the table was wrapped (glue present) and not pinned to an edge.
+    assert "\\setlength{\\LTleft}{\\fill}" in latex
+    assert "\\setlength{\\LTright}{0pt}" not in latex
+    assert "\\setlength{\\LTleft}{0pt}" not in latex
+
+
+def test_percentage_width_sets_fractional_columns():
+    latex = _html_to_latex(_table("width: 40%; margin-left: 0px; margin-right: auto;"))
+    fractions = [float(x) for x in re.findall(r"\\real\{([0-9.]+)\}", latex)]
+    assert fractions, "expected \\real{} column widths in the longtable preamble"
+    # Three columns summing to ~0.40 of the line width.
+    assert abs(sum(fractions) - 0.40) < 0.01
+
+
+def test_absolute_width_is_a_small_fraction():
+    latex = _html_to_latex(_table("width: 100px; margin-left: 0px; margin-right: auto;"))
+    fractions = [float(x) for x in re.findall(r"\\real\{([0-9.]+)\}", latex)]
+    assert fractions
+    # 100px = 75pt against a 468pt reference text width ~= 0.16 of the line.
+    assert abs(sum(fractions) - (75.0 / 468.0)) < 0.02
+
+
+def test_table_without_style_is_untouched():
+    latex = _html_to_latex("<table><tr><td>a</td><td>b</td></tr></table>")
+    assert "\\LTleft" not in latex
+    assert "\\real{" not in latex
+
+
+def test_non_latex_target_is_untouched():
+    """The filter is a no-op for non-LaTeX writers (defensive FORMAT gate)."""
+    html = f"<html><body>{_table('width: 40%; margin-left: auto; margin-right: auto;')}</body></html>"
+    completed = subprocess.run(  # noqa: S603
+        [_PANDOC, "-f", "html", "-t", "html", "--lua-filter", _FILTER],
+        input=html.encode(),
+        capture_output=True,
+        check=True,
+    )
+    assert "LTleft" not in completed.stdout.decode()

--- a/tests/test_pandoc_controller.py
+++ b/tests/test_pandoc_controller.py
@@ -632,7 +632,7 @@ def test_convert_with_encoding():
 
         # Assertions
         mock_convert.assert_called_once_with("# Test Content", "markdown", "html", DEFAULT_CONVERSION_OPTIONS, preserve_table_styles=False)
-        mock_postprocess.assert_called_once_with(b"<html>Test</html>", "html", "converted-document.html", None, None)
+        mock_postprocess.assert_called_once_with(b"<html>Test</html>", "html", "converted-document.html", None, None, None)
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
         assert response.content == b"<html>Test</html>"
@@ -652,7 +652,7 @@ def test_convert_with_custom_filename():
 
         # Assertions
         mock_convert.assert_called_once_with(b"# Test Content", "markdown", "html", DEFAULT_CONVERSION_OPTIONS, preserve_table_styles=False)
-        mock_postprocess.assert_called_once_with(b"<html>Test</html>", "html", "custom.html", None, None)
+        mock_postprocess.assert_called_once_with(b"<html>Test</html>", "html", "custom.html", None, None, None)
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
         assert response.content == b"<html>Test</html>"
@@ -682,7 +682,7 @@ def test_convert_docx_with_ref_source_text():
         assert call_args[2] == "docx"  # Target format
 
         # Check that postprocess_and_build_response was called
-        mock_postprocess.assert_called_once_with(b"DOCX content", "docx", "converted-document.docx", None, None)
+        mock_postprocess.assert_called_once_with(b"DOCX content", "docx", "converted-document.docx", None, None, None)
 
         # Check the response
         assert response.status_code == 200
@@ -721,7 +721,7 @@ def test_convert_docx_with_ref_no_template():
         assert not any("--reference-doc" in option for option in options)
 
         # Check that postprocess_and_build_response was called
-        mock_postprocess.assert_called_once_with(b"DOCX content", "docx", "converted-document.docx", None, None)
+        mock_postprocess.assert_called_once_with(b"DOCX content", "docx", "converted-document.docx", None, None, None)
 
         # Check the response
         assert response.status_code == 200
@@ -748,7 +748,7 @@ def test_convert_docx_to_pdf_with_custom_filename():
         assert args[2] == "pdf"
         assert "--pdf-engine=tectonic" in args[3]
 
-        mock_postprocess.assert_called_once_with(b"%PDF-test", "pdf", "custom.pdf", None, None)
+        mock_postprocess.assert_called_once_with(b"%PDF-test", "pdf", "custom.pdf", None, None, None)
 
         assert response.status_code == 200
         assert response.headers["content-type"] == "application/pdf"
@@ -949,7 +949,7 @@ def test_convert_docx_with_ref_no_source_file():
 def test_postprocess_and_build_response_with_headers():
     """Test postprocess_and_build_response with all headers."""
     with (
-        patch("app.DocxPostProcess.process", side_effect=lambda x, y=None, z=None: x),
+        patch("app.DocxPostProcess.process", side_effect=lambda x, y=None, z=None, layouts=None: x),
         patch("app.PandocController.get_pandoc_version", return_value="3.1.9"),
         patch.dict(os.environ, {"PANDOC_SERVICE_VERSION": "1.0.0"}),
     ):
@@ -1052,7 +1052,7 @@ def test_convert_endpoint_with_custom_file_extension():
         assert response.status_code == 200
 
         # Verify the custom filename was passed to postprocess_and_build_response
-        mock_postprocess.assert_called_once_with(b"Converted content", "html", "custom_name.html", None, None)
+        mock_postprocess.assert_called_once_with(b"Converted content", "html", "custom_name.html", None, None, None)
 
 
 def test_docx_with_template_encoding():


### PR DESCRIPTION
### Proposed changes

Fix to preserve table sizes when converting HTML to DOCX and DOCX to PDF.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
