### PR TITLE
fix: preserve images and links in styled tables, fix table width over…

### DIFF
--- a/app/DocxPostProcess.py
+++ b/app/DocxPostProcess.py
@@ -430,45 +430,49 @@ def _process_table(table: Table, parent_columns_count: int, max_width: int, layo
                 _process_table(sub_table, columns_count, max_width, layout_iter)
 
 
-def _apply_table_layout(tbl: Any, table_properties: Any, layout: TableLayout | None, max_width: int = 0) -> None:
-    """Write width, alignment and indent onto a table's <w:tblPr>.
+def _clamp_twips(width_twips: int, max_width_emu: int) -> int:
+    """Clamp a width in twips to the available page width (given in EMU)."""
+    if max_width_emu <= 0:
+        return width_twips
+    max_twips = max_width_emu // 635
+    if width_twips > max_twips:
+        logger.debug(f"Clamped table width from {width_twips} to {max_twips} twips")
+        return max_twips
+    return width_twips
 
-    Default (no layout, or a layout carrying no width): 100 % width with
-    autofit layout — the historical behaviour that keeps every existing table
-    filling the text column. A percentage width keeps autofit (Word renders the
-    table at that fraction of the text column). An absolute width switches to
-    fixed layout and rescales the column grid so Word honours the exact size.
-    Alignment (<w:jc>) and left indent (<w:tblInd>) are applied when present.
-    """
-    # Width: pct keeps autofit; dxa needs fixed layout + a rescaled grid.
-    # When no HtmlTableLayout is available, check whether the Lua filter
-    # (preserve_table_styles) already set a fixed width — if so, keep it.
-    if layout is not None and layout.width_type is not None and layout.width_value is not None:
-        width_type, width_value = layout.width_type, layout.width_value
-        use_fixed_layout = width_type == "dxa"
-        # Clamp absolute width to page width to prevent overflow
-        if use_fixed_layout and max_width > 0:
-            max_width_twips = max_width // 635
-            if width_value > max_width_twips:
-                logger.debug(f"Clamped HtmlTableLayout width from {width_value} to {max_width_twips} twips")
-                width_value = max_width_twips
-        if use_fixed_layout:
-            _rescale_table_grid(tbl, width_value)
-    elif _has_existing_fixed_width(table_properties):
-        # Lua filter already set a dxa width + fixed layout.
-        # Clamp to page width if it overflows.
-        # max_width is in EMU; tblW is in twips (dxa). 1 twip = 635 EMU.
-        if max_width > 0:
-            max_width_twips = max_width // 635
-            tbl_w = table_properties.find("w:tblW", namespaces={"w": SCHEMA})
-            current = int(tbl_w.get(f"{{{SCHEMA}}}w", "0"))
-            if current > max_width_twips:
-                tbl_w.set(f"{{{SCHEMA}}}w", str(max_width_twips))
-                _rescale_table_grid(tbl, max_width_twips)
-                logger.debug(f"Clamped table width from {current} to {max_width_twips} twips")
+
+def _clamp_existing_fixed_width(tbl: Any, table_properties: Any, max_width: int) -> None:
+    """Clamp a Lua-filter-set dxa width to the page width if it overflows."""
+    if max_width <= 0:
         return
-    else:
-        width_type, width_value, use_fixed_layout = "pct", 5000, False
+    tbl_w = table_properties.find("w:tblW", namespaces={"w": SCHEMA})
+    current = int(tbl_w.get(f"{{{SCHEMA}}}w", "0"))
+    clamped = _clamp_twips(current, max_width)
+    if clamped < current:
+        tbl_w.set(f"{{{SCHEMA}}}w", str(clamped))
+        _rescale_table_grid(tbl, clamped)
+
+
+def _resolve_layout_width(layout: TableLayout | None) -> tuple[str, int, bool]:
+    """Extract width parameters from an HtmlTableLayout, or return defaults."""
+    if layout is not None and layout.width_type is not None and layout.width_value is not None:
+        return layout.width_type, layout.width_value, layout.width_type == "dxa"
+    return "pct", 5000, False
+
+
+def _apply_table_layout(tbl: Any, table_properties: Any, layout: TableLayout | None, max_width: int = 0) -> None:
+    """Write width, alignment and indent onto a table's <w:tblPr>."""
+    has_layout = layout is not None and layout.width_type is not None and layout.width_value is not None
+
+    if not has_layout and _has_existing_fixed_width(table_properties):
+        _clamp_existing_fixed_width(tbl, table_properties, max_width)
+        return
+
+    width_type, width_value, use_fixed_layout = _resolve_layout_width(layout)
+
+    if use_fixed_layout:
+        width_value = _clamp_twips(width_value, max_width)
+        _rescale_table_grid(tbl, width_value)
 
     _set_tblpr_child(table_properties, parse_xml(f'<w:tblW {nsdecls("w")} w:w="{width_value}" w:type="{width_type}"/>'))
 

--- a/app/DocxPostProcess.py
+++ b/app/DocxPostProcess.py
@@ -109,6 +109,7 @@ def _replace_image_placeholders(doc: DocumentObject) -> None:
     text placeholder and this function resolves it using python-docx.
     """
     body = doc.element.body
+    doc_pr_id = max((int(dp.get("id", "0")) for dp in body.iter("{http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing}docPr")), default=0)
     for t_el in body.findall(f".//{{{SCHEMA}}}t"):
         if t_el.text is None:
             continue
@@ -131,18 +132,19 @@ def _replace_image_placeholders(doc: DocumentObject) -> None:
             r_id, img = doc.part.get_or_add_image(io.BytesIO(image_bytes))
             width = img.px_width * EMU_1_INCH // 96  # px to EMU at 96 dpi
             height = img.px_height * EMU_1_INCH // 96
+            doc_pr_id += 1
 
             # Build the drawing XML
             drawing_xml = (
                 f'<w:drawing {nsdecls("w", "wp", "a", "pic", "r")}>'
                 f'<wp:inline distT="0" distB="0" distL="0" distR="0">'
                 f'<wp:extent cx="{width}" cy="{height}"/>'
-                f'<wp:docPr id="1" name="Image"/>'
+                f'<wp:docPr id="{doc_pr_id}" name="Image"/>'
                 f"<a:graphic>"
                 f'<a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">'
                 f"<pic:pic>"
                 f"<pic:nvPicPr>"
-                f'<pic:cNvPr id="0" name="Image"/>'
+                f'<pic:cNvPr id="{doc_pr_id}" name="Image"/>'
                 f"<pic:cNvPicPr/>"
                 f"</pic:nvPicPr>"
                 f"<pic:blipFill>"
@@ -183,7 +185,10 @@ def _resolve_image_src(src: str) -> bytes | None:
             try:
                 return base64.b64decode(match.group(1))
             except Exception:
+                logger.warning("Failed to decode base64 image data")
                 return None
+    if src:
+        logger.warning("Unsupported image src scheme (only data: URIs are supported): %s", src[:80])
     return None
 
 

--- a/app/DocxPostProcess.py
+++ b/app/DocxPostProcess.py
@@ -1,5 +1,7 @@
+import base64
 import io
 import logging
+import re
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -83,11 +85,134 @@ def process(docx_bytes: bytes, paper_size: str | None = None, orientation: str |
     _replace_size_and_orientation(doc, paper_size, orientation)
     _replace_table_properties(doc, table_layouts)
     apply_math_colors(doc)
+    _replace_image_placeholders(doc)
+    _replace_link_placeholders(doc)
     add_table_of_contents_entries(doc)
     enable_auto_update_fields(doc)
     out = io.BytesIO()
     doc.save(out)
     return out.getvalue()
+
+
+_IMG_PLACEHOLDER_RE = re.compile(r"\{\{IMG:(.*?)\}\}")
+_HREF_PLACEHOLDER_RE = re.compile(r"\{\{HREF:(.*?)\}\}")
+
+RELATIONSHIPS_SCHEMA = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"  # NOSONAR
+
+
+def _replace_image_placeholders(doc: DocumentObject) -> None:
+    """Replace ``{{IMG:<src>}}`` placeholders with real embedded images.
+
+    The ``inline_styles.lua`` filter emits these markers when it rebuilds a
+    styled table as raw OOXML. Images can't be embedded in raw OOXML (they
+    need writer-level relationship entries), so the Lua filter writes a
+    text placeholder and this function resolves it using python-docx.
+    """
+    body = doc.element.body
+    for t_el in body.findall(f".//{{{SCHEMA}}}t"):
+        if t_el.text is None:
+            continue
+        match = _IMG_PLACEHOLDER_RE.search(t_el.text)
+        if not match:
+            continue
+
+        src = match.group(1)
+        run_el = t_el.getparent()
+        if run_el is None or not run_el.tag.endswith("}r"):
+            continue
+
+        image_bytes = _resolve_image_src(src)
+        if image_bytes is None:
+            # Can't resolve — leave the placeholder text as alt-text fallback
+            t_el.text = t_el.text.replace(match.group(0), "[image]")
+            continue
+
+        try:
+            r_id, img = doc.part.get_or_add_image(io.BytesIO(image_bytes))
+            width = img.px_width * EMU_1_INCH // 96  # px to EMU at 96 dpi
+            height = img.px_height * EMU_1_INCH // 96
+
+            # Build the drawing XML
+            drawing_xml = (
+                f'<w:drawing {nsdecls("w", "wp", "a", "pic", "r")}>'
+                f'<wp:inline distT="0" distB="0" distL="0" distR="0">'
+                f'<wp:extent cx="{width}" cy="{height}"/>'
+                f'<wp:docPr id="1" name="Image"/>'
+                f"<a:graphic>"
+                f'<a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">'
+                f"<pic:pic>"
+                f"<pic:nvPicPr>"
+                f'<pic:cNvPr id="0" name="Image"/>'
+                f"<pic:cNvPicPr/>"
+                f"</pic:nvPicPr>"
+                f"<pic:blipFill>"
+                f'<a:blip r:embed="{r_id}"/>'
+                f"<a:stretch><a:fillRect/></a:stretch>"
+                f"</pic:blipFill>"
+                f"<pic:spPr>"
+                f"<a:xfrm>"
+                f'<a:off x="0" y="0"/>'
+                f'<a:ext cx="{width}" cy="{height}"/>'
+                f"</a:xfrm>"
+                f'<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>'
+                f"</pic:spPr>"
+                f"</pic:pic>"
+                f"</a:graphicData>"
+                f"</a:graphic>"
+                f"</wp:inline>"
+                f"</w:drawing>"
+            )
+            drawing_el = parse_xml(drawing_xml)
+
+            # Replace the text run with the drawing
+            run_el.remove(t_el)
+            run_el.append(drawing_el)
+
+            logger.debug(f"Replaced image placeholder with embedded image ({img.px_width}x{img.px_height})")
+        except Exception as e:
+            logger.warning(f"Could not embed image from placeholder: {e}")
+            t_el.text = t_el.text.replace(match.group(0), "[image]")
+
+
+def _resolve_image_src(src: str) -> bytes | None:
+    """Resolve an image src to bytes. Supports data: URIs."""
+    if src.startswith("data:"):
+        # data:image/gif;base64,AAAA...
+        match = re.match(r"data:[^;]+;base64,(.*)", src)
+        if match:
+            try:
+                return base64.b64decode(match.group(1))
+            except Exception:
+                return None
+    return None
+
+
+def _replace_link_placeholders(doc: DocumentObject) -> None:
+    """Replace ``{{HREF:<url>}}`` placeholders in hyperlink tooltips with real relationships.
+
+    The ``inline_styles.lua`` filter emits ``<w:hyperlink w:tooltip="{{HREF:url}}">``
+    when it rebuilds styled tables as raw OOXML. This function registers the
+    URL as a hyperlink relationship and sets the correct ``r:id``.
+    """
+    ns_w = f"{{{SCHEMA}}}"
+    ns_r = f"{{{RELATIONSHIPS_SCHEMA}}}"
+    body = doc.element.body
+
+    for hyperlink in body.findall(f".//{ns_w}hyperlink"):
+        tooltip = hyperlink.get(f"{ns_w}tooltip", "")
+        match = _HREF_PLACEHOLDER_RE.search(tooltip)
+        if not match:
+            continue
+
+        url = match.group(1)
+        try:
+            r_id = doc.part.relate_to(url, "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink", is_external=True)  # NOSONAR
+            hyperlink.set(f"{ns_r}id", r_id)
+            hyperlink.attrib.pop(f"{ns_w}tooltip", None)
+            logger.debug(f"Resolved hyperlink placeholder to {url} (r:id={r_id})")
+        except Exception as e:
+            logger.warning(f"Could not resolve hyperlink placeholder: {e}")
+            hyperlink.attrib.pop(f"{ns_w}tooltip", None)
 
 
 def _replace_first_paragraph_styles(doc: DocumentObject) -> None:
@@ -290,7 +415,7 @@ def _process_table(table: Table, parent_columns_count: int, max_width: int, layo
         table_properties = parse_xml(f"<w:tblPr {nsdecls('w')}/>")
         tbl.insert(0, table_properties)
 
-    _apply_table_layout(tbl, table_properties, layout)
+    _apply_table_layout(tbl, table_properties, layout, max_width)
 
     # Process nested tables
     for row in table.rows:
@@ -300,7 +425,7 @@ def _process_table(table: Table, parent_columns_count: int, max_width: int, layo
                 _process_table(sub_table, columns_count, max_width, layout_iter)
 
 
-def _apply_table_layout(tbl: Any, table_properties: Any, layout: TableLayout | None) -> None:
+def _apply_table_layout(tbl: Any, table_properties: Any, layout: TableLayout | None, max_width: int = 0) -> None:
     """Write width, alignment and indent onto a table's <w:tblPr>.
 
     Default (no layout, or a layout carrying no width): 100 % width with
