### PR TITLE
fix: replace plain-text caption numbers with SEQ fields and pre-fille…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,6 +127,7 @@ COPY filters/docx_tables_to_latex.lua "/usr/local/share/pandoc/filters/docx_tabl
 COPY filters/html_lists.lua "/usr/local/share/pandoc/filters/html_lists.lua"
 COPY filters/html_tables_to_latex.lua "/usr/local/share/pandoc/filters/html_tables_to_latex.lua"
 COPY filters/html_captions.lua "/usr/local/share/pandoc/filters/html_captions.lua"
+COPY filters/docx_caption_labels_to_latex.lua "/usr/local/share/pandoc/filters/docx_caption_labels_to_latex.lua"
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD curl -fsS http://localhost:9082/health || exit 1

--- a/app/DocxReferencesPostProcess.py
+++ b/app/DocxReferencesPostProcess.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
 from docx.oxml import parse_xml
@@ -106,11 +107,23 @@ def _find_and_process_captions(body: Any) -> tuple[list, list]:
 
         text_stripped = _get_paragraph_text(para).strip()
 
-        # Classify Figure vs Table. Language-independent strategy:
+        # Classify Figure vs Table. Strategy (in priority order):
         # 1. Pandoc's own styles are unambiguous (ImageCaption / TableCaption).
-        # 2. For the generic "Caption" style, check whether the paragraph is
-        #    adjacent to a <w:tbl> element — if so it's a table caption.
-        is_figure = style == "ImageCaption" or (style != "TableCaption" and not _is_adjacent_to_table(para))
+        # 2. If a SEQ field already exists (from Lua filter), its identifier
+        #    comes from Polarion's data-sequence attribute. Table captions
+        #    always have a <w:tbl> nearby; if adjacency fails but a SEQ name
+        #    exists that is NOT "Figure", treat it as a table caption anyway
+        #    (Polarion would not set a table sequence on a figure).
+        # 3. Fall back to structural adjacency: if the next content element
+        #    is a <w:tbl>, it's a table caption; otherwise figure.
+        if style == "ImageCaption":
+            is_figure = True
+        elif style == "TableCaption" or _is_adjacent_to_table(para):
+            is_figure = False
+        else:
+            # No table nearby — check if an existing SEQ name hints at table
+            existing_seq = _get_seq_name(para)
+            is_figure = existing_seq is None or existing_seq == "Figure"
         seq_name = "Figure" if is_figure else "Table"
 
         # Ensure the caption number is a SEQ field (not plain text).
@@ -178,6 +191,16 @@ def _has_seq_field(para: Any) -> bool:
     return any(instr.text and "SEQ" in instr.text for instr in para.findall(".//w:instrText", namespaces={"w": SCHEMA}))
 
 
+def _get_seq_name(para: Any) -> str | None:
+    """Extract the SEQ field identifier from a paragraph (e.g. "Table", "Tabela")."""
+    for instr in para.findall(".//w:instrText", namespaces={"w": SCHEMA}):
+        if instr.text and "SEQ" in instr.text:
+            match = re.search(r"SEQ\s+(\S+)", instr.text)
+            if match:
+                return match.group(1)
+    return None
+
+
 def _ensure_seq_field(para: Any, seq_name: str) -> None:
     """Replace a plain-text caption number with a Word SEQ field.
 
@@ -185,36 +208,58 @@ def _ensure_seq_field(para: Any, seq_name: str) -> None:
     ``1`` with ``{SEQ Figure \\* ARABIC}`` so Word can auto-number captions.
     Does nothing if the paragraph already contains a SEQ field (e.g. one
     inserted by the Lua filter).
+
+    Only the run containing the first number is replaced; all other runs
+    (with formatting, links, etc.) are preserved.
     """
     if _has_seq_field(para):
         return
 
-    text = _get_paragraph_text(para).strip()
-    match = re.match(r"^(\D+?)(\d+)(.*)", text, re.DOTALL)
-    if not match:
-        return
+    ns = f'xmlns:w="{SCHEMA}"'
+    runs = list(para.findall("w:r", namespaces={"w": SCHEMA}))
 
-    prefix = match.group(1)
-    number = match.group(2)
-    suffix = match.group(3)
+    for run in runs:
+        t_el = run.find("w:t", namespaces={"w": SCHEMA})
+        if t_el is None or not t_el.text:
+            continue
+        match = re.search(r"\d+", t_el.text)
+        if not match:
+            continue
 
-    # Remove all existing runs (keep pPr and non-run children like bookmarks)
-    for run in list(para.findall("w:r", namespaces={"w": SCHEMA})):
+        number = match.group(0)
+        before = t_el.text[: match.start()]
+        after = t_el.text[match.end() :]
+
+        # Build replacement elements
+        replacements = []
+        if before:
+            r_before = parse_xml(f'<w:r {ns}><w:t xml:space="preserve">{_escape_xml(before)}</w:t></w:r>')
+            # Copy run properties if any
+            rpr = run.find("w:rPr", namespaces={"w": SCHEMA})
+            if rpr is not None:
+                r_before.insert(0, deepcopy(rpr))
+            replacements.append(r_before)
+
+        replacements.append(parse_xml(f'<w:r {ns}><w:fldChar w:fldCharType="begin"/></w:r>'))
+        replacements.append(parse_xml(f'<w:r {ns}><w:instrText xml:space="preserve"> SEQ {_escape_xml(seq_name)} \\* ARABIC </w:instrText></w:r>'))
+        replacements.append(parse_xml(f'<w:r {ns}><w:fldChar w:fldCharType="separate"/></w:r>'))
+        replacements.append(parse_xml(f"<w:r {ns}><w:t>{_escape_xml(number)}</w:t></w:r>"))
+        replacements.append(parse_xml(f'<w:r {ns}><w:fldChar w:fldCharType="end"/></w:r>'))
+
+        if after:
+            r_after = parse_xml(f'<w:r {ns}><w:t xml:space="preserve">{_escape_xml(after)}</w:t></w:r>')
+            rpr = run.find("w:rPr", namespaces={"w": SCHEMA})
+            if rpr is not None:
+                r_after.insert(0, deepcopy(rpr))
+            replacements.append(r_after)
+
+        # Insert replacements before the original run, then remove it
+        for repl in replacements:
+            run.addprevious(repl)
         para.remove(run)
 
-    ns = f'xmlns:w="{SCHEMA}"'
-
-    para.append(parse_xml(f'<w:r {ns}><w:t xml:space="preserve">{_escape_xml(prefix)}</w:t></w:r>'))
-    para.append(parse_xml(f'<w:r {ns}><w:fldChar w:fldCharType="begin"/></w:r>'))
-    para.append(parse_xml(f'<w:r {ns}><w:instrText xml:space="preserve"> SEQ {_escape_xml(seq_name)} \\* ARABIC </w:instrText></w:r>'))
-    para.append(parse_xml(f'<w:r {ns}><w:fldChar w:fldCharType="separate"/></w:r>'))
-    para.append(parse_xml(f"<w:r {ns}><w:t>{_escape_xml(number)}</w:t></w:r>"))
-    para.append(parse_xml(f'<w:r {ns}><w:fldChar w:fldCharType="end"/></w:r>'))
-
-    if suffix:
-        para.append(parse_xml(f'<w:r {ns}><w:t xml:space="preserve">{_escape_xml(suffix)}</w:t></w:r>'))
-
-    logger.debug(f"Replaced plain-text number with SEQ {seq_name} field in caption: {text}")
+        logger.debug(f"Replaced number {number} with SEQ {seq_name} field in caption run")
+        return
 
 
 def _ensure_caption_style(para: Any) -> None:

--- a/app/DocxReferencesPostProcess.py
+++ b/app/DocxReferencesPostProcess.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import TYPE_CHECKING, Any
 
 from docx.oxml import parse_xml
@@ -31,10 +32,10 @@ logger = logging.getLogger(__name__)
 def add_table_of_contents_entries(doc: DocumentObject) -> None:
     """
     Add Table of Contents, Table of Figures and/or Table of Tables by:
-    1. Finding figure/table captions and adding TC fields
+    1. Finding figure/table captions, ensuring SEQ fields, adding TC fields with bookmarks
     2. Replacing TOC_PLACEHOLDER with Word TOC field
-    3. Replacing TOF_PLACEHOLDER with Word TOF field
-    4. Replacing TOT_PLACEHOLDER with Word TOT field
+    3. Replacing TOF_PLACEHOLDER with Word TOF field (with cached entries)
+    4. Replacing TOT_PLACEHOLDER with Word TOT field (with cached entries)
     """
     body = doc.element.body
 
@@ -54,63 +55,170 @@ def enable_auto_update_fields(doc: DocumentObject) -> None:
     This sets the updateFields flag in settings.xml
     """
     try:
-        # Access the settings part
         settings = doc.settings
         settings_element = settings.element
 
-        # Check if updateFields already exists
         update_fields = settings_element.find(".//w:updateFields", namespaces={"w": SCHEMA})
 
         if update_fields is None:
-            # Create the updateFields element
             update_fields = parse_xml(f'<w:updateFields {nsdecls("w")} w:val="true"/>')
             settings_element.append(update_fields)
             logger.info("Enabled auto-update of fields on document open")
         else:
-            # Update existing value
             update_fields.set(f"{{{SCHEMA}}}val", "true")
             logger.info("Updated existing auto-update fields setting")
     except Exception as e:
         logger.warning(f"Could not enable auto-update fields: {e}")
 
 
+def _escape_xml(text: str) -> str:
+    """Escape characters that aren't safe inside XML element body or attributes."""
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
+
+
+def _get_max_bookmark_id(body: Any) -> int:
+    """Find the highest bookmark ID in the document to avoid ID conflicts."""
+    max_id = 0
+    for bm in body.findall(".//w:bookmarkStart", namespaces={"w": SCHEMA}):
+        try:
+            bm_id = int(bm.get(f"{{{SCHEMA}}}id", "0"))
+            max_id = max(max_id, bm_id)
+        except ValueError:
+            pass
+    return max_id
+
+
 def _find_and_process_captions(body: Any) -> tuple[list, list]:
-    """Find all figure and table captions and add TC fields to them."""
-    figure_paragraphs = []
-    table_paragraphs = []
+    """Find all figure and table captions, ensure SEQ fields, add TC fields with bookmarks.
+
+    Returns two lists (figure_entries, table_entries) where each entry is
+    a tuple ``(paragraph_element, caption_text, bookmark_name)``.
+    """
+    figure_paragraphs: list[tuple[Any, str, str]] = []
+    table_paragraphs: list[tuple[Any, str, str]] = []
+
+    bookmark_id = _get_max_bookmark_id(body)
 
     for para in body.findall(".//w:p", namespaces={"w": SCHEMA}):
-        # Only real captions are considered — those carrying a caption STYLE
-        # (Polarion's "Caption" from filters/html_captions.lua, Word's "Caption",
-        # or pandoc's own "TableCaption"/"ImageCaption"). Prose, headings and
-        # labels that merely start with "Table"/"Figure" never carry one, so
-        # they are ignored.
         style = _get_paragraph_style(para)
         if style not in CAPTION_STYLE_IDS:
             continue
 
         text_stripped = _get_paragraph_text(para).strip()
 
-        # Classify Figure vs Table from the caption style, falling back to the
-        # leading word for the generic "Caption" style (Polarion/Word captions
-        # open with the "Figure"/"Table" sequence keyword). Default to Table.
-        is_figure = style == "ImageCaption" or (style != "TableCaption" and text_stripped.startswith("Figure"))
+        # Classify Figure vs Table. Language-independent strategy:
+        # 1. Pandoc's own styles are unambiguous (ImageCaption / TableCaption).
+        # 2. For the generic "Caption" style, check whether the paragraph is
+        #    adjacent to a <w:tbl> element — if so it's a table caption.
+        is_figure = style == "ImageCaption" or (style != "TableCaption" and not _is_adjacent_to_table(para))
+        seq_name = "Figure" if is_figure else "Table"
+
+        # Ensure the caption number is a SEQ field (not plain text).
+        _ensure_seq_field(para, seq_name)
+        # Re-read text after potential SEQ insertion (content may have changed)
+        text_stripped = _get_paragraph_text(para).strip()
+
+        # Ensure Caption style is set
+        _ensure_caption_style(para)
+
+        # Assign a unique bookmark for this caption's TC field
+        bookmark_id += 1
+        bookmark_name = f"_Toc{bookmark_id:09d}"
+
+        # Add TC field with bookmark at the end of the caption paragraph
+        field_flag = "F" if is_figure else "T"
+        _add_tc_field(para, text_stripped, field_flag, bookmark_id, bookmark_name)
+
         if is_figure:
-            figure_paragraphs.append((para, text_stripped))
-            _add_caption_style_and_tc_field(para, text_stripped, field_flag="F")
-            logger.debug(f"Added TC field to figure caption: {text_stripped}")
+            figure_paragraphs.append((para, text_stripped, bookmark_name))
+            logger.debug(f"Processed figure caption: {text_stripped}")
         else:
-            table_paragraphs.append((para, text_stripped))
-            _add_caption_style_and_tc_field(para, text_stripped, field_flag="T")
-            logger.debug(f"Added TC field to table caption: {text_stripped}")
+            table_paragraphs.append((para, text_stripped, bookmark_name))
+            logger.debug(f"Processed table caption: {text_stripped}")
 
     logger.info(f"Found {len(figure_paragraphs)} figure captions and {len(table_paragraphs)} table captions")
     return figure_paragraphs, table_paragraphs
 
 
-def _add_caption_style_and_tc_field(para: Any, caption_text: str, field_flag: str) -> None:
-    """Add Caption style and TC field to a paragraph."""
-    # Add or update paragraph style to Caption
+def _is_adjacent_to_table(para: Any) -> bool:
+    """Return True if the paragraph is followed by a w:tbl element.
+
+    This is a language-independent way to classify captions: table captions
+    sit **before** their table in the document body. Only the forward
+    direction is checked — a caption after a table (e.g. a figure caption
+    that happens to follow a table) must not be misclassified as a table
+    caption.
+
+    Skips non-content elements (bookmarkStart, bookmarkEnd, sectPr, empty
+    paragraphs) that pandoc/Word may insert between a caption and its table.
+    """
+    tbl_tag = f"{{{SCHEMA}}}tbl"
+    p_tag = f"{{{SCHEMA}}}p"
+    skip_tags = {
+        f"{{{SCHEMA}}}bookmarkStart",
+        f"{{{SCHEMA}}}bookmarkEnd",
+        f"{{{SCHEMA}}}sectPr",
+    }
+
+    def _is_empty_para(el: Any) -> bool:
+        return el.tag == p_tag and not _get_paragraph_text(el).strip()
+
+    def _should_skip(el: Any) -> bool:
+        return el.tag in skip_tags or _is_empty_para(el)
+
+    # Look forward only — table caption always precedes its table
+    el = para.getnext()
+    while el is not None and _should_skip(el):
+        el = el.getnext()
+    return el is not None and el.tag == tbl_tag
+
+
+def _has_seq_field(para: Any) -> bool:
+    """Return True if the paragraph already contains a SEQ field."""
+    return any(instr.text and "SEQ" in instr.text for instr in para.findall(".//w:instrText", namespaces={"w": SCHEMA}))
+
+
+def _ensure_seq_field(para: Any, seq_name: str) -> None:
+    """Replace a plain-text caption number with a Word SEQ field.
+
+    For a caption paragraph like ``Figure 1 My picture`` this replaces the
+    ``1`` with ``{SEQ Figure \\* ARABIC}`` so Word can auto-number captions.
+    Does nothing if the paragraph already contains a SEQ field (e.g. one
+    inserted by the Lua filter).
+    """
+    if _has_seq_field(para):
+        return
+
+    text = _get_paragraph_text(para).strip()
+    match = re.match(r"^(\D+?)(\d+)(.*)", text, re.DOTALL)
+    if not match:
+        return
+
+    prefix = match.group(1)
+    number = match.group(2)
+    suffix = match.group(3)
+
+    # Remove all existing runs (keep pPr and non-run children like bookmarks)
+    for run in list(para.findall("w:r", namespaces={"w": SCHEMA})):
+        para.remove(run)
+
+    ns = f'xmlns:w="{SCHEMA}"'
+
+    para.append(parse_xml(f'<w:r {ns}><w:t xml:space="preserve">{_escape_xml(prefix)}</w:t></w:r>'))
+    para.append(parse_xml(f'<w:r {ns}><w:fldChar w:fldCharType="begin"/></w:r>'))
+    para.append(parse_xml(f'<w:r {ns}><w:instrText xml:space="preserve"> SEQ {_escape_xml(seq_name)} \\* ARABIC </w:instrText></w:r>'))
+    para.append(parse_xml(f'<w:r {ns}><w:fldChar w:fldCharType="separate"/></w:r>'))
+    para.append(parse_xml(f"<w:r {ns}><w:t>{_escape_xml(number)}</w:t></w:r>"))
+    para.append(parse_xml(f'<w:r {ns}><w:fldChar w:fldCharType="end"/></w:r>'))
+
+    if suffix:
+        para.append(parse_xml(f'<w:r {ns}><w:t xml:space="preserve">{_escape_xml(suffix)}</w:t></w:r>'))
+
+    logger.debug(f"Replaced plain-text number with SEQ {seq_name} field in caption: {text}")
+
+
+def _ensure_caption_style(para: Any) -> None:
+    """Ensure the paragraph has the Caption style set."""
     p_pr = para.find(XPATH_P_PR, namespaces={"w": SCHEMA})
     if p_pr is None:
         p_pr = parse_xml(f'<w:pPr {nsdecls("w")}><w:pStyle w:val="Caption"/></w:pPr>')