@@ -311,12 +436,34 @@ def _apply_table_layout(tbl: Any, table_properties: Any, layout: TableLayout | N
     Alignment (<w:jc>) and left indent (<w:tblInd>) are applied when present.
     """
     # Width: pct keeps autofit; dxa needs fixed layout + a rescaled grid.
-    width_type, width_value, use_fixed_layout = "pct", 5000, False
+    # When no HtmlTableLayout is available, check whether the Lua filter
+    # (preserve_table_styles) already set a fixed width — if so, keep it.
     if layout is not None and layout.width_type is not None and layout.width_value is not None:
         width_type, width_value = layout.width_type, layout.width_value
         use_fixed_layout = width_type == "dxa"
+        # Clamp absolute width to page width to prevent overflow
+        if use_fixed_layout and max_width > 0:
+            max_width_twips = max_width // 635
+            if width_value > max_width_twips:
+                logger.debug(f"Clamped HtmlTableLayout width from {width_value} to {max_width_twips} twips")
+                width_value = max_width_twips
         if use_fixed_layout:
             _rescale_table_grid(tbl, width_value)
+    elif _has_existing_fixed_width(table_properties):
+        # Lua filter already set a dxa width + fixed layout.
+        # Clamp to page width if it overflows.
+        # max_width is in EMU; tblW is in twips (dxa). 1 twip = 635 EMU.
+        if max_width > 0:
+            max_width_twips = max_width // 635
+            tbl_w = table_properties.find("w:tblW", namespaces={"w": SCHEMA})
+            current = int(tbl_w.get(f"{{{SCHEMA}}}w", "0"))
+            if current > max_width_twips:
+                tbl_w.set(f"{{{SCHEMA}}}w", str(max_width_twips))
+                _rescale_table_grid(tbl, max_width_twips)
+                logger.debug(f"Clamped table width from {current} to {max_width_twips} twips")
+        return
+    else:
+        width_type, width_value, use_fixed_layout = "pct", 5000, False
 
     _set_tblpr_child(table_properties, parse_xml(f'<w:tblW {nsdecls("w")} w:w="{width_value}" w:type="{width_type}"/>'))
 
@@ -328,6 +475,15 @@ def _apply_table_layout(tbl: Any, table_properties: Any, layout: TableLayout | N
 
     if layout is not None and layout.indent_twips is not None:
         _set_tblpr_child(table_properties, parse_xml(f'<w:tblInd {nsdecls("w")} w:w="{layout.indent_twips}" w:type="dxa"/>'))
+
+
+def _has_existing_fixed_width(table_properties: Any) -> bool:
+    """Return True if the table already has a fixed (dxa) width from the Lua filter."""
+    tbl_w = table_properties.find("w:tblW", namespaces={"w": SCHEMA})
+    if tbl_w is not None and tbl_w.get(f"{{{SCHEMA}}}type") == "dxa":
+        w = tbl_w.get(f"{{{SCHEMA}}}w", "0")
+        return int(w) > 0
+    return False
 
 
 def _set_tblpr_child(table_properties: Any, new_child: Any) -> None:

--- a/filters/inline_styles.lua
+++ b/filters/inline_styles.lua
@@ -425,12 +425,23 @@ walk = function(inlines, props, vert_align)
         end
       end
       if is_caption_span then
-        -- Don't consume the caption span here — pass it through unchanged
-        -- so html_captions.lua (which runs after this filter) can still
-        -- detect it and apply the "Caption" paragraph style. The SEQ field
-        -- replacement happens either in html_captions.lua or as a fallback
-        -- in the DOCX post-processor.
-        result[#result + 1] = inline
+        -- Emit the SEQ field as raw OOXML so inlines_to_openxml succeeds
+        -- and build_para_w_p can apply paragraph alignment. The Caption
+        -- style is added by contains_caption_span() in build_para_w_p,
+        -- and as a fallback by html_captions.lua for non-aligned captions.
+        local seq_type = inline.attributes and (inline.attributes["sequence"] or inline.attributes["data-sequence"])
+        if seq_type then
+          local number_text = pandoc.utils.stringify(inline.content)
+          result[#result + 1] = pandoc.RawInline("openxml",
+            '<w:r><w:fldChar w:fldCharType="begin"/></w:r>'
+            .. '<w:r><w:instrText xml:space="preserve"> SEQ '
+            .. escape_attr(seq_type) .. ' \\* ARABIC </w:instrText></w:r>'
+            .. '<w:r><w:fldChar w:fldCharType="separate"/></w:r>'
+            .. '<w:r><w:t>' .. escape_xml(number_text) .. '</w:t></w:r>'
+            .. '<w:r><w:fldChar w:fldCharType="end"/></w:r>')
+        else
+          result[#result + 1] = inline
+        end
       else
         -- Nested span: parse its style (if any) on top of inherited props,
         -- then descend with the merged set.
@@ -897,14 +908,45 @@ local function block_to_ooxml(block, jc_val)
     for _, r in ipairs(runs) do
       if r.t == "RawInline" and r.format == "openxml" then
         run_parts[#run_parts + 1] = r.text
+      elseif r.t == "Image" and r.src and r.src ~= "" then
+        -- Images need writer-level relationship handling. Emit a
+        -- placeholder for the Python post-processor.
+        run_parts[#run_parts + 1] = "<w:r><w:t xml:space=\"preserve\">"
+          .. "{{IMG:" .. escape_xml(r.src) .. "}}"
+          .. "</w:t></w:r>"
+      elseif r.t == "Link" then
+        -- Links need writer-level .rels entries for the hyperlink target.
+        -- Emit a <w:hyperlink> with a placeholder tooltip that encodes the
+        -- URL. The Python post-processor registers the real relationship.
+        -- Walk the link content, then replace rPr with just Hyperlink rStyle
+        -- so the link renders blue/underlined. Inline CSS colors would
+        -- override the Hyperlink style, so we strip them.
+        local link_inlines = walk(r.content, {}, nil)
+        local link_runs = {}
+        for _, lr in ipairs(link_inlines) do
+          if lr.t == "RawInline" and lr.format == "openxml" then
+            -- Replace any existing <w:rPr>...</w:rPr> with just Hyperlink rStyle
+            local text = lr.text
+            text = text:gsub("<w:rPr>.-</w:rPr>", '<w:rPr><w:rStyle w:val="Hyperlink"/></w:rPr>')
+            if not text:find("w:rPr") then
+              text = text:gsub("<w:r>", '<w:r><w:rPr><w:rStyle w:val="Hyperlink"/></w:rPr>')
+            end
+            link_runs[#link_runs + 1] = text
+          elseif lr.t == "Image" and lr.src and lr.src ~= "" then
+            link_runs[#link_runs + 1] = "<w:r><w:t xml:space=\"preserve\">"
+              .. "{{IMG:" .. escape_xml(lr.src) .. "}}"
+              .. "</w:t></w:r>"
+          else
+            link_runs[#link_runs + 1] = '<w:r><w:rPr><w:rStyle w:val="Hyperlink"/></w:rPr>'
+              .. '<w:t xml:space="preserve">'
+              .. escape_xml(pandoc.utils.stringify(lr)) .. "</w:t></w:r>"
+          end
+        end
+        run_parts[#run_parts + 1] = '<w:hyperlink w:tooltip="{{HREF:'
+          .. escape_attr(r.target) .. '}}">'
+          .. table.concat(link_runs) .. "</w:hyperlink>"
       else
-        -- Known limitation: Link and Image nodes returned by walk() are not
-        -- RawInline("openxml") — they need writer-level relationship handling
-        -- that raw OOXML can't reproduce. Links lose their hyperlink target
-        -- (text is preserved) and Images are reduced to alt-text. Nested
-        -- tables and lists also hit this path. This is acceptable for the
-        -- opt-in table-style feature; the alternative would be to fall back
-        -- the entire table to the default writer, losing all cell styling.
+        -- Nested tables, lists, etc. — fall back to plain text.
         run_parts[#run_parts + 1] = "<w:r><w:t xml:space=\"preserve\">"
           .. escape_xml(pandoc.utils.stringify(r))
           .. "</w:t></w:r>"
@@ -932,6 +974,7 @@ local function cell_blocks_to_ooxml(blocks, jc_val)
   return table.concat(paras)
 end
 
+-- Check if any cell in a list of Rows carries a style attribute.
 -- Check if any cell in a list of Rows carries a style attribute.
 local function rows_have_styles(rows)
   for _, row in ipairs(rows) do
@@ -1043,12 +1086,33 @@ function filter.Table(tbl)
   local xml = {}
   xml[#xml + 1] = "<w:tbl>"
 
-  -- Table properties: 100 % width, autofit layout, default single-line
-  -- borders matching Pandoc's default DOCX writer output. Without these,
-  -- tables that only set background-color (no per-cell border) would
-  -- render with no gridlines at all.
+  -- Determine table width from the HTML style attribute.
+  -- - Percentage (e.g. "100%") → pct (fiftieths of a percent, so 100% = 5000)
+  -- - Pixel value (e.g. "738px") → dxa (twips, 1px ≈ 15 twips at 96 dpi)
+  -- - No width / unrecognised → default to 100 % (5000 pct)
+  local tbl_style = tbl.attr and tbl.attr.attributes and tbl.attr.attributes.style
+  local tbl_w_val = "5000"
+  local tbl_w_type = "pct"
+  local tbl_total_twips = nil  -- set when we know a fixed width in twips
+
+  if tbl_style then
+    local pct = tbl_style:match("width:%s*(%d+)%%")
+    local px = tbl_style:match("width:%s*(%d+)px")
+    if pct then
+      tbl_w_val = tostring(math.floor(tonumber(pct) * 50))
+      tbl_w_type = "pct"
+    elseif px then
+      tbl_total_twips = math.floor(tonumber(px) * 15)  -- 1px ≈ 15 twips
+      tbl_w_val = tostring(tbl_total_twips)
+      tbl_w_type = "dxa"
+    end
+  end
+
+  -- Table properties with default single-line borders matching Pandoc's
+  -- default DOCX writer output. Without these, tables that only set
+  -- background-color (no per-cell border) render with no gridlines.
   xml[#xml + 1] = "<w:tblPr>"
-  xml[#xml + 1] = '<w:tblW w:w="5000" w:type="pct"/>'
+  xml[#xml + 1] = '<w:tblW w:w="' .. tbl_w_val .. '" w:type="' .. tbl_w_type .. '"/>'
   xml[#xml + 1] = "<w:tblBorders>"
   xml[#xml + 1] = '<w:top w:val="single" w:sz="4" w:space="0" w:color="000000"/>'
   xml[#xml + 1] = '<w:left w:val="single" w:sz="4" w:space="0" w:color="000000"/>'
@@ -1057,12 +1121,26 @@ function filter.Table(tbl)
   xml[#xml + 1] = '<w:insideH w:val="single" w:sz="4" w:space="0" w:color="000000"/>'
   xml[#xml + 1] = '<w:insideV w:val="single" w:sz="4" w:space="0" w:color="000000"/>'
   xml[#xml + 1] = "</w:tblBorders>"
-  xml[#xml + 1] = '<w:tblLayout w:type="autofit"/>'
+  if tbl_total_twips then
+    xml[#xml + 1] = '<w:tblLayout w:type="fixed"/>'
+  else
+    xml[#xml + 1] = '<w:tblLayout w:type="autofit"/>'
+  end
   xml[#xml + 1] = "</w:tblPr>"
 
-  -- Grid columns (widths left to autofit).
+  -- Grid columns. When colspecs provide fractional widths, use them;
+  -- otherwise distribute the total width evenly across columns.
   xml[#xml + 1] = "<w:tblGrid>"
-  for _ = 1, num_cols do xml[#xml + 1] = "<w:gridCol/>" end
+  for i = 1, num_cols do
+    local cw = tbl.colspecs[i] and tbl.colspecs[i][2]
+    if cw and tbl_total_twips then
+      xml[#xml + 1] = '<w:gridCol w:w="' .. math.floor(cw * tbl_total_twips) .. '"/>'
+    elseif tbl_total_twips then
+      xml[#xml + 1] = '<w:gridCol w:w="' .. math.floor(tbl_total_twips / num_cols) .. '"/>'
+    else
+      xml[#xml + 1] = "<w:gridCol/>"
+    end
+  end
   xml[#xml + 1] = "</w:tblGrid>"
 
   -- Rows

--- a/filters/inline_styles.lua
+++ b/filters/inline_styles.lua
@@ -925,12 +925,12 @@ local function block_to_ooxml(block, jc_val)
         local link_runs = {}
         for _, lr in ipairs(link_inlines) do
           if lr.t == "RawInline" and lr.format == "openxml" then
-            -- Replace any existing <w:rPr>...</w:rPr> with just Hyperlink rStyle
+            -- Replace existing <w:rPr> with Hyperlink rStyle, and add rPr
+            -- to bare <w:r> runs that don't have one (a single lr.text may
+            -- contain multiple <w:r> elements).
             local text = lr.text
             text = text:gsub("<w:rPr>.-</w:rPr>", '<w:rPr><w:rStyle w:val="Hyperlink"/></w:rPr>')
-            if not text:find("w:rPr") then
-              text = text:gsub("<w:r>", '<w:r><w:rPr><w:rStyle w:val="Hyperlink"/></w:rPr>')
-            end
+            text = text:gsub("<w:r>(<w:t)", '<w:r><w:rPr><w:rStyle w:val="Hyperlink"/></w:rPr>%1')
             link_runs[#link_runs + 1] = text
           elseif lr.t == "Image" and lr.src and lr.src ~= "" then
             link_runs[#link_runs + 1] = "<w:r><w:t xml:space=\"preserve\">"
@@ -974,7 +974,6 @@ local function cell_blocks_to_ooxml(blocks, jc_val)
   return table.concat(paras)
 end
 
--- Check if any cell in a list of Rows carries a style attribute.
 -- Check if any cell in a list of Rows carries a style attribute.
 local function rows_have_styles(rows)
   for _, row in ipairs(rows) do

--- a/tests/test_docx_post_process.py
+++ b/tests/test_docx_post_process.py
@@ -7,7 +7,15 @@ from docx.table import Table, _Cell
 from lxml import etree
 
 from app import DocxPostProcess
-from app.DocxPostProcess import SCHEMA, _process_table, _replace_table_properties
+from app.DocxPostProcess import (
+    SCHEMA,
+    _has_existing_fixed_width,
+    _process_table,
+    _replace_image_placeholders,
+    _replace_link_placeholders,
+    _replace_table_properties,
+    _resolve_image_src,
+)
 
 WORD_PROCESSING_ML_MAIN_SCHEMA = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
 WORD_PROCESSING_ML_MAIN_SCHEMA_IN_BRACKETS = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
@@ -1426,3 +1434,248 @@ class TestReplaceFirstParagraphStyles:
                 if val == "BodyText":
                     first_paragraph_replaced = True
         assert first_paragraph_replaced, "Expected at least one paragraph to be replaced with BodyText"
+
+
+# ---- _resolve_image_src ----
+
+
+def test_resolve_image_src_data_uri():
+    """data: URI with base64-encoded 1x1 GIF should return bytes."""
+    gif_b64 = "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+    result = _resolve_image_src(f"data:image/gif;base64,{gif_b64}")
+    assert result is not None
+    assert result[:3] == b"GIF"
+
+
+def test_resolve_image_src_invalid_base64():
+    """data: URI with invalid base64 should return None."""
+    assert _resolve_image_src("data:image/png;base64,!!!invalid!!!") is None
+
+
+def test_resolve_image_src_http_unsupported():
+    """http:// URIs are not supported and should return None."""
+    assert _resolve_image_src("http://example.com/img.png") is None
+
+
+def test_resolve_image_src_empty():
+    """Empty string should return None."""
+    assert _resolve_image_src("") is None
+
+
+# ---- _replace_image_placeholders ----
+
+
+def test_replace_image_placeholder_with_data_uri():
+    """Image placeholder with data: URI should be replaced with w:drawing."""
+    from docx import Document
+
+    gif_b64 = "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+    doc = Document()
+    p = doc.add_paragraph(f"{{{{IMG:data:image/gif;base64,{gif_b64}}}}}")
+
+    _replace_image_placeholders(doc)
+
+    body_xml = etree.tostring(doc.element.body, encoding="unicode")
+    assert "w:drawing" in body_xml
+    assert "{{IMG:" not in body_xml
+
+
+def test_replace_image_placeholder_unsupported_src():
+    """Unsupported image src should be replaced with [image] text."""
+    from docx import Document
+
+    doc = Document()
+    doc.add_paragraph("{{IMG:http://example.com/img.png}}")
+
+    _replace_image_placeholders(doc)
+
+    body_xml = etree.tostring(doc.element.body, encoding="unicode")
+    assert "[image]" in body_xml
+    assert "{{IMG:" not in body_xml
+
+
+def test_replace_image_placeholder_unique_ids():
+    """Multiple image placeholders should get unique docPr IDs."""
+    from docx import Document
+
+    gif_b64 = "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+    doc = Document()
+    doc.add_paragraph(f"{{{{IMG:data:image/gif;base64,{gif_b64}}}}}")
+    doc.add_paragraph(f"{{{{IMG:data:image/gif;base64,{gif_b64}}}}}")
+
+    _replace_image_placeholders(doc)
+
+    body_xml = etree.tostring(doc.element.body, encoding="unicode")
+    import re
+
+    ids = re.findall(r'docPr id="(\d+)"', body_xml)
+    assert len(ids) >= 2
+    assert ids[0] != ids[1]
+
+
+# ---- _replace_link_placeholders ----
+
+
+def test_replace_link_placeholder():
+    """HREF placeholder in hyperlink tooltip should be replaced with real r:id."""
+    from docx import Document
+    from docx.oxml import parse_xml
+    from docx.oxml.ns import nsdecls
+
+    doc = Document()
+    body = doc.element.body
+    p = parse_xml(
+        f'<w:p {nsdecls("w")}>'
+        f'<w:hyperlink w:tooltip="{{{{HREF:http://example.com}}}}">'
+        f"<w:r><w:t>click</w:t></w:r>"
+        f"</w:hyperlink>"
+        f"</w:p>"
+    )
+    body.append(p)
+
+    _replace_link_placeholders(doc)
+
+    body_xml = etree.tostring(body, encoding="unicode")
+    assert "{{HREF:" not in body_xml
+    # r:id should be set on the hyperlink
+    ns_r = "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}"
+    hyperlink = body.find(f".//{{{SCHEMA}}}hyperlink")
+    assert hyperlink is not None
+    assert hyperlink.get(f"{ns_r}id") is not None
+
+
+def test_replace_link_placeholder_no_match():
+    """Hyperlink without HREF placeholder should not be modified."""
+    from docx import Document
+    from docx.oxml import parse_xml
+    from docx.oxml.ns import nsdecls
+
+    doc = Document()
+    body = doc.element.body
+    p = parse_xml(
+        f'<w:p {nsdecls("w")}>'
+        f'<w:hyperlink w:tooltip="Normal tooltip">'
+        f"<w:r><w:t>click</w:t></w:r>"
+        f"</w:hyperlink>"
+        f"</w:p>"
+    )
+    body.append(p)
+
+    _replace_link_placeholders(doc)
+
+    hyperlink = body.find(f".//{{{SCHEMA}}}hyperlink")
+    assert hyperlink.get(f"{{{SCHEMA}}}tooltip") == "Normal tooltip"
+
+
+# ---- _has_existing_fixed_width ----
+
+
+def test_has_existing_fixed_width_true():
+    """tblPr with tblW type=dxa and positive width should return True."""
+    from docx.oxml import parse_xml
+    from docx.oxml.ns import nsdecls
+
+    tblPr = parse_xml(f'<w:tblPr {nsdecls("w")}><w:tblW w:w="5000" w:type="dxa"/></w:tblPr>')
+    assert _has_existing_fixed_width(tblPr) is True
+
+
+def test_has_existing_fixed_width_pct():
+    """tblPr with tblW type=pct should return False."""
+    from docx.oxml import parse_xml
+    from docx.oxml.ns import nsdecls
+
+    tblPr = parse_xml(f'<w:tblPr {nsdecls("w")}><w:tblW w:w="5000" w:type="pct"/></w:tblPr>')
+    assert _has_existing_fixed_width(tblPr) is False
+
+
+def test_has_existing_fixed_width_zero():
+    """tblPr with tblW type=dxa but w=0 should return False."""
+    from docx.oxml import parse_xml
+    from docx.oxml.ns import nsdecls
+
+    tblPr = parse_xml(f'<w:tblPr {nsdecls("w")}><w:tblW w:w="0" w:type="dxa"/></w:tblPr>')
+    assert _has_existing_fixed_width(tblPr) is False
+
+
+def test_has_existing_fixed_width_missing():
+    """tblPr without tblW should return False."""
+    from docx.oxml import parse_xml
+    from docx.oxml.ns import nsdecls
+
+    tblPr = parse_xml(f'<w:tblPr {nsdecls("w")}/>')
+    assert _has_existing_fixed_width(tblPr) is False
+
+
+# ---- table width clamping ----
+
+
+def test_apply_table_layout_clamps_dxa_to_page_width():
+    """Fixed dxa width from HtmlTableLayout should be clamped to page width."""
+    from docx.oxml import parse_xml
+    from docx.oxml.ns import nsdecls
+
+    from app.DocxPostProcess import _apply_table_layout
+
+    tbl = parse_xml(
+        f'<w:tbl {nsdecls("w")}>'
+        f"<w:tblPr/>"
+        f"<w:tblGrid><w:gridCol w:w=\"5000\"/><w:gridCol w:w=\"5000\"/></w:tblGrid>"
+        f"</w:tbl>"
+    )
+    tblPr = tbl.find(f"{{{SCHEMA}}}tblPr")
+
+    layout = MagicMock()
+    layout.width_type = "dxa"
+    layout.width_value = 11070  # 738px, wider than page
+    layout.jc = None
+    layout.indent_twips = None
+
+    # max_width in EMU: 9360 twips * 635 = ~5943600
+    _apply_table_layout(tbl, tblPr, layout, max_width=5943600)
+
+    tblW = tblPr.find(f"{{{SCHEMA}}}tblW")
+    assert tblW is not None
+    actual_width = int(tblW.get(f"{{{SCHEMA}}}w"))
+    assert actual_width <= 9360  # clamped to page width
+
+
+def test_apply_table_layout_preserves_lua_fixed_width():
+    """Lua filter fixed width that fits should not be changed."""
+    from docx.oxml import parse_xml
+    from docx.oxml.ns import nsdecls
+
+    from app.DocxPostProcess import _apply_table_layout
+
+    tbl = parse_xml(
+        f'<w:tbl {nsdecls("w")}>'
+        f'<w:tblPr><w:tblW w:w="5000" w:type="dxa"/><w:tblLayout w:type="fixed"/></w:tblPr>'
+        f"<w:tblGrid><w:gridCol w:w=\"2500\"/><w:gridCol w:w=\"2500\"/></w:tblGrid>"
+        f"</w:tbl>"
+    )
+    tblPr = tbl.find(f"{{{SCHEMA}}}tblPr")
+
+    _apply_table_layout(tbl, tblPr, None, max_width=5943600)
+
+    tblW = tblPr.find(f"{{{SCHEMA}}}tblW")
+    assert int(tblW.get(f"{{{SCHEMA}}}w")) == 5000  # unchanged
+
+
+def test_apply_table_layout_clamps_lua_fixed_width():
+    """Lua filter fixed width that overflows should be clamped."""
+    from docx.oxml import parse_xml
+    from docx.oxml.ns import nsdecls
+
+    from app.DocxPostProcess import _apply_table_layout
+
+    tbl = parse_xml(
+        f'<w:tbl {nsdecls("w")}>'
+        f'<w:tblPr><w:tblW w:w="11070" w:type="dxa"/><w:tblLayout w:type="fixed"/></w:tblPr>'
+        f"<w:tblGrid><w:gridCol w:w=\"5535\"/><w:gridCol w:w=\"5535\"/></w:tblGrid>"
+        f"</w:tbl>"
+    )
+    tblPr = tbl.find(f"{{{SCHEMA}}}tblPr")
+
+    _apply_table_layout(tbl, tblPr, None, max_width=5943600)
+
+    tblW = tblPr.find(f"{{{SCHEMA}}}tblW")
+    assert int(tblW.get(f"{{{SCHEMA}}}w")) <= 9360

--- a/tests/test_docx_post_process.py
+++ b/tests/test_docx_post_process.py
@@ -1471,7 +1471,7 @@ def test_replace_image_placeholder_with_data_uri():
 
     gif_b64 = "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
     doc = Document()
-    p = doc.add_paragraph(f"{{{{IMG:data:image/gif;base64,{gif_b64}}}}}")
+    doc.add_paragraph(f"{{{{IMG:data:image/gif;base64,{gif_b64}}}}}")
 
     _replace_image_placeholders(doc)
 


### PR DESCRIPTION
…flow

Refs: #201

### Proposed changes

  - Preserve images inside styled table cells when preserve_table_styles is enabled — Lua filter emits {{IMG:...}} placeholders, post-processor replaces them with real <w:drawing> elements                                                                                                                                                                                                                                                                                       
  - Preserve hyperlinks in styled table cells — Lua filter emits <w:hyperlink> with {{HREF:...}} placeholder, post-processor registers the relationship
  - Hyperlinks in styled table cells render with Hyperlink style (blue, underlined)                                                                                                                                                                                                                                                                                                                                                                                                
  - Tables with fixed pixel width (e.g. width: 738px) are clamped to available page width to prevent overflow beyond page margins                                                                                                                                                                                                                                                                                                                                                  
  - Table captions extracted from Table AST in docx→pdf to prevent LaTeX \caption numbering duplication 

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