@@ -123,31 +231,40 @@ def _add_caption_style_and_tc_field(para: Any, caption_text: str, field_flag: st
         else:
             p_style.set(f"{{{SCHEMA}}}val", "Caption")
 
-    # Add TC field runs at the end of paragraph
-    tc_runs = _create_tc_field_runs(caption_text, field_flag=field_flag)
-    for run in tc_runs:
-        para.append(run)
+
+def _add_tc_field(para: Any, caption_text: str, field_flag: str, bookmark_id: int, bookmark_name: str) -> None:
+    """Add a TC field with embedded bookmark at the end of a caption paragraph.
+
+    The TC field marks this paragraph for collection by {TOC \\f T/F}.
+    A bookmark inside the TC instruction text lets cached TOF/TOT
+    entries hyperlink directly to this caption.
+    """
+    ns = f'xmlns:w="{SCHEMA}"'
+    escaped = _escape_xml(caption_text)
+
+    para.append(parse_xml(f'<w:r {ns}><w:fldChar w:fldCharType="begin"/></w:r>'))
+    para.append(parse_xml(f'<w:r {ns}><w:instrText xml:space="preserve"> TC "</w:instrText></w:r>'))
+    para.append(parse_xml(f'<w:bookmarkStart {ns} w:id="{bookmark_id}" w:name="{bookmark_name}"/>'))
+    para.append(parse_xml(f"<w:r {ns}><w:instrText>{escaped}</w:instrText></w:r>"))
+    para.append(parse_xml(f'<w:bookmarkEnd {ns} w:id="{bookmark_id}"/>'))
+    para.append(parse_xml(f'<w:r {ns}><w:instrText xml:space="preserve">" \\f {field_flag} \\l "1" </w:instrText></w:r>'))
+    para.append(parse_xml(f'<w:r {ns}><w:fldChar w:fldCharType="end"/></w:r>'))
 
 
 def _find_elements_to_replace(body: Any) -> list:
     """Find all elements that need to be replaced with Word fields."""
     elements_to_replace: list = []
-
-    # Find TOC/TOF/TOT placeholder paragraphs
     _find_placeholder_paragraphs(body, elements_to_replace)
-
     return elements_to_replace
 
 
 def _find_placeholder_paragraphs(body: Any, elements_to_replace: list) -> None:
     """Find TOC_PLACEHOLDER, TOF_PLACEHOLDER, and TOT_PLACEHOLDER paragraphs."""
     for idx, element in enumerate(body):
-        # Check for placeholders in paragraphs
         if element.tag.endswith("}p"):
             text = _get_paragraph_text(element).strip()
             style = _get_paragraph_style(element)
 
-            # Only process placeholders in body text paragraphs, not in titles or headings
             if style not in ["BodyText", "FirstParagraph", None]:
                 continue
 
@@ -164,14 +281,11 @@ def _find_placeholder_paragraphs(body: Any, elements_to_replace: list) -> None:
 
 def _replace_elements_with_fields(body: Any, elements_to_replace: list, figure_paragraphs: list, table_paragraphs: list) -> None:
     """Replace found elements with Word field codes."""
-    # Sort by index in reverse order to maintain correct positions during removal
     for idx, element, has_toc, has_figure_links, has_table_links in sorted(elements_to_replace, key=lambda x: x[0], reverse=True):
-        # Remove element
         if element is not None:
             body.remove(element)
             logger.debug(f"Removed element at index {idx}")
 
-        # Insert replacement fields
         _insert_field_at_position(body, idx, has_toc, has_figure_links, has_table_links, figure_paragraphs, table_paragraphs)
 
 
@@ -184,53 +298,80 @@ def _insert_field_at_position(body: Any, idx: int, has_toc: bool, has_figure_lin
         logger.info(f"Inserted Table of Contents at index {idx}")
 
     if has_figure_links and figure_paragraphs:
-        tof_paragraphs = _create_tof_field()
+        figure_entries = [(text, bm) for _, text, bm in figure_paragraphs]
+        tof_paragraphs = _create_tof_field(figure_entries)
         for tof_para in reversed(tof_paragraphs):
             body.insert(idx, tof_para)
         logger.info(f"Inserted Table of Figures at index {idx}")
 
     if has_table_links and table_paragraphs:
-        tot_paragraphs = _create_tot_field()
+        table_entries = [(text, bm) for _, text, bm in table_paragraphs]
+        tot_paragraphs = _create_tot_field(table_entries)
         for tot_para in reversed(tot_paragraphs):
             body.insert(idx, tot_para)
         logger.info(f"Inserted Table of Tables at index {idx}")
 
 
 def _create_field(field_code: str) -> list[Any]:
-    """Create a Word field with specified field code.
-
-    Args:
-        field_code: The field instruction text (e.g., 'TOC \\o "1-3" \\h \\z \\u')
-
-    Returns:
-        List of paragraph elements containing the field
-    """
-    paragraphs = []
-
-    # Field paragraph
+    """Create a Word field with specified field code (no cached entries)."""
     field_para = parse_xml(f'''
     <w:p xmlns:w="{SCHEMA}">
-        <w:r>
-            <w:fldChar w:fldCharType="begin"/>
-        </w:r>
-        <w:r>
-            <w:instrText xml:space="preserve"> {field_code} </w:instrText>
-        </w:r>
-        <w:r>
-            <w:fldChar w:fldCharType="separate"/>
-        </w:r>
-        <w:r>
-            <w:fldChar w:fldCharType="end"/>
-        </w:r>
+        <w:r><w:fldChar w:fldCharType="begin"/></w:r>
+        <w:r><w:instrText xml:space="preserve"> {field_code} </w:instrText></w:r>
+        <w:r><w:fldChar w:fldCharType="separate"/></w:r>
+        <w:r><w:fldChar w:fldCharType="end"/></w:r>
     </w:p>
     ''')
-    paragraphs.append(field_para)
+    empty_para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"/>')
+    return [field_para, empty_para]
 
-    # Add empty paragraph for spacing
+
+def _create_field_with_entries(field_code: str, entries: list[tuple[str, str]]) -> list[Any]:
+    """Create a Word field with pre-filled TOC entries (cached content)."""
+    if not entries:
+        return _create_field(field_code)
+
+    paragraphs: list[Any] = []
+
+    first_text, first_bm = entries[0]
+    first_para = parse_xml(
+        f'<w:p xmlns:w="{SCHEMA}">'
+        f'<w:pPr><w:pStyle w:val="TOC1"/></w:pPr>'
+        f'<w:r><w:fldChar w:fldCharType="begin"/></w:r>'
+        f'<w:r><w:instrText xml:space="preserve"> {field_code} </w:instrText></w:r>'
+        f'<w:r><w:fldChar w:fldCharType="separate"/></w:r>' + _hyperlink_xml(first_text, first_bm) + "</w:p>"
+    )
+    paragraphs.append(first_para)
+
+    for text, bm in entries[1:]:
+        para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:pPr><w:pStyle w:val="TOC1"/></w:pPr>' + _hyperlink_xml(text, bm) + "</w:p>")
+        paragraphs.append(para)
+
+    end_para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>')
+    paragraphs.append(end_para)
+
     empty_para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"/>')
     paragraphs.append(empty_para)
 
     return paragraphs
+
+
+def _hyperlink_xml(caption_text: str, bookmark_name: str) -> str:
+    """Build the raw OOXML for a TOC entry hyperlink with a PAGEREF field."""
+    escaped = _escape_xml(caption_text)
+    return (
+        f'<w:hyperlink w:anchor="{bookmark_name}" w:history="1">'
+        f'<w:r><w:rPr><w:rStyle w:val="Hyperlink"/></w:rPr>'
+        f"<w:t>{escaped}</w:t></w:r>"
+        f"<w:r><w:rPr><w:webHidden/></w:rPr><w:tab/></w:r>"
+        f'<w:r><w:rPr><w:webHidden/></w:rPr><w:fldChar w:fldCharType="begin"/></w:r>'
+        f"<w:r><w:rPr><w:webHidden/></w:rPr>"
+        f'<w:instrText xml:space="preserve"> PAGEREF {bookmark_name} \\h </w:instrText></w:r>'
+        f'<w:r><w:rPr><w:webHidden/></w:rPr><w:fldChar w:fldCharType="separate"/></w:r>'
+        f"<w:r><w:rPr><w:webHidden/></w:rPr><w:t>1</w:t></w:r>"
+        f'<w:r><w:rPr><w:webHidden/></w:rPr><w:fldChar w:fldCharType="end"/></w:r>'
+        f"</w:hyperlink>"
+    )
 
 
 def _create_toc_field() -> list[Any]:
@@ -238,52 +379,20 @@ def _create_toc_field() -> list[Any]:
     return _create_field('TOC \\o "1-9" \\h \\z \\u')
 
 
-def _create_table_listing_field(field_type: str) -> list[Any]:
-    """Create TOC-based field paragraphs (TOF or TOT).
-
-    Args:
-        field_type: "F" for figures, "T" for tables
-
-    Returns:
-        List of paragraph elements
-    """
-    return _create_field(f"TOC \\h \\z \\f {field_type}")
+def _create_tof_field(entries: list[tuple[str, str]] | None = None) -> list[Any]:
+    """Create Table of Figures field paragraphs using TOC \\f F."""
+    field_code = "TOC \\h \\z \\f F"
+    if entries:
+        return _create_field_with_entries(field_code, entries)
+    return _create_field(field_code)
 
 
-def _create_tof_field() -> list[Any]:
-    """Create Table of Figures field paragraphs."""
-    return _create_table_listing_field("F")
-
-
-def _create_tot_field() -> list[Any]:
-    """Create Table of Tables field paragraphs."""
-    return _create_table_listing_field("T")
-
-
-def _create_tc_field_runs(caption_text: str, field_flag: str = "F") -> list[Any]:
-    """Create TC (Table of Contents Entry) field runs for a caption.
-
-    Args:
-        caption_text: The caption text (e.g., "Figure 1", "Table 1")
-        field_flag: The field flag - "F" for figures, "T" for tables
-    """
-    runs = []
-
-    # Begin run
-    begin_run = parse_xml(f'<w:r xmlns:w="{SCHEMA}"><w:fldChar w:fldCharType="begin"/></w:r>')
-    runs.append(begin_run)
-
-    # Instruction run
-    instr_run = parse_xml(f'''<w:r xmlns:w="{SCHEMA}">
-        <w:instrText xml:space="preserve"> TC "{caption_text}" \\f {field_flag} \\l "1" </w:instrText>
-    </w:r>''')
-    runs.append(instr_run)
-
-    # End run
-    end_run = parse_xml(f'<w:r xmlns:w="{SCHEMA}"><w:fldChar w:fldCharType="end"/></w:r>')
-    runs.append(end_run)
-
-    return runs
+def _create_tot_field(entries: list[tuple[str, str]] | None = None) -> list[Any]:
+    """Create Table of Tables field paragraphs using TOC \\f T."""
+    field_code = "TOC \\h \\z \\f T"
+    if entries:
+        return _create_field_with_entries(field_code, entries)
+    return _create_field(field_code)
 
 
 def _get_paragraph_text(para: Any) -> str:

--- a/app/DocxReferencesPostProcess.py
+++ b/app/DocxReferencesPostProcess.py
@@ -89,7 +89,7 @@ def _get_max_bookmark_id(body: Any) -> int:
     return max_id
 
 
-def _find_and_process_captions(body: Any) -> tuple[list, list]:
+def _find_and_process_captions(body: Any) -> tuple[list, list]:  # noqa: C901
     """Find all figure and table captions, ensure SEQ fields, add TC fields with bookmarks.
 
     Returns two lists (figure_entries, table_entries) where each entry is
@@ -104,8 +104,6 @@ def _find_and_process_captions(body: Any) -> tuple[list, list]:
         style = _get_paragraph_style(para)
         if style not in CAPTION_STYLE_IDS:
             continue
-
-        text_stripped = _get_paragraph_text(para).strip()
 
         # Classify Figure vs Table. Strategy (in priority order):
         # 1. Pandoc's own styles are unambiguous (ImageCaption / TableCaption).
@@ -201,6 +199,28 @@ def _get_seq_name(para: Any) -> str | None:
     return None
 
 
+def _clone_run_with_text(run: Any, text: str) -> Any:
+    """Create a new run with the given text, copying rPr from the source run."""
+    ns = f'xmlns:w="{SCHEMA}"'
+    new_run = parse_xml(f'<w:r {ns}><w:t xml:space="preserve">{_escape_xml(text)}</w:t></w:r>')
+    rpr = run.find("w:rPr", namespaces={"w": SCHEMA})
+    if rpr is not None:
+        new_run.insert(0, deepcopy(rpr))
+    return new_run
+
+
+def _build_seq_field_runs(seq_name: str, number: str) -> list[Any]:
+    """Build the run elements for a SEQ field: begin, instrText, separate, value, end."""
+    ns = f'xmlns:w="{SCHEMA}"'
+    return [
+        parse_xml(f'<w:r {ns}><w:fldChar w:fldCharType="begin"/></w:r>'),
+        parse_xml(f'<w:r {ns}><w:instrText xml:space="preserve"> SEQ {_escape_xml(seq_name)} \\* ARABIC </w:instrText></w:r>'),
+        parse_xml(f'<w:r {ns}><w:fldChar w:fldCharType="separate"/></w:r>'),
+        parse_xml(f"<w:r {ns}><w:t>{_escape_xml(number)}</w:t></w:r>"),
+        parse_xml(f'<w:r {ns}><w:fldChar w:fldCharType="end"/></w:r>'),
+    ]
+
+
 def _ensure_seq_field(para: Any, seq_name: str) -> None:
     """Replace a plain-text caption number with a Word SEQ field.
 
@@ -215,10 +235,7 @@ def _ensure_seq_field(para: Any, seq_name: str) -> None:
     if _has_seq_field(para):
         return
 
-    ns = f'xmlns:w="{SCHEMA}"'
-    runs = list(para.findall("w:r", namespaces={"w": SCHEMA}))
-
-    for run in runs:
+    for run in list(para.findall("w:r", namespaces={"w": SCHEMA})):
         t_el = run.find("w:t", namespaces={"w": SCHEMA})
         if t_el is None or not t_el.text:
             continue
@@ -230,30 +247,13 @@ def _ensure_seq_field(para: Any, seq_name: str) -> None:
         before = t_el.text[: match.start()]
         after = t_el.text[match.end() :]
 
-        # Build replacement elements
-        replacements = []
+        replacements: list[Any] = []
         if before:
-            r_before = parse_xml(f'<w:r {ns}><w:t xml:space="preserve">{_escape_xml(before)}</w:t></w:r>')
-            # Copy run properties if any
-            rpr = run.find("w:rPr", namespaces={"w": SCHEMA})
-            if rpr is not None:
-                r_before.insert(0, deepcopy(rpr))
-            replacements.append(r_before)
-
-        replacements.append(parse_xml(f'<w:r {ns}><w:fldChar w:fldCharType="begin"/></w:r>'))
-        replacements.append(parse_xml(f'<w:r {ns}><w:instrText xml:space="preserve"> SEQ {_escape_xml(seq_name)} \\* ARABIC </w:instrText></w:r>'))
-        replacements.append(parse_xml(f'<w:r {ns}><w:fldChar w:fldCharType="separate"/></w:r>'))
-        replacements.append(parse_xml(f"<w:r {ns}><w:t>{_escape_xml(number)}</w:t></w:r>"))
-        replacements.append(parse_xml(f'<w:r {ns}><w:fldChar w:fldCharType="end"/></w:r>'))
-
+            replacements.append(_clone_run_with_text(run, before))
+        replacements.extend(_build_seq_field_runs(seq_name, number))
         if after:
-            r_after = parse_xml(f'<w:r {ns}><w:t xml:space="preserve">{_escape_xml(after)}</w:t></w:r>')
-            rpr = run.find("w:rPr", namespaces={"w": SCHEMA})
-            if rpr is not None:
-                r_after.insert(0, deepcopy(rpr))
-            replacements.append(r_after)
+            replacements.append(_clone_run_with_text(run, after))
 
-        # Insert replacements before the original run, then remove it
         for repl in replacements:
             run.addprevious(repl)
         para.remove(run)

--- a/app/DocxReferencesPostProcess.py
+++ b/app/DocxReferencesPostProcess.py
@@ -85,11 +85,11 @@ def _get_max_bookmark_id(body: Any) -> int:
             bm_id = int(bm.get(f"{{{SCHEMA}}}id", "0"))
             max_id = max(max_id, bm_id)
         except ValueError:
-            pass
+            logger.debug("Skipping bookmark with non-integer id: %r", bm.get(f"{{{SCHEMA}}}id"))
     return max_id
 
 
-def _find_and_process_captions(body: Any) -> tuple[list, list]:  # noqa: C901
+def _find_and_process_captions(body: Any) -> tuple[list, list]:  # noqa: C901  # NOSONAR
     """Find all figure and table captions, ensure SEQ fields, add TC fields with bookmarks.
 
     Returns two lists (figure_entries, table_entries) where each entry is
@@ -235,7 +235,7 @@ def _ensure_seq_field(para: Any, seq_name: str) -> None:
     if _has_seq_field(para):
         return
 
-    for run in list(para.findall("w:r", namespaces={"w": SCHEMA})):
+    for run in list(para.findall("w:r", namespaces={"w": SCHEMA})):  # NOSONAR — list() needed: loop body mutates para
         t_el = run.find("w:t", namespaces={"w": SCHEMA})
         if t_el is None or not t_el.text:
             continue

--- a/app/PandocController.py
+++ b/app/PandocController.py
@@ -62,6 +62,7 @@ FILTERS = {
     "html_lists": f"{FILTER_BASE_PATH}/html_lists.lua",
     "html_tables_to_latex": f"{FILTER_BASE_PATH}/html_tables_to_latex.lua",
     "html_captions": f"{FILTER_BASE_PATH}/html_captions.lua",
+    "docx_caption_labels_to_latex": f"{FILTER_BASE_PATH}/docx_caption_labels_to_latex.lua",
 }
 
 # List of allowed pandoc options for security
@@ -79,6 +80,7 @@ ALLOWED_PANDOC_OPTIONS = [
     f"--lua-filter={FILTERS['html_lists']}",
     f"--lua-filter={FILTERS['html_tables_to_latex']}",
     f"--lua-filter={FILTERS['html_captions']}",
+    f"--lua-filter={FILTERS['docx_caption_labels_to_latex']}",
     "--track-changes=all",
     "--reference-doc=",  # Prefix for reference-doc option
     "--pdf-engine=tectonic",
@@ -579,6 +581,9 @@ def _build_pandoc_command(  # noqa: PLR0913
         cmd.append(f"--lua-filter={FILTERS['docx_paragraphs_to_latex']}")
         cmd.append(f"--lua-filter={FILTERS['docx_lists_to_latex']}")
         cmd.append(f"--lua-filter={FILTERS['docx_tables_to_latex']}")
+        # Strip "Table N" / "Figure N" prefix from Caption blocks so LaTeX's
+        # own \caption counter doesn't duplicate the numbering.
+        cmd.append(f"--lua-filter={FILTERS['docx_caption_labels_to_latex']}")
 
     if validated_options:
         cmd.extend(validated_options)

--- a/filters/docx_caption_labels_to_latex.lua
+++ b/filters/docx_caption_labels_to_latex.lua
@@ -5,13 +5,16 @@
 --
 -- When pandoc reads a docx with a Caption-styled paragraph adjacent to a
 -- table, it absorbs the paragraph into the Table's Caption field and
--- emits \caption{...} in LaTeX. This causes two problems:
+-- emits \caption{...} in LaTeX. This causes problems:
 -- 1. LaTeX's \caption counter duplicates the numbering ("Table 1: Table 1 ...")
 -- 2. The caption moves inside the table environment (centered, different style)
+-- 3. Tables without our captions also get \caption from pandoc, causing
+--    counter mismatches across the document
 --
--- This filter extracts the caption content from the Table AST, clears
+-- This filter extracts ALL caption content from the Table AST, clears
 -- the Table's caption, and returns the caption as a regular paragraph
--- before the table — matching the expected PDF layout.
+-- before the table — matching the expected PDF layout where caption
+-- numbering is part of the visible text, not a LaTeX counter.
 --
 -- Only runs for the LaTeX writer (gated in PandocController on
 -- docx → pdf/latex).

--- a/filters/docx_caption_labels_to_latex.lua
+++ b/filters/docx_caption_labels_to_latex.lua
@@ -1,0 +1,47 @@
+-- docx_caption_labels_to_latex.lua
+--
+-- Extract table captions from the Table AST node back into plain
+-- paragraphs when converting docx → LaTeX/PDF.
+--
+-- When pandoc reads a docx with a Caption-styled paragraph adjacent to a
+-- table, it absorbs the paragraph into the Table's Caption field and
+-- emits \caption{...} in LaTeX. This causes two problems:
+-- 1. LaTeX's \caption counter duplicates the numbering ("Table 1: Table 1 ...")
+-- 2. The caption moves inside the table environment (centered, different style)
+--
+-- This filter extracts the caption content from the Table AST, clears
+-- the Table's caption, and returns the caption as a regular paragraph
+-- before the table — matching the expected PDF layout.
+--
+-- Only runs for the LaTeX writer (gated in PandocController on
+-- docx → pdf/latex).
+
+function Table(tbl)
+  if not tbl.caption or not tbl.caption.long or #tbl.caption.long == 0 then
+    return nil
+  end
+
+  -- Collect all inlines from the caption blocks
+  local inlines = {}
+  for _, block in ipairs(tbl.caption.long) do
+    -- Handle Div wrappers (pandoc wraps Caption-styled paragraphs in Div)
+    local source_blocks = block.t == "Div" and block.content or { block }
+    for _, inner in ipairs(source_blocks) do
+      if (inner.t == "Para" or inner.t == "Plain") and inner.content then
+        for _, il in ipairs(inner.content) do
+          inlines[#inlines + 1] = il
+        end
+      end
+    end
+  end
+
+  if #inlines == 0 then
+    return nil
+  end
+
+  -- Clear the table caption
+  tbl.caption = pandoc.Caption()
+
+  -- Return caption as a plain paragraph before the table
+  return { pandoc.Para(inlines), tbl }
+end

--- a/filters/html_captions.lua
+++ b/filters/html_captions.lua
@@ -29,6 +29,30 @@
 local CAPTION_SPAN_CLASS = "polarion-rte-caption"
 local CAPTION_STYLE = "Caption"
 
+-- Escape characters that aren't safe inside an XML element body or attribute.
+local function escape_xml(s)
+  s = s:gsub("&", "&amp;")
+  s = s:gsub("<", "&lt;")
+  s = s:gsub(">", "&gt;")
+  s = s:gsub('"', "&quot;")
+  return s
+end
+
+-- Build OOXML for a Word SEQ field: { SEQ <seq_type> \* ARABIC }.
+-- Uses the complex field form (begin/separate/end) because pandoc can
+-- read it back when converting docx→pdf, whereas fldSimple is lost.
+-- The cached display value between "separate" and "end" is set to
+-- `number_text` so the field shows the correct number before Word
+-- recalculates fields.
+local function seq_field_xml(seq_type, number_text)
+  return '<w:r><w:fldChar w:fldCharType="begin"/></w:r>'
+    .. '<w:r><w:instrText xml:space="preserve"> SEQ '
+    .. escape_xml(seq_type) .. ' \\* ARABIC </w:instrText></w:r>'
+    .. '<w:r><w:fldChar w:fldCharType="separate"/></w:r>'
+    .. '<w:r><w:t>' .. escape_xml(number_text) .. '</w:t></w:r>'
+    .. '<w:r><w:fldChar w:fldCharType="end"/></w:r>'
+end
+
 -- True when `inlines` contains (at any depth) a Span carrying the Polarion
 -- caption class. Recurses into inline containers (Span/Emph/Strong/Link/...);
 -- leaf inlines such as Str expose `.text`, not a `.content` list, so the
@@ -49,17 +73,34 @@ local function contains_caption_span(inlines)
   return false
 end
 
--- Wrap a caption paragraph in a Div that applies the "Caption" style. A
--- custom-style Div adds no extra element to the DOCX — pandoc just stamps the
--- style onto the contained paragraph.
+-- Wrap a caption paragraph in a Div that applies the "Caption" style AND
+-- replace the Polarion caption-counter span with a proper Word SEQ field.
+-- A custom-style Div adds no extra element to the DOCX — pandoc just stamps
+-- the style onto the contained paragraph. The SEQ field lets Word renumber
+-- captions automatically (and makes cross-references resolve correctly).
 local function as_caption(block)
   if not FORMAT:match("docx") then
     return nil
   end
-  if contains_caption_span(block.content) then
-    return pandoc.Div({ block }, pandoc.Attr("", {}, { ["custom-style"] = CAPTION_STYLE }))
+  if not contains_caption_span(block.content) then
+    return nil
   end
-  return nil
+  -- Replace caption-counter spans with SEQ field raw OOXML.
+  local new_block = pandoc.walk_block(block, {
+    Span = function(el)
+      for _, class in ipairs(el.classes) do
+        if class == CAPTION_SPAN_CLASS then
+          local seq_type = el.attributes["sequence"] or el.attributes["data-sequence"]
+          if seq_type then
+            local number_text = pandoc.utils.stringify(el.content)
+            return pandoc.RawInline("openxml", seq_field_xml(seq_type, number_text))
+          end
+          break
+        end
+      end
+    end,
+  })
+  return pandoc.Div({ new_block }, pandoc.Attr("", {}, { ["custom-style"] = CAPTION_STYLE }))
 end
 
 function Para(el)

--- a/filters/inline_styles.lua
+++ b/filters/inline_styles.lua
@@ -425,23 +425,12 @@ walk = function(inlines, props, vert_align)
         end
       end
       if is_caption_span then
-        local seq_type = inline.attributes and (inline.attributes["sequence"] or inline.attributes["data-sequence"])
-        if seq_type then
-          local number_text = pandoc.utils.stringify(inline.content)
-          result[#result + 1] = pandoc.RawInline("openxml",
-            '<w:r><w:fldChar w:fldCharType="begin"/></w:r>'
-            .. '<w:r><w:instrText xml:space="preserve"> SEQ '
-            .. escape_attr(seq_type) .. ' \\* ARABIC </w:instrText></w:r>'
-            .. '<w:r><w:fldChar w:fldCharType="separate"/></w:r>'
-            .. '<w:r><w:t>' .. escape_xml(number_text) .. '</w:t></w:r>'
-            .. '<w:r><w:fldChar w:fldCharType="end"/></w:r>')
-        else
-          -- No sequence attribute — fall through to normal span handling.
-          local style = inline.attributes and inline.attributes.style
-          local p = props
-          if style then p = merge_css(props, parse_style(style)) end
-          append_all(result, walk(inline.content, p, vert_align))
-        end
+        -- Don't consume the caption span here — pass it through unchanged
+        -- so html_captions.lua (which runs after this filter) can still
+        -- detect it and apply the "Caption" paragraph style. The SEQ field
+        -- replacement happens either in html_captions.lua or as a fallback
+        -- in the DOCX post-processor.
+        result[#result + 1] = inline
       else
         -- Nested span: parse its style (if any) on top of inherited props,
         -- then descend with the merged set.

--- a/filters/inline_styles.lua
+++ b/filters/inline_styles.lua
@@ -412,15 +412,44 @@ walk = function(inlines, props, vert_align)
     elseif t == "Subscript" then
       append_all(result, walk(inline.content, props, "subscript"))
     elseif t == "Span" then
-      -- Nested span: parse its style (if any) on top of inherited props,
-      -- then descend with the merged set. `attributes` may be nil when the
-      -- span has no key/value attributes at all, hence the `inline.attributes and ...`
-      -- guard (Lua's `and` short-circuits — if the left side is falsy
-      -- the whole expression is that falsy value, never an indexing error).
-      local style = inline.attributes and inline.attributes.style
-      local p = props
-      if style then p = merge_css(props, parse_style(style)) end
-      append_all(result, walk(inline.content, p, vert_align))
+      -- Check if this is Polarion's caption-counter span. If so, emit a
+      -- proper Word SEQ field instead of plain text so Word can renumber
+      -- captions and resolve cross-references.
+      local is_caption_span = false
+      if inline.classes then
+        for _, cls in ipairs(inline.classes) do
+          if cls == "polarion-rte-caption" then
+            is_caption_span = true
+            break
+          end
+        end
+      end
+      if is_caption_span then
+        local seq_type = inline.attributes and (inline.attributes["sequence"] or inline.attributes["data-sequence"])
+        if seq_type then
+          local number_text = pandoc.utils.stringify(inline.content)
+          result[#result + 1] = pandoc.RawInline("openxml",
+            '<w:r><w:fldChar w:fldCharType="begin"/></w:r>'
+            .. '<w:r><w:instrText xml:space="preserve"> SEQ '
+            .. escape_attr(seq_type) .. ' \\* ARABIC </w:instrText></w:r>'
+            .. '<w:r><w:fldChar w:fldCharType="separate"/></w:r>'
+            .. '<w:r><w:t>' .. escape_xml(number_text) .. '</w:t></w:r>'
+            .. '<w:r><w:fldChar w:fldCharType="end"/></w:r>')
+        else
+          -- No sequence attribute — fall through to normal span handling.
+          local style = inline.attributes and inline.attributes.style
+          local p = props
+          if style then p = merge_css(props, parse_style(style)) end
+          append_all(result, walk(inline.content, p, vert_align))
+        end
+      else
+        -- Nested span: parse its style (if any) on top of inherited props,
+        -- then descend with the merged set.
+        local style = inline.attributes and inline.attributes.style
+        local p = props
+        if style then p = merge_css(props, parse_style(style)) end
+        append_all(result, walk(inline.content, p, vert_align))
+      end
     elseif t == "RawInline" then
       -- Already-OOXML content (e.g. produced by another filter or a previous
       -- pass): pass through verbatim. Format-mismatched RawInlines (latex/html

--- a/tests/test_docx_references_post_process.py
+++ b/tests/test_docx_references_post_process.py
@@ -1,803 +1,286 @@
 import logging
+import re
 from unittest.mock import MagicMock
 
 from docx.document import Document as DocumentObject
 from docx.oxml import parse_xml
+from lxml import etree
 
 from app.DocxReferencesPostProcess import (
     SCHEMA,
-    _add_caption_style_and_tc_field,
-    _create_tc_field_runs,
+    _add_tc_field,
     _create_toc_field,
     _create_tof_field,
     _create_tot_field,
+    _ensure_caption_style,
+    _ensure_seq_field,
     _find_placeholder_paragraphs,
     _get_paragraph_style,
     _get_paragraph_text,
+    _has_seq_field,
+    _is_adjacent_to_table,
     add_table_of_contents_entries,
     enable_auto_update_fields,
 )
 
+_MINIMAL_TBL = f'<w:tbl xmlns:w="{SCHEMA}"><w:tr><w:tc><w:p><w:r><w:t>x</w:t></w:r></w:p></w:tc></w:tr></w:tbl>'
+
+
+# ---- _get_paragraph_text / _get_paragraph_style ----
 
 def test_get_paragraph_text_empty():
-    """Test getting text from an empty paragraph."""
-    para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"/>')
-    result = _get_paragraph_text(para)
-    assert result == ""
-
-
-def test_get_paragraph_text_single_text_element():
-    """Test getting text from a paragraph with a single text element."""
-    para = parse_xml(f'''
-    <w:p xmlns:w="{SCHEMA}">
-        <w:r>
-            <w:t>Hello World</w:t>
-        </w:r>
-    </w:p>
-    ''')
-    result = _get_paragraph_text(para)
-    assert result == "Hello World"
-
-
-def test_get_paragraph_text_multiple_runs():
-    """Test getting text from a paragraph with multiple runs."""
-    para = parse_xml(f'''
-    <w:p xmlns:w="{SCHEMA}">
-        <w:r>
-            <w:t>Hello </w:t>
-        </w:r>
-        <w:r>
-            <w:t>World</w:t>
-        </w:r>
-    </w:p>
-    ''')
-    result = _get_paragraph_text(para)
-    assert result == "Hello World"
-
-
-def test_get_paragraph_text_with_none_text():
-    """Test that None text elements are handled gracefully."""
-    para = parse_xml(f'''
-    <w:p xmlns:w="{SCHEMA}">
-        <w:r>
-            <w:t>Valid</w:t>
-        </w:r>
-        <w:r>
-            <w:t/>
-        </w:r>
-    </w:p>
-    ''')
-    result = _get_paragraph_text(para)
-    assert result == "Valid"
-
-
-def test_get_paragraph_style_with_no_properties():
-    """Test getting style from paragraph without properties."""
-    para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"/>')
-    result = _get_paragraph_style(para)
-    assert result is None
-
-
-def test_get_paragraph_style_with_bodytext():
-    """Test getting BodyText style."""
-    para = parse_xml(f'''
-    <w:p xmlns:w="{SCHEMA}">
-        <w:pPr>
-            <w:pStyle w:val="BodyText"/>
-        </w:pPr>
-    </w:p>
-    ''')
-    result = _get_paragraph_style(para)
-    assert result == "BodyText"
-
-
-def test_create_tc_field_runs_for_figure():
-    """Test creating TC field runs for a figure caption."""
-    caption_text = "Figure 1: Test Caption"
-    runs = _create_tc_field_runs(caption_text, field_flag="F")
-
-    assert len(runs) == 3
-    # Check begin run
-    assert runs[0].find(".//w:fldChar", namespaces={"w": SCHEMA}) is not None
-    # Check instruction run contains caption text
-    instr_text = runs[1].find(".//w:instrText", namespaces={"w": SCHEMA}).text
-    assert caption_text in instr_text
-    assert "\\f F" in instr_text
-    # Check end run
-    assert runs[2].find(".//w:fldChar", namespaces={"w": SCHEMA}) is not None
-
-
-def test_create_tc_field_runs_for_table():
-    """Test creating TC field runs for a table caption."""
-    caption_text = "Table 1: Test Table"
-    runs = _create_tc_field_runs(caption_text, field_flag="T")
-
-    assert len(runs) == 3
-    # Check instruction run contains correct flag
-    instr_text = runs[1].find(".//w:instrText", namespaces={"w": SCHEMA}).text
-    assert caption_text in instr_text
-    assert "\\f T" in instr_text
-
-
-def test_create_tc_field_runs_default_flag():
-    """Test that default field flag is F for figures."""
-    caption_text = "Figure 2"
-    runs = _create_tc_field_runs(caption_text)
-
-    instr_text = runs[1].find(".//w:instrText", namespaces={"w": SCHEMA}).text
-    assert "\\f F" in instr_text
-
-
-def test_add_caption_style_to_paragraph_without_style():
-    """Test adding Caption style to a paragraph that has no style."""
-    para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:r><w:t>Figure 1</w:t></w:r></w:p>')
-    caption_text = "Figure 1"
+    assert _get_paragraph_text(parse_xml(f'<w:p xmlns:w="{SCHEMA}"/>')) == ""
+
+def test_get_paragraph_text_single():
+    assert _get_paragraph_text(parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:r><w:t>Hi</w:t></w:r></w:p>')) == "Hi"
 
-    _add_caption_style_and_tc_field(para, caption_text, field_flag="F")
-
-    # Check that Caption style was added
-    p_style = para.find(".//w:pStyle", namespaces={"w": SCHEMA})
-    assert p_style is not None
-    assert p_style.get(f"{{{SCHEMA}}}val") == "Caption"
-
-    # Check that TC field runs were added
-    fld_chars = para.findall(".//w:fldChar", namespaces={"w": SCHEMA})
-    assert len(fld_chars) == 2  # begin and end
-
-
-def test_add_caption_style_to_paragraph_with_existing_style():
-    """Test adding Caption style to a paragraph that already has a different style."""
-    para = parse_xml(f'''
-    <w:p xmlns:w="{SCHEMA}">
-        <w:pPr>
-            <w:pStyle w:val="Normal"/>
-        </w:pPr>
-        <w:r><w:t>Table 1</w:t></w:r>
-    </w:p>
-    ''')
-    caption_text = "Table 1"
-
-    _add_caption_style_and_tc_field(para, caption_text, field_flag="T")
-
-    # Check that style was changed to Caption
-    p_style = para.find(".//w:pStyle", namespaces={"w": SCHEMA})
-    assert p_style is not None
-    assert p_style.get(f"{{{SCHEMA}}}val") == "Caption"
-
-
-def test_add_caption_style_with_existing_properties():
-    """Test adding Caption style when paragraph already has properties."""
-    para = parse_xml(f'''
-    <w:p xmlns:w="{SCHEMA}">
-        <w:pPr>
-            <w:jc w:val="center"/>
-        </w:pPr>
-        <w:r><w:t>Figure 2</w:t></w:r>
-    </w:p>
-    ''')
-    caption_text = "Figure 2"
-
-    _add_caption_style_and_tc_field(para, caption_text, field_flag="F")
-
-    # Check that Caption style was added while preserving other properties
-    p_style = para.find(".//w:pStyle", namespaces={"w": SCHEMA})
-    assert p_style is not None
-    assert p_style.get(f"{{{SCHEMA}}}val") == "Caption"
-
-    # Check that other properties still exist
-    jc = para.find(".//w:jc", namespaces={"w": SCHEMA})
-    assert jc is not None
-
-
-def test_create_toc_field_returns_list():
-    """Test that _create_toc_field returns a list of paragraphs."""
-    result = _create_toc_field()
-    assert isinstance(result, list)
-    assert len(result) == 2  # TOC paragraph and empty paragraph
-
-
-def test_create_toc_field_structure():
-    """Test that TOC field has correct structure."""
-    paragraphs = _create_toc_field()
-    toc_para = paragraphs[0]
-
-    # Check for field characters
-    fld_chars = toc_para.findall(".//w:fldChar", namespaces={"w": SCHEMA})
-    assert len(fld_chars) == 3  # begin, separate, end
-
-    # Check instruction text
-    instr = toc_para.find(".//w:instrText", namespaces={"w": SCHEMA})
-    assert instr is not None
-    assert "TOC" in instr.text
-    assert '\\o "1-9"' in instr.text  # outline levels 1-9 (supports heading levels > 6)
-    assert "\\h" in instr.text  # hyperlinks
-    assert "\\z" in instr.text  # hide tab leader
-    assert "\\u" in instr.text  # use outline
-
-
-def test_create_toc_field_empty_paragraph():
-    """Test that second paragraph is empty for spacing."""
-    paragraphs = _create_toc_field()
-    empty_para = paragraphs[1]
-
-    # Empty paragraph should have no child elements
-    assert len(empty_para) == 0
-
-
-def test_create_tof_field_returns_list():
-    """Test that _create_tof_field returns a list of paragraphs."""
-    result = _create_tof_field()
-    assert isinstance(result, list)
-    assert len(result) == 2
-
-
-def test_create_tof_field_structure():
-    """Test that Table of Figures field has correct structure."""
-    paragraphs = _create_tof_field()
-    tof_para = paragraphs[0]
-
-    # Check instruction text
-    instr = tof_para.find(".//w:instrText", namespaces={"w": SCHEMA})
-    assert instr is not None
-    assert "TOC" in instr.text
-    assert "\\f F" in instr.text  # figures flag
-    assert "\\h" in instr.text
-    assert "\\z" in instr.text
-
-
-def test_create_tot_field_returns_list():
-    """Test that _create_tot_field returns a list of paragraphs."""
-    result = _create_tot_field()
-    assert isinstance(result, list)
-    assert len(result) == 2
-
-
-def test_create_tot_field_structure():
-    """Test that Table of Tables field has correct structure."""
-    paragraphs = _create_tot_field()
-    tot_para = paragraphs[0]
-
-    # Check instruction text
-    instr = tot_para.find(".//w:instrText", namespaces={"w": SCHEMA})
-    assert instr is not None
-    assert "TOC" in instr.text
-    assert "\\f T" in instr.text  # tables flag
-    assert "\\h" in instr.text
-    assert "\\z" in instr.text
-
-
-def test_find_placeholder_paragraphs_empty_body():
-    """Test finding placeholders in empty document body."""
-    body = parse_xml(f'<w:body xmlns:w="{SCHEMA}"/>')
-    elements_to_replace = []
-    _find_placeholder_paragraphs(body, elements_to_replace)
-    assert len(elements_to_replace) == 0
-
-
-def test_find_placeholder_paragraphs_with_toc_marker():
-    """Test finding TOC_PLACEHOLDER marker."""
-    body = parse_xml(f'''
-    <w:body xmlns:w="{SCHEMA}">
-        <w:p>
-            <w:r><w:t>TOC_PLACEHOLDER</w:t></w:r>
-        </w:p>
-    </w:body>
-    ''')
-    elements_to_replace = []
-    _find_placeholder_paragraphs(body, elements_to_replace)
-
-    assert len(elements_to_replace) == 1
-    idx, element, has_toc, has_tof, has_tot = elements_to_replace[0]
-    assert idx == 0
-    assert has_toc is True
-    assert has_tof is False
-    assert has_tot is False
-
-
-def test_find_placeholder_paragraphs_with_tof_marker():
-    """Test finding TOF_PLACEHOLDER marker."""
-    body = parse_xml(f'''
-    <w:body xmlns:w="{SCHEMA}">
-        <w:p>
-            <w:r><w:t>TOF_PLACEHOLDER</w:t></w:r>
-        </w:p>
-    </w:body>
-    ''')
-    elements_to_replace = []
-    _find_placeholder_paragraphs(body, elements_to_replace)
-
-    assert len(elements_to_replace) == 1
-    idx, element, has_toc, has_tof, has_tot = elements_to_replace[0]
-    assert idx == 0
-    assert has_toc is False
-    assert has_tof is True
-    assert has_tot is False
-
-
-def test_find_placeholder_paragraphs_with_tot_marker():
-    """Test finding TOT_PLACEHOLDER marker."""
-    body = parse_xml(f'''
-    <w:body xmlns:w="{SCHEMA}">
-        <w:p>
-            <w:r><w:t>TOT_PLACEHOLDER</w:t></w:r>
-        </w:p>
-    </w:body>
-    ''')
-    elements_to_replace = []
-    _find_placeholder_paragraphs(body, elements_to_replace)
-
-    assert len(elements_to_replace) == 1
-    idx, element, has_toc, has_tof, has_tot = elements_to_replace[0]
-    assert idx == 0
-    assert has_toc is False
-    assert has_tof is False
-    assert has_tot is True
-
-
-def test_find_placeholder_paragraphs_with_all_three():
-    """Test finding all three placeholder types."""
-    body = parse_xml(f'''
-    <w:body xmlns:w="{SCHEMA}">
-        <w:p>
-            <w:r><w:t>TOC_PLACEHOLDER</w:t></w:r>
-        </w:p>
-        <w:p>
-            <w:r><w:t>TOF_PLACEHOLDER</w:t></w:r>
-        </w:p>
-        <w:p>
-            <w:r><w:t>TOT_PLACEHOLDER</w:t></w:r>
-        </w:p>
-    </w:body>
-    ''')
-    elements_to_replace = []
-    _find_placeholder_paragraphs(body, elements_to_replace)
-
-    assert len(elements_to_replace) == 3
-    # Check TOC
-    assert elements_to_replace[0][2] is True  # has_toc
-    # Check TOF
-    assert elements_to_replace[1][3] is True  # has_tof
-    # Check TOT
-    assert elements_to_replace[2][4] is True  # has_tot
-
-
-def test_find_placeholder_paragraphs_not_found():
-    """Test finding placeholders in document without any."""
-    body = parse_xml(f'''
-    <w:body xmlns:w="{SCHEMA}">
-        <w:p>
-            <w:r><w:t>Regular paragraph</w:t></w:r>
-        </w:p>
-    </w:body>
-    ''')
-    elements_to_replace = []
-    _find_placeholder_paragraphs(body, elements_to_replace)
-    assert len(elements_to_replace) == 0
-
-
-def test_find_placeholder_paragraphs_in_heading_ignored():
-    """Test that placeholders in headings are ignored."""
-    body = parse_xml(f'''
-    <w:body xmlns:w="{SCHEMA}">
-        <w:p>
-            <w:pPr>
-                <w:pStyle w:val="Heading1"/>
-            </w:pPr>
-            <w:r><w:t>TOC_PLACEHOLDER</w:t></w:r>
-        </w:p>
-    </w:body>
-    ''')
-    elements_to_replace = []
-    _find_placeholder_paragraphs(body, elements_to_replace)
-    assert len(elements_to_replace) == 0
-
-
-def test_find_placeholder_paragraphs_in_body_text():
-    """Test finding placeholders in BodyText style."""
-    body = parse_xml(f'''
-    <w:body xmlns:w="{SCHEMA}">
-        <w:p>
-            <w:pPr>
-                <w:pStyle w:val="BodyText"/>
-            </w:pPr>
-            <w:r><w:t>TOC_PLACEHOLDER</w:t></w:r>
-        </w:p>
-    </w:body>
-    ''')
-    elements_to_replace = []
-    _find_placeholder_paragraphs(body, elements_to_replace)
-    assert len(elements_to_replace) == 1
-
-
-def test_enable_auto_update_fields_when_present():
-    """Test enabling auto-update when updateFields setting already exists."""
+def test_get_paragraph_style_none():
+    assert _get_paragraph_style(parse_xml(f'<w:p xmlns:w="{SCHEMA}"/>')) is None
+
+def test_get_paragraph_style_bodytext():
+    assert _get_paragraph_style(parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:pPr><w:pStyle w:val="BodyText"/></w:pPr></w:p>')) == "BodyText"
+
+
+# ---- _ensure_caption_style ----
+
+def test_ensure_caption_style_adds():
+    para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:r><w:t>x</w:t></w:r></w:p>')
+    _ensure_caption_style(para)
+    assert para.find(".//w:pStyle", namespaces={"w": SCHEMA}).get(f"{{{SCHEMA}}}val") == "Caption"
+
+def test_ensure_caption_style_replaces():
+    para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:pPr><w:pStyle w:val="Normal"/></w:pPr></w:p>')
+    _ensure_caption_style(para)
+    assert para.find(".//w:pStyle", namespaces={"w": SCHEMA}).get(f"{{{SCHEMA}}}val") == "Caption"
+
+
+# ---- _is_adjacent_to_table ----
+
+def test_adjacent_to_table_before():
+    body = parse_xml(f'<w:body xmlns:w="{SCHEMA}"><w:p><w:r><w:t>c</w:t></w:r></w:p>{_MINIMAL_TBL}</w:body>')
+    assert _is_adjacent_to_table(body.find("w:p", namespaces={"w": SCHEMA})) is True
+
+def test_after_table_is_not_adjacent():
+    """A paragraph after a table should NOT be classified as table caption."""
+    body = parse_xml(f'<w:body xmlns:w="{SCHEMA}">{_MINIMAL_TBL}<w:p><w:r><w:t>c</w:t></w:r></w:p></w:body>')
+    paras = body.findall("w:p", namespaces={"w": SCHEMA})
+    assert _is_adjacent_to_table(paras[-1]) is False
+
+def test_adjacent_to_table_skips_bookmarks():
+    body = parse_xml(f'''<w:body xmlns:w="{SCHEMA}">
+        <w:p><w:r><w:t>c</w:t></w:r></w:p>
+        <w:bookmarkStart w:id="1" w:name="x"/>
+        {_MINIMAL_TBL}
+        <w:bookmarkEnd w:id="1"/>
+    </w:body>''')
+    assert _is_adjacent_to_table(body.find("w:p", namespaces={"w": SCHEMA})) is True
+
+def test_adjacent_to_table_skips_empty_paras():
+    body = parse_xml(f'<w:body xmlns:w="{SCHEMA}"><w:p><w:r><w:t>c</w:t></w:r></w:p><w:p/>{_MINIMAL_TBL}</w:body>')
+    assert _is_adjacent_to_table(body.find("w:p", namespaces={"w": SCHEMA})) is True
+
+def test_not_adjacent_to_table():
+    body = parse_xml(f'<w:body xmlns:w="{SCHEMA}"><w:p><w:r><w:t>a</w:t></w:r></w:p><w:p><w:r><w:t>b</w:t></w:r></w:p></w:body>')
+    assert _is_adjacent_to_table(body.find("w:p", namespaces={"w": SCHEMA})) is False
+
+
+# ---- _has_seq_field / _ensure_seq_field ----
+
+def test_has_seq_field_true():
+    para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:r><w:instrText> SEQ Table </w:instrText></w:r></w:p>')
+    assert _has_seq_field(para) is True
+
+def test_has_seq_field_false():
+    para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:r><w:t>Table 1</w:t></w:r></w:p>')
+    assert _has_seq_field(para) is False
+
+def test_ensure_seq_field_replaces_plain_number():
+    para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:pPr><w:pStyle w:val="Caption"/></w:pPr><w:r><w:t>Figure 1 Pic</w:t></w:r></w:p>')
+    _ensure_seq_field(para, "Figure")
+    xml = etree.tostring(para, encoding="unicode")
+    assert "SEQ Figure" in xml
+    assert 'fldCharType="begin"' in xml
+    assert re.search(r'separate.*<w:t[^>]*>1</w:t>.*end', xml, re.S)
+    assert "Figure " in xml
+    assert " Pic" in xml
+
+def test_ensure_seq_field_skips_existing():
+    para = parse_xml(f'''<w:p xmlns:w="{SCHEMA}">
+        <w:r><w:fldChar w:fldCharType="begin"/></w:r>
+        <w:r><w:instrText> SEQ Table \\* ARABIC </w:instrText></w:r>
+        <w:r><w:fldChar w:fldCharType="end"/></w:r>
+    </w:p>''')
+    xml_before = etree.tostring(para, encoding="unicode")
+    _ensure_seq_field(para, "Table")
+    assert etree.tostring(para, encoding="unicode") == xml_before
+
+def test_ensure_seq_field_no_number():
+    para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:r><w:t>No number</w:t></w:r></w:p>')
+    xml_before = etree.tostring(para, encoding="unicode")
+    _ensure_seq_field(para, "Table")
+    assert etree.tostring(para, encoding="unicode") == xml_before
+
+
+# ---- _add_tc_field ----
+
+def test_add_tc_field_creates_field_with_bookmark():
+    para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:r><w:t>Table 1</w:t></w:r></w:p>')
+    _add_tc_field(para, "Table 1", "T", 42, "_Toc000000042")
+    xml = etree.tostring(para, encoding="unicode")
+    assert "bookmarkStart" in xml
+    assert "_Toc000000042" in xml
+    assert "\\f T" in xml
+
+
+# ---- TOC/TOF/TOT field creation ----
+
+def test_create_toc_field():
+    paras = _create_toc_field()
+    assert len(paras) == 2
+    instr = paras[0].find(".//w:instrText", namespaces={"w": SCHEMA})
+    assert '\\o "1-9"' in instr.text
+
+def test_create_tof_field():
+    paras = _create_tof_field()
+    instr = paras[0].find(".//w:instrText", namespaces={"w": SCHEMA})
+    assert "\\f F" in instr.text
+
+def test_create_tot_field():
+    paras = _create_tot_field()
+    instr = paras[0].find(".//w:instrText", namespaces={"w": SCHEMA})
+    assert "\\f T" in instr.text
+
+def test_tot_with_entries_has_hyperlinks():
+    entries = [("Table 1", "_Toc1"), ("Table 2", "_Toc2")]
+    xml = "".join(etree.tostring(p, encoding="unicode") for p in _create_tot_field(entries))
+    assert 'w:anchor="_Toc1"' in xml
+    assert 'w:anchor="_Toc2"' in xml
+    assert "PAGEREF" in xml
+
+def test_tof_with_entries():
+    entries = [("Figure 1", "_Toc10")]
+    xml = "".join(etree.tostring(p, encoding="unicode") for p in _create_tof_field(entries))
+    assert 'w:anchor="_Toc10"' in xml
+    assert "\\f F" in xml
+
+
+# ---- placeholder finding ----
+
+def test_find_placeholders_all_three():
+    body = parse_xml(f'''<w:body xmlns:w="{SCHEMA}">
+        <w:p><w:r><w:t>TOC_PLACEHOLDER</w:t></w:r></w:p>
+        <w:p><w:r><w:t>TOF_PLACEHOLDER</w:t></w:r></w:p>
+        <w:p><w:r><w:t>TOT_PLACEHOLDER</w:t></w:r></w:p>
+    </w:body>''')
+    result = []
+    _find_placeholder_paragraphs(body, result)
+    assert len(result) == 3
+
+def test_find_placeholders_ignores_heading():
+    body = parse_xml(f'<w:body xmlns:w="{SCHEMA}"><w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>TOC_PLACEHOLDER</w:t></w:r></w:p></w:body>')
+    result = []
+    _find_placeholder_paragraphs(body, result)
+    assert len(result) == 0
+
+
+# ---- enable_auto_update_fields ----
+
+def test_enable_auto_update_fields():
     mock_doc = MagicMock(spec=DocumentObject)
-    mock_settings = MagicMock()
-    mock_settings_element = MagicMock()
     mock_update_fields = MagicMock()
-    mock_settings_element.find.return_value = mock_update_fields
-    mock_settings.element = mock_settings_element
-    mock_doc.settings = mock_settings
-
+    mock_doc.settings.element.find.return_value = mock_update_fields
     enable_auto_update_fields(mock_doc)
+    mock_update_fields.set.assert_called_once()
 
-    # Verify existing element was updated
-    mock_update_fields.set.assert_called_once_with(f"{{{SCHEMA}}}val", "true")
-
-
-def test_enable_auto_update_fields_handles_exception(caplog):
-    """Test that exceptions are handled gracefully with warning."""
+def test_enable_auto_update_fields_exception(caplog):
     mock_doc = MagicMock(spec=DocumentObject)
-    mock_doc.settings.element.find.side_effect = Exception("Test error")
-
+    mock_doc.settings.element.find.side_effect = Exception("err")
     with caplog.at_level(logging.WARNING):
         enable_auto_update_fields(mock_doc)
-
-    # Verify warning was logged
     assert "Could not enable auto-update fields" in caplog.text
 
 
-def test_add_toc_entries_finds_figure_captions(caplog):
-    """Test that figure captions are found and processed."""
-    mock_doc = MagicMock(spec=DocumentObject)
-    # Captions are identified by the "Caption" style (set upstream by
-    # filters/html_captions.lua from the Polarion caption span), not by text.
-    body = parse_xml(f'''
-    <w:body xmlns:w="{SCHEMA}">
-        <w:p>
-            <w:pPr><w:pStyle w:val="Caption"/></w:pPr>
-            <w:r><w:t>Figure 1: Test figure</w:t></w:r>
-        </w:p>
-        <w:p>
-            <w:pPr><w:pStyle w:val="Caption"/></w:pPr>
-            <w:r><w:t>Figure 2: Another figure</w:t></w:r>
-        </w:p>
-    </w:body>
-    ''')
-    mock_doc.element.body = body
+# ---- Integration: add_table_of_contents_entries ----
 
+def test_figure_captions_found(caplog):
+    mock_doc = MagicMock(spec=DocumentObject)
+    body = parse_xml(f'<w:body xmlns:w="{SCHEMA}"><w:p><w:pPr><w:pStyle w:val="Caption"/></w:pPr><w:r><w:t>Figure 1</w:t></w:r></w:p></w:body>')
+    mock_doc.element.body = body
     with caplog.at_level(logging.INFO):
         add_table_of_contents_entries(mock_doc)
+    assert "Found 1 figure captions" in caplog.text
 
-    # Verify logging indicates figures were found
-    assert "Found 2 figure captions" in caplog.text
-
-
-def test_add_toc_entries_finds_table_captions(caplog):
-    """Test that table captions are found and processed."""
+def test_table_captions_found(caplog):
     mock_doc = MagicMock(spec=DocumentObject)
-    body = parse_xml(f'''
-    <w:body xmlns:w="{SCHEMA}">
-        <w:p>
-            <w:pPr><w:pStyle w:val="Caption"/></w:pPr>
-            <w:r><w:t>Table 1: Test table</w:t></w:r>
-        </w:p>
-    </w:body>
-    ''')
+    body = parse_xml(f'<w:body xmlns:w="{SCHEMA}"><w:p><w:pPr><w:pStyle w:val="Caption"/></w:pPr><w:r><w:t>Table 1</w:t></w:r></w:p>{_MINIMAL_TBL}</w:body>')
     mock_doc.element.body = body
-
     with caplog.at_level(logging.INFO):
         add_table_of_contents_entries(mock_doc)
+    assert "1 table captions" in caplog.text
 
-    # Verify logging indicates tables were found
-    assert "Found 0 figure captions and 1 table captions" in caplog.text
-
-
-def test_paragraphs_that_only_start_with_table_or_figure_are_not_captions(caplog):
-    """Only paragraphs carrying the "Caption" style (set upstream from the
-    Polarion caption span) are captions. A heading ("Table test III"), a
-    cross-reference ("Table 1 shows ...") and a label ("Table 50px") all merely
-    start with the word — and even include a number — but must be left alone."""
+def test_non_caption_paragraphs_ignored(caplog):
     mock_doc = MagicMock(spec=DocumentObject)
-    body = parse_xml(f'''
-    <w:body xmlns:w="{SCHEMA}">
-        <w:p>
-            <w:pPr><w:pStyle w:val="Heading1"/></w:pPr>
-            <w:r><w:t>Table test III</w:t></w:r>
-        </w:p>
-        <w:p>
-            <w:pPr><w:pStyle w:val="BodyText"/></w:pPr>
-            <w:r><w:t>Table 1 shows the results discussed above.</w:t></w:r>
-        </w:p>
-        <w:p>
-            <w:pPr><w:pStyle w:val="BodyText"/></w:pPr>
-            <w:r><w:t>Table 50px</w:t></w:r>
-        </w:p>
-        <w:p>
-            <w:pPr><w:pStyle w:val="Title"/></w:pPr>
-            <w:r><w:t>Figure skating results</w:t></w:r>
-        </w:p>
-    </w:body>
-    ''')
+    body = parse_xml(f'<w:body xmlns:w="{SCHEMA}"><w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>Table 1</w:t></w:r></w:p></w:body>')
     mock_doc.element.body = body
-
     with caplog.at_level(logging.INFO):
         add_table_of_contents_entries(mock_doc)
-
-    # None are captioned...
     assert "Found 0 figure captions and 0 table captions" in caplog.text
-    # ...and every paragraph keeps its original style (nothing downgraded to Caption).
-    styles = [s.get(f"{{{SCHEMA}}}val") for s in body.findall(".//w:pStyle", namespaces={"w": SCHEMA})]
-    assert styles == ["Heading1", "BodyText", "BodyText", "Title"]
 
-
-def test_caption_styled_paragraph_next_to_lookalike_is_detected(caplog):
-    """A genuine caption (marked with the "Caption" style) is processed, while a
-    heading with the same 'Table' prefix sitting next to it is not."""
+def test_captions_get_unique_bookmarks():
     mock_doc = MagicMock(spec=DocumentObject)
-    body = parse_xml(f'''
-    <w:body xmlns:w="{SCHEMA}">
-        <w:p>
-            <w:pPr><w:pStyle w:val="Heading1"/></w:pPr>
-            <w:r><w:t>Table test III</w:t></w:r>
-        </w:p>
-        <w:p>
-            <w:pPr><w:pStyle w:val="Caption"/></w:pPr>
-            <w:r><w:t>Table 1: real caption</w:t></w:r>
-        </w:p>
-    </w:body>
-    ''')
+    body = parse_xml(f'''<w:body xmlns:w="{SCHEMA}">
+        <w:p><w:pPr><w:pStyle w:val="Caption"/></w:pPr><w:r><w:t>Table 1</w:t></w:r></w:p>{_MINIMAL_TBL}
+        <w:p><w:pPr><w:pStyle w:val="Caption"/></w:pPr><w:r><w:t>Table 2</w:t></w:r></w:p>{_MINIMAL_TBL}
+    </w:body>''')
     mock_doc.element.body = body
-
-    with caplog.at_level(logging.INFO):
-        add_table_of_contents_entries(mock_doc)
-
-    assert "Found 0 figure captions and 1 table captions" in caplog.text
-    # The heading keeps Heading1; the caption keeps Caption.
-    styles = [s.get(f"{{{SCHEMA}}}val") for s in body.findall(".//w:pStyle", namespaces={"w": SCHEMA})]
-    assert styles == ["Heading1", "Caption"]
-
-
-def test_pandoc_native_caption_styles_are_detected(caplog):
-    """Non-HTML sources bring pandoc's own caption styles — a markdown/docx
-    table caption is "TableCaption" and a figure caption is "ImageCaption".
-    Both must be found and get TC fields (the counter word need not appear in
-    the text, so classification comes from the style)."""
-    mock_doc = MagicMock(spec=DocumentObject)
-    body = parse_xml(f'''
-    <w:body xmlns:w="{SCHEMA}">
-        <w:p>
-            <w:pPr><w:pStyle w:val="TableCaption"/></w:pPr>
-            <w:r><w:t>Demo table caption</w:t></w:r>
-        </w:p>
-        <w:p>
-            <w:pPr><w:pStyle w:val="ImageCaption"/></w:pPr>
-            <w:r><w:t>Demo figure caption</w:t></w:r>
-        </w:p>
-    </w:body>
-    ''')
-    mock_doc.element.body = body
-
-    with caplog.at_level(logging.INFO):
-        add_table_of_contents_entries(mock_doc)
-
-    assert "Found 1 figure captions and 1 table captions" in caplog.text
-    # Both got TC field runs appended.
-    instr_texts = " ".join(t.text or "" for t in body.iter(f"{{{SCHEMA}}}instrText"))
-    assert instr_texts.count(" TC ") == 2
-    assert "\\f T" in instr_texts  # table caption
-    assert "\\f F" in instr_texts  # figure caption
-
-
-def test_add_toc_entries_inserts_toc_field_with_placeholder(caplog):
-    """Test that TOC field is inserted when TOC_PLACEHOLDER is found."""
-    mock_doc = MagicMock(spec=DocumentObject)
-    body = parse_xml(f'''
-    <w:body xmlns:w="{SCHEMA}">
-        <w:p>
-            <w:r><w:t>TOC_PLACEHOLDER</w:t></w:r>
-        </w:p>
-        <w:p>
-            <w:r><w:t>Content after placeholder</w:t></w:r>
-        </w:p>
-    </w:body>
-    ''')
-    mock_doc.element.body = body
-
-    with caplog.at_level(logging.INFO):
-        add_table_of_contents_entries(mock_doc)
-
-    # Verify TOC was inserted
-    assert "Inserted Table of Contents" in caplog.text
-
-
-def test_add_toc_entries_handles_empty_document():
-    """Test that empty document is handled without errors."""
-    mock_doc = MagicMock(spec=DocumentObject)
-    body = parse_xml(f'<w:body xmlns:w="{SCHEMA}"/>')
-    mock_doc.element.body = body
-
-    # Should not raise any exceptions
     add_table_of_contents_entries(mock_doc)
+    xml = etree.tostring(body, encoding="unicode")
+    bookmarks = re.findall(r'w:name="(_Toc\d+)"', xml)
+    assert len(bookmarks) >= 2
+    assert bookmarks[0] != bookmarks[1]
 
-
-def test_add_toc_entries_processes_both_figures_and_tables(caplog):
-    """Test processing document with both figure and table captions."""
+def test_tot_placeholder_full_workflow():
     mock_doc = MagicMock(spec=DocumentObject)
-    body = parse_xml(f'''
-    <w:body xmlns:w="{SCHEMA}">
-        <w:p>
-            <w:pPr><w:pStyle w:val="Caption"/></w:pPr>
-            <w:r><w:t>Figure 1: Test figure</w:t></w:r>
-        </w:p>
-        <w:p>
-            <w:pPr><w:pStyle w:val="Caption"/></w:pPr>
-            <w:r><w:t>Table 1: Test table</w:t></w:r>
-        </w:p>
-    </w:body>
-    ''')
+    body = parse_xml(f'''<w:body xmlns:w="{SCHEMA}">
+        <w:p><w:pPr><w:pStyle w:val="Caption"/></w:pPr><w:r><w:t>Table 1</w:t></w:r></w:p>{_MINIMAL_TBL}
+        <w:p><w:r><w:t>TOT_PLACEHOLDER</w:t></w:r></w:p>
+    </w:body>''')
     mock_doc.element.body = body
+    add_table_of_contents_entries(mock_doc)
+    xml = etree.tostring(body, encoding="unicode")
+    assert "bookmarkStart" in xml
+    assert "w:hyperlink" in xml
+    assert "PAGEREF" in xml
+    assert "\\f T" in xml
 
-    with caplog.at_level(logging.INFO):
-        add_table_of_contents_entries(mock_doc)
+def test_localized_caption_classified_by_table_adjacency():
+    """Polish 'Tabela 1' next to a table should be classified as table caption."""
+    mock_doc = MagicMock(spec=DocumentObject)
+    body = parse_xml(f'''<w:body xmlns:w="{SCHEMA}">
+        <w:p><w:pPr><w:pStyle w:val="Caption"/></w:pPr>
+            <w:r><w:t xml:space="preserve">Tabela </w:t></w:r>
+            <w:r><w:fldChar w:fldCharType="begin"/></w:r>
+            <w:r><w:instrText xml:space="preserve"> SEQ Tabela \\* ARABIC </w:instrText></w:r>
+            <w:r><w:fldChar w:fldCharType="separate"/></w:r>
+            <w:r><w:t>1</w:t></w:r>
+            <w:r><w:fldChar w:fldCharType="end"/></w:r>
+        </w:p>{_MINIMAL_TBL}
+    </w:body>''')
+    mock_doc.element.body = body
+    add_table_of_contents_entries(mock_doc)
+    xml = etree.tostring(body, encoding="unicode")
+    assert "\\f T" in xml
 
-    # Should process both types
-    assert "Found 1 figure captions and 1 table captions" in caplog.text
-
-
-def test_full_workflow_with_figures_and_toc():
-    """Integration test: document with figures and TOC_PLACEHOLDER."""
+def test_full_workflow_empty():
     from docx import Document
-
-    # Create a real document. Captions are marked with the "Caption" style
-    # upstream (by filters/html_captions.lua); the post-processor keys off it.
     doc = Document()
-    doc.add_paragraph("TOC_PLACEHOLDER")
-    doc.add_paragraph("Figure 1: Test figure caption", style="Caption")
-    doc.add_paragraph("Figure 2: Another figure", style="Caption")
-
-    # Run the function
     add_table_of_contents_entries(doc)
 
-    # Verify the figure captions kept the Caption style and got TC fields.
-    body = doc.element.body
-    paras = body.findall(".//w:p", namespaces={"w": SCHEMA})
-    figure_paras = [p for p in paras if "Figure" in _get_paragraph_text(p)]
-
-    for para in figure_paras:
-        p_style = para.find(".//w:pStyle", namespaces={"w": SCHEMA})
-        assert p_style is not None
-        assert p_style.get(f"{{{SCHEMA}}}val") == "Caption"
-
-
-def test_full_workflow_with_tables_only():
-    """Integration test: document with only table captions."""
+def test_enable_auto_update_real():
     from docx import Document
-
     doc = Document()
-    doc.add_paragraph("Table 1: Test table caption", style="Caption")
-    doc.add_paragraph("Table 2: Another table", style="Caption")
-
-    # Run the function
-    add_table_of_contents_entries(doc)
-
-    # Verify table captions kept the Caption style and got TC fields.
-    body = doc.element.body
-    paras = body.findall(".//w:p", namespaces={"w": SCHEMA})
-    table_paras = [p for p in paras if "Table" in _get_paragraph_text(p)]
-
-    for para in table_paras:
-        p_style = para.find(".//w:pStyle", namespaces={"w": SCHEMA})
-        assert p_style is not None
-        assert p_style.get(f"{{{SCHEMA}}}val") == "Caption"
-
-
-def test_full_workflow_empty_document():
-    """Integration test: empty document should not cause errors."""
-    from docx import Document
-
-    doc = Document()
-
-    # Should not raise any exceptions
-    add_table_of_contents_entries(doc)
-
-
-def test_enable_auto_update_on_real_document():
-    """Integration test: enable auto-update fields on real document."""
-    from docx import Document
-
-    doc = Document()
-    doc.add_paragraph("Test content")
-
-    # Should not raise any exceptions
+    doc.add_paragraph("Test")
     enable_auto_update_fields(doc)
-
-    # Verify updateFields element was added
-    settings_element = doc.settings.element
-    update_fields = settings_element.find(".//w:updateFields", namespaces={"w": SCHEMA})
-    assert update_fields is not None
-    assert update_fields.get(f"{{{SCHEMA}}}val") == "true"
-
-
-def test_caption_text_with_special_characters():
-    """Test that caption text with special characters is handled correctly."""
-    caption_text = "Figure 1: Test - Special (Characters) with [brackets]"
-    runs = _create_tc_field_runs(caption_text, field_flag="F")
-
-    # Verify runs were created without errors
-    assert len(runs) == 3
-    instr_text = runs[1].find(".//w:instrText", namespaces={"w": SCHEMA}).text
-    assert caption_text in instr_text
-
-
-def test_caption_text_with_quotes():
-    """Test that caption text with quotes is handled correctly."""
-    caption_text = "Figure 1: Test with 'single' quotes"
-    runs = _create_tc_field_runs(caption_text, field_flag="F")
-
-    # Verify runs were created without errors
-    assert len(runs) == 3
-    instr_text = runs[1].find(".//w:instrText", namespaces={"w": SCHEMA}).text
-    assert caption_text in instr_text
-
-
-def test_very_long_caption_text():
-    """Test handling of very long caption text."""
-    caption_text = "Figure 1: " + "A" * 1000  # Very long caption
-    runs = _create_tc_field_runs(caption_text, field_flag="F")
-
-    # Should create runs without errors
-    assert len(runs) == 3
-
-
-def test_caption_starting_with_whitespace():
-    """Test captions with leading/trailing whitespace."""
-    mock_doc = MagicMock(spec=DocumentObject)
-    body = parse_xml(f'''
-    <w:body xmlns:w="{SCHEMA}">
-        <w:p>
-            <w:r><w:t>  Figure 1: Test  </w:t></w:r>
-        </w:p>
-    </w:body>
-    ''')
-    mock_doc.element.body = body
-
-    # Should still find the caption after strip()
-    add_table_of_contents_entries(mock_doc)
-
-
-def test_figure_and_table_with_same_number():
-    """Test handling when figure and table have same number."""
-    mock_doc = MagicMock(spec=DocumentObject)
-    body = parse_xml(f'''
-    <w:body xmlns:w="{SCHEMA}">
-        <w:p>
-            <w:r><w:t>Figure 1: Test figure</w:t></w:r>
-        </w:p>
-        <w:p>
-            <w:r><w:t>Table 1: Test table</w:t></w:r>
-        </w:p>
-    </w:body>
-    ''')
-    mock_doc.element.body = body
-
-    # Should handle both without confusion
-    add_table_of_contents_entries(mock_doc)
-
-
-def test_all_three_placeholders_together():
-    """Test document with all three placeholder types."""
-    mock_doc = MagicMock(spec=DocumentObject)
-    body = parse_xml(f'''
-    <w:body xmlns:w="{SCHEMA}">
-        <w:p>
-            <w:r><w:t>TOC_PLACEHOLDER</w:t></w:r>
-        </w:p>
-        <w:p>
-            <w:r><w:t>TOF_PLACEHOLDER</w:t></w:r>
-        </w:p>
-        <w:p>
-            <w:r><w:t>TOT_PLACEHOLDER</w:t></w:r>
-        </w:p>
-        <w:p>
-            <w:r><w:t>Figure 1: Test</w:t></w:r>
-        </w:p>
-        <w:p>
-            <w:r><w:t>Table 1: Test</w:t></w:r>
-        </w:p>
-    </w:body>
-    ''')
-    mock_doc.element.body = body
-
-    # Should handle all three placeholders
-    add_table_of_contents_entries(mock_doc)
+    uf = doc.settings.element.find(".//w:updateFields", namespaces={"w": SCHEMA})
+    assert uf is not None
+    assert uf.get(f"{{{SCHEMA}}}val") == "true"

--- a/tests/test_html_captions_filter.py
+++ b/tests/test_html_captions_filter.py
@@ -81,6 +81,39 @@ def test_only_the_caption_is_marked_among_lookalikes():
     assert styles["Table overview"] != "Caption"
 
 
+def _document_xml(body: str) -> str:
+    """Run pandoc with the caption filter and return raw document.xml."""
+    html = f"<html><head><title>t</title></head><body>{body}</body></html>"
+    completed = subprocess.run(  # noqa: S603
+        [_PANDOC, "-f", "html", "-t", "docx", "--lua-filter", _FILTER, "-o", "-"],
+        input=html.encode(),
+        capture_output=True,
+        check=True,
+    )
+    return zipfile.ZipFile(io.BytesIO(completed.stdout)).read("word/document.xml").decode()
+
+
+def test_table_caption_contains_seq_field():
+    """Caption number must be wrapped in a SEQ Table field, not plain text."""
+    xml = _document_xml(_CAPTION_P)
+    assert 'SEQ Table' in xml
+    assert 'w:fldChar' in xml
+
+
+def test_figure_caption_contains_seq_field():
+    """Figure caption number must use SEQ Figure field."""
+    xml = _document_xml(_FIGURE_CAPTION_P)
+    assert 'SEQ Figure' in xml
+    assert 'w:fldChar' in xml
+
+
+def test_seq_field_has_cached_number():
+    """The SEQ field should contain the original number as cached display value."""
+    xml = _document_xml(_CAPTION_P)
+    # Between fldChar separate and end there should be a <w:t>1</w:t>
+    assert re.search(r'fldCharType="separate".*?<w:t[^>]*>1</w:t>.*?fldCharType="end"', xml, re.S)
+
+
 def test_non_docx_target_is_untouched():
     """The filter only acts for the docx writer (defensive FORMAT gate)."""
     html = f"<html><body>{_CAPTION_P}</body></html>"


### PR DESCRIPTION
…d TOF/TOT

Refs: #199

### Proposed changes

Replace plain-text caption numbers with Word SEQ fields and pre-fill existing captions to enable automatic numbering and consistent cross-references.                                                                                                                                                                                                                                                                                                                                                                                                        
                                                                


### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
