### PR TITLE
refactor: unify docx references post-processing style

### DIFF
--- a/app/DocxReferencesPostProcess.py
+++ b/app/DocxReferencesPostProcess.py
@@ -16,16 +16,49 @@ SCHEMA = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"  # NOSON
 XPATH_P_PR = ".//w:pPr"
 XPATH_P_STYLE = ".//w:pStyle"
 
-# Paragraph style id that marks a genuine caption. filters/html_captions.lua
-# sets it on paragraphs that carry Polarion's <span data-sequence=...> caption
-# counter. Non-HTML inputs bring their own caption styles: pandoc emits
-# "TableCaption"/"ImageCaption" for markdown/docx table & figure captions, and
+# Word paragraph style applied to (and marking) caption paragraphs.
+CAPTION_STYLE = "Caption"
+
+# Caption styles pandoc's own writers emit for markdown/docx table & figure captions.
+TABLE_CAPTION_STYLE = "TableCaption"
+IMAGE_CAPTION_STYLE = "ImageCaption"
+
+# Paragraph style ids that mark a genuine caption. filters/html_captions.lua
+# sets CAPTION_STYLE on paragraphs that carry Polarion's <span data-sequence=...>
+# caption counter. Non-HTML inputs bring their own caption styles: pandoc emits
+# TableCaption/ImageCaption for markdown/docx table & figure captions, and
 # Word uses "Caption". Keying off this set of caption STYLES — rather than "does
 # the text start with Table/Figure" — captures real captions from every source
 # while still excluding headings ("Table test III"), cross-references
 # ("Table 1 shows ...") and labels ("Table 50px"), which never carry a caption
 # style.
-CAPTION_STYLE_IDS = frozenset({"Caption", "TableCaption", "ImageCaption"})
+CAPTION_STYLE_IDS = frozenset({CAPTION_STYLE, TABLE_CAPTION_STYLE, IMAGE_CAPTION_STYLE})
+
+# Placeholder paragraph texts the HTML producer (docx-exporter) emits for the
+# ToC (table of contents), ToF (table of figures) and ToT (table of tables)
+# macros.
+TOC_PLACEHOLDER = "TOC_PLACEHOLDER"
+TOF_PLACEHOLDER = "TOF_PLACEHOLDER"
+TOT_PLACEHOLDER = "TOT_PLACEHOLDER"
+
+# Placeholder kinds (parsed from the placeholder texts above)
+KIND_TOC = "toc"
+KIND_TOF = "tof"
+KIND_TOT = "tot"
+
+# Paragraph styles a placeholder paragraph may carry; placeholders inside
+# titles/headings are ignored
+PLACEHOLDER_PARAGRAPH_STYLES = ("BodyText", "FirstParagraph", None)
+
+# Caption sequence identifiers assigned when a caption does not already carry
+# one (standard Polarion sequences)
+FIGURE_SEQUENCE = "Figure"
+TABLE_SEQUENCE = "Table"
+
+# Word field instruction codes for all generated fields
+TOC_FIELD_CODE = 'TOC \\o "1-9" \\h \\z \\u'
+TOF_FIELD_CODE = "TOC \\h \\z \\f F"
+TOT_FIELD_CODE = "TOC \\h \\z \\f T"
 
 logger = logging.getLogger(__name__)
 
@@ -114,15 +147,15 @@ def _find_and_process_captions(body: Any) -> tuple[list, list]:  # noqa: C901  #
         #    (Polarion would not set a table sequence on a figure).
         # 3. Fall back to structural adjacency: if the next content element
         #    is a <w:tbl>, it's a table caption; otherwise figure.
-        if style == "ImageCaption":
+        if style == IMAGE_CAPTION_STYLE:
             is_figure = True
-        elif style == "TableCaption" or _is_adjacent_to_table(para):
+        elif style == TABLE_CAPTION_STYLE or _is_adjacent_to_table(para):
             is_figure = False
         else:
             # No table nearby — check if an existing SEQ name hints at table
             existing_seq = _get_seq_name(para)
-            is_figure = existing_seq is None or existing_seq == "Figure"
-        seq_name = "Figure" if is_figure else "Table"
+            is_figure = existing_seq is None or existing_seq == FIGURE_SEQUENCE
+        seq_name = FIGURE_SEQUENCE if is_figure else TABLE_SEQUENCE
 
         # Ensure the caption number is a SEQ field (not plain text).
         _ensure_seq_field(para, seq_name)
@@ -130,7 +163,7 @@ def _find_and_process_captions(body: Any) -> tuple[list, list]:  # noqa: C901  #
         text_stripped = _get_paragraph_text(para).strip()
 
         # Ensure Caption style is set
-        _ensure_caption_style(para)
+        _set_paragraph_style(para, CAPTION_STYLE)
 
         # Assign a unique bookmark for this caption's TC field
         bookmark_id += 1
@@ -262,19 +295,19 @@ def _ensure_seq_field(para: Any, seq_name: str) -> None:
         return
 
 
-def _ensure_caption_style(para: Any) -> None:
-    """Ensure the paragraph has the Caption style set."""
+def _set_paragraph_style(para: Any, style_name: str) -> None:
+    """Set (or replace) the paragraph style, creating pPr when missing."""
     p_pr = para.find(XPATH_P_PR, namespaces={"w": SCHEMA})
     if p_pr is None:
-        p_pr = parse_xml(f'<w:pPr {nsdecls("w")}><w:pStyle w:val="Caption"/></w:pPr>')
+        p_pr = parse_xml(f'<w:pPr {nsdecls("w")}><w:pStyle w:val="{style_name}"/></w:pPr>')
         para.insert(0, p_pr)
+        return
+    p_style = p_pr.find(XPATH_P_STYLE, namespaces={"w": SCHEMA})
+    if p_style is None:
+        p_style = parse_xml(f'<w:pStyle {nsdecls("w")} w:val="{style_name}"/>')
+        p_pr.insert(0, p_style)
     else:
-        p_style = p_pr.find(XPATH_P_STYLE, namespaces={"w": SCHEMA})
-        if p_style is None:
-            p_style = parse_xml(f'<w:pStyle {nsdecls("w")} w:val="Caption"/>')
-            p_pr.insert(0, p_style)
-        else:
-            p_style.set(f"{{{SCHEMA}}}val", "Caption")
+        p_style.set(f"{{{SCHEMA}}}val", style_name)
 
 
 def _add_tc_field(para: Any, caption_text: str, field_flag: str, bookmark_id: int, bookmark_name: str) -> None:
@@ -303,58 +336,65 @@ def _find_elements_to_replace(body: Any) -> list:
     return elements_to_replace
 
 
+def _parse_placeholder(text: str) -> str | None:
+    """Map a placeholder paragraph text to its kind (KIND_TOC / KIND_TOF /
+    KIND_TOT), or None when the text is not a placeholder."""
+    return {
+        TOC_PLACEHOLDER: KIND_TOC,
+        TOF_PLACEHOLDER: KIND_TOF,
+        TOT_PLACEHOLDER: KIND_TOT,
+    }.get(text)
+
+
 def _find_placeholder_paragraphs(body: Any, elements_to_replace: list) -> None:
-    """Find TOC_PLACEHOLDER, TOF_PLACEHOLDER, and TOT_PLACEHOLDER paragraphs."""
+    """Find TOC/TOF/TOT placeholder paragraphs."""
     for idx, element in enumerate(body):
         if element.tag.endswith("}p"):
             text = _get_paragraph_text(element).strip()
             style = _get_paragraph_style(element)
 
-            if style not in ["BodyText", "FirstParagraph", None]:
+            # Only process placeholders in body text paragraphs, not in titles or headings
+            if style not in PLACEHOLDER_PARAGRAPH_STYLES:
                 continue
 
-            if text == "TOC_PLACEHOLDER":
-                elements_to_replace.append((idx, element, True, False, False))
-                logger.info(f"Found TOC_PLACEHOLDER at index {idx}, will replace with TOC field")
-            elif text == "TOF_PLACEHOLDER":
-                elements_to_replace.append((idx, element, False, True, False))
-                logger.info(f"Found TOF_PLACEHOLDER at index {idx}, will replace with TOF field")
-            elif text == "TOT_PLACEHOLDER":
-                elements_to_replace.append((idx, element, False, False, True))
-                logger.info(f"Found TOT_PLACEHOLDER at index {idx}, will replace with TOT field")
+            kind = _parse_placeholder(text)
+            if kind is not None:
+                elements_to_replace.append((idx, element, kind))
+                logger.info(f"Found {text} at index {idx}, will replace with a {kind} field")
 
 
 def _replace_elements_with_fields(body: Any, elements_to_replace: list, figure_paragraphs: list, table_paragraphs: list) -> None:
     """Replace found elements with Word field codes."""
-    for idx, element, has_toc, has_figure_links, has_table_links in sorted(elements_to_replace, key=lambda x: x[0], reverse=True):
-        if element is not None:
-            body.remove(element)
-            logger.debug(f"Removed element at index {idx}")
+    # Sort by index in reverse order to maintain correct positions during removal
+    for idx, element, kind in sorted(elements_to_replace, key=lambda x: x[0], reverse=True):
+        body.remove(element)
+        logger.debug(f"Removed element at index {idx}")
 
-        _insert_field_at_position(body, idx, has_toc, has_figure_links, has_table_links, figure_paragraphs, table_paragraphs)
+        _insert_field_at_position(body, idx, kind, figure_paragraphs, table_paragraphs)
 
 
-def _insert_field_at_position(body: Any, idx: int, has_toc: bool, has_figure_links: bool, has_table_links: bool, figure_paragraphs: list, table_paragraphs: list) -> None:  # noqa: PLR0913
-    """Insert appropriate Word fields at the specified position."""
-    if has_toc:
-        toc_paragraphs = _create_toc_field()
-        for toc_para in reversed(toc_paragraphs):
-            body.insert(idx, toc_para)
+def _insert_field_at_position(body: Any, idx: int, kind: str, figure_paragraphs: list, table_paragraphs: list) -> None:
+    """Insert the Word field for one placeholder at the specified position.
+
+    A table of figures/tables with no entries is skipped entirely (the
+    placeholder is still removed by the caller)."""
+    if kind == KIND_TOC:
+        _insert_paragraphs(body, idx, _create_toc_field())
         logger.info(f"Inserted Table of Contents at index {idx}")
-
-    if has_figure_links and figure_paragraphs:
+    elif kind == KIND_TOF and figure_paragraphs:
         figure_entries = [(text, bm) for _, text, bm in figure_paragraphs]
-        tof_paragraphs = _create_tof_field(figure_entries)
-        for tof_para in reversed(tof_paragraphs):
-            body.insert(idx, tof_para)
+        _insert_paragraphs(body, idx, _create_tof_field(figure_entries))
         logger.info(f"Inserted Table of Figures at index {idx}")
-
-    if has_table_links and table_paragraphs:
+    elif kind == KIND_TOT and table_paragraphs:
         table_entries = [(text, bm) for _, text, bm in table_paragraphs]
-        tot_paragraphs = _create_tot_field(table_entries)
-        for tot_para in reversed(tot_paragraphs):
-            body.insert(idx, tot_para)
+        _insert_paragraphs(body, idx, _create_tot_field(table_entries))
         logger.info(f"Inserted Table of Tables at index {idx}")
+
+
+def _insert_paragraphs(body: Any, idx: int, paragraphs: list[Any]) -> None:
+    """Insert paragraphs at the given body position, preserving their order."""
+    for para in reversed(paragraphs):
+        body.insert(idx, para)
 
 
 def _create_field(field_code: str) -> list[Any]:
@@ -421,23 +461,24 @@ def _hyperlink_xml(caption_text: str, bookmark_name: str) -> str:
 
 def _create_toc_field() -> list[Any]:
     """Create Table of Contents field paragraphs."""
-    return _create_field('TOC \\o "1-9" \\h \\z \\u')
+    return _create_field(TOC_FIELD_CODE)
+
+
+def _create_listing_field(field_code: str, entries: list[tuple[str, str]] | None) -> list[Any]:
+    """Create a table-of listing field, pre-filled when entries are given."""
+    if entries:
+        return _create_field_with_entries(field_code, entries)
+    return _create_field(field_code)
 
 
 def _create_tof_field(entries: list[tuple[str, str]] | None = None) -> list[Any]:
     """Create Table of Figures field paragraphs using TOC \\f F."""
-    field_code = "TOC \\h \\z \\f F"
-    if entries:
-        return _create_field_with_entries(field_code, entries)
-    return _create_field(field_code)
+    return _create_listing_field(TOF_FIELD_CODE, entries)
 
 
 def _create_tot_field(entries: list[tuple[str, str]] | None = None) -> list[Any]:
     """Create Table of Tables field paragraphs using TOC \\f T."""
-    field_code = "TOC \\h \\z \\f T"
-    if entries:
-        return _create_field_with_entries(field_code, entries)
-    return _create_field(field_code)
+    return _create_listing_field(TOT_FIELD_CODE, entries)
 
 
 def _get_paragraph_text(para: Any) -> str:

--- a/tests/test_caption_references_integration.py
+++ b/tests/test_caption_references_integration.py
@@ -1,0 +1,100 @@
+"""End-to-end integration tests for the caption pipeline with a localized
+caption sequence.
+
+Polarion caption sequences are arbitrary names — a German instance emits
+``<span data-sequence="Tabelle" ...>`` and the paragraph label reads
+"Tabelle 1 ...", which does NOT start with "Table". The old text-prefix
+heuristic silently produced an empty Table of Tables for such documents.
+The current pipeline (filters/html_captions.lua marks captions by the
+Polarion caption span; DocxReferencesPostProcess keys on the Caption style)
+must handle them like any other caption.
+
+These tests run the whole chain through the service container and assert on
+the final document.xml.
+"""
+
+import zipfile
+from io import BytesIO
+from xml.etree import ElementTree as ET
+
+from tests.test_container import TestParameters
+
+W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+
+
+def _convert_html_to_docx(test_parameters: TestParameters, html: str) -> bytes:
+    url = f"{test_parameters.base_url}/convert/html/to/docx"
+    response = test_parameters.request_session.post(url, data=html)
+    if response.status_code // 100 != 2:
+        raise AssertionError(f"pandoc-service returned {response.status_code}:\n{response.text}")
+    return response.content
+
+
+def _document_xml(test_parameters: TestParameters, html: str) -> ET.Element:
+    docx_bytes = _convert_html_to_docx(test_parameters, html)
+    with zipfile.ZipFile(BytesIO(docx_bytes)) as zf:
+        return ET.fromstring(zf.read("word/document.xml"))
+
+
+def _instr_texts(doc: ET.Element) -> list[str]:
+    return [i.text or "" for i in doc.iter(f"{{{W_NS}}}instrText")]
+
+
+def _paragraph_text(p: ET.Element) -> str:
+    return "".join(t.text or "" for t in p.iter(f"{{{W_NS}}}t"))
+
+
+def _paragraphs_with_text(doc: ET.Element, needle: str) -> list[ET.Element]:
+    found = [p for p in doc.iter(f"{{{W_NS}}}p") if needle in _paragraph_text(p)]
+    if not found:
+        raise AssertionError(f"no <w:p> contained {needle!r}")
+    return found
+
+
+def _style_of(p: ET.Element) -> str | None:
+    p_style = p.find(f".//{{{W_NS}}}pStyle")
+    return p_style.get(f"{{{W_NS}}}val") if p_style is not None else None
+
+
+_TABELLE_DOC = (
+    "<p>TOT_PLACEHOLDER</p>"
+    "<p>Table 3 shows the false-positive scenario.</p>"
+    '<p class="polarion-rte-caption-paragraph" style="text-align: left;">'
+    'Tabelle <span data-sequence="Tabelle" class="polarion-rte-caption">1</span> -- erste Tabelle</p>'
+    "<table><tr><td>A</td><td>B</td></tr></table>"
+    '<p class="polarion-rte-caption-paragraph" style="text-align: left;">'
+    'Tabelle <span data-sequence="Tabelle" class="polarion-rte-caption">2</span> -- zweite Tabelle</p>'
+    "<table><tr><td>C</td><td>D</td></tr></table>"
+)
+
+
+def test_localized_sequence_captions_end_up_in_table_of_tables(test_parameters: TestParameters):
+    """German "Tabelle" captions get SEQ fields (keeping their own sequence
+    identifier) and are listed in the pre-filled Table of Tables."""
+    doc = _document_xml(test_parameters, _TABELLE_DOC)
+    instr = _instr_texts(doc)
+
+    # Caption numbers became SEQ fields with the Polarion sequence identifier
+    assert sum("SEQ Tabelle" in t for t in instr) == 2, f"expected 2 SEQ Tabelle fields, instructions: {instr!r}"
+
+    # The ToT placeholder became a TOC \f T field with pre-filled entries
+    assert any("TOC \\h \\z \\f T" in t for t in instr), "TOT placeholder was not replaced with a TOC field"
+    assert sum("PAGEREF" in t for t in instr) == 2, "pre-filled ToT entries (PAGEREF hyperlinks) missing"
+    assert "TOT_PLACEHOLDER" not in "".join(_paragraph_text(p) for p in doc.iter(f"{{{W_NS}}}p"))
+
+    # Caption paragraphs carry the Caption style. The caption text also
+    # appears in the pre-filled ToT list (styled TOC1), so look for the
+    # Caption-styled occurrence among all matches.
+    for needle in ("erste Tabelle", "zweite Tabelle"):
+        styles = [_style_of(p) for p in _paragraphs_with_text(doc, needle)]
+        assert "Caption" in styles, f"caption {needle!r} did not get the Caption style (styles found: {styles!r})"
+
+
+def test_localized_sequence_does_not_enable_text_heuristic(test_parameters: TestParameters):
+    """A body paragraph starting with "Table" must NOT be restyled as a
+    caption or listed in the Table of Tables."""
+    doc = _document_xml(test_parameters, _TABELLE_DOC)
+
+    styles = [_style_of(p) for p in _paragraphs_with_text(doc, "false-positive scenario")]
+    assert "Caption" not in styles, "body text starting with 'Table' was restyled as a caption"
+    assert not any("false-positive" in t for t in _instr_texts(doc)), "body text leaked into TC entries"

--- a/tests/test_docx_references_post_process.py
+++ b/tests/test_docx_references_post_process.py
@@ -7,12 +7,20 @@ from docx.oxml import parse_xml
 from lxml import etree
 
 from app.DocxReferencesPostProcess import (
+    KIND_TOC,
+    KIND_TOF,
+    KIND_TOT,
     SCHEMA,
+    TOF_FIELD_CODE,
+    _create_field_with_entries,
+    _get_max_bookmark_id,
+    _get_seq_name,
+    _parse_placeholder,
     _add_tc_field,
     _create_toc_field,
     _create_tof_field,
     _create_tot_field,
-    _ensure_caption_style,
+    _set_paragraph_style,
     _ensure_seq_field,
     _find_placeholder_paragraphs,
     _get_paragraph_style,
@@ -28,43 +36,52 @@ _MINIMAL_TBL = f'<w:tbl xmlns:w="{SCHEMA}"><w:tr><w:tc><w:p><w:r><w:t>x</w:t></w
 
 # ---- _get_paragraph_text / _get_paragraph_style ----
 
+
 def test_get_paragraph_text_empty():
     assert _get_paragraph_text(parse_xml(f'<w:p xmlns:w="{SCHEMA}"/>')) == ""
+
 
 def test_get_paragraph_text_single():
     assert _get_paragraph_text(parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:r><w:t>Hi</w:t></w:r></w:p>')) == "Hi"
 
+
 def test_get_paragraph_style_none():
     assert _get_paragraph_style(parse_xml(f'<w:p xmlns:w="{SCHEMA}"/>')) is None
+
 
 def test_get_paragraph_style_bodytext():
     assert _get_paragraph_style(parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:pPr><w:pStyle w:val="BodyText"/></w:pPr></w:p>')) == "BodyText"
 
 
-# ---- _ensure_caption_style ----
+# ---- _set_paragraph_style ----
 
-def test_ensure_caption_style_adds():
+
+def test_set_paragraph_style_adds():
     para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:r><w:t>x</w:t></w:r></w:p>')
-    _ensure_caption_style(para)
+    _set_paragraph_style(para, "Caption")
     assert para.find(".//w:pStyle", namespaces={"w": SCHEMA}).get(f"{{{SCHEMA}}}val") == "Caption"
 
-def test_ensure_caption_style_replaces():
+
+def test_set_paragraph_style_replaces():
     para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:pPr><w:pStyle w:val="Normal"/></w:pPr></w:p>')
-    _ensure_caption_style(para)
+    _set_paragraph_style(para, "Caption")
     assert para.find(".//w:pStyle", namespaces={"w": SCHEMA}).get(f"{{{SCHEMA}}}val") == "Caption"
 
 
 # ---- _is_adjacent_to_table ----
 
+
 def test_adjacent_to_table_before():
     body = parse_xml(f'<w:body xmlns:w="{SCHEMA}"><w:p><w:r><w:t>c</w:t></w:r></w:p>{_MINIMAL_TBL}</w:body>')
     assert _is_adjacent_to_table(body.find("w:p", namespaces={"w": SCHEMA})) is True
+
 
 def test_after_table_is_not_adjacent():
     """A paragraph after a table should NOT be classified as table caption."""
     body = parse_xml(f'<w:body xmlns:w="{SCHEMA}">{_MINIMAL_TBL}<w:p><w:r><w:t>c</w:t></w:r></w:p></w:body>')
     paras = body.findall("w:p", namespaces={"w": SCHEMA})
     assert _is_adjacent_to_table(paras[-1]) is False
+
 
 def test_adjacent_to_table_skips_bookmarks():
     body = parse_xml(f'''<w:body xmlns:w="{SCHEMA}">
@@ -75,9 +92,11 @@ def test_adjacent_to_table_skips_bookmarks():
     </w:body>''')
     assert _is_adjacent_to_table(body.find("w:p", namespaces={"w": SCHEMA})) is True
 
+
 def test_adjacent_to_table_skips_empty_paras():
     body = parse_xml(f'<w:body xmlns:w="{SCHEMA}"><w:p><w:r><w:t>c</w:t></w:r></w:p><w:p/>{_MINIMAL_TBL}</w:body>')
     assert _is_adjacent_to_table(body.find("w:p", namespaces={"w": SCHEMA})) is True
+
 
 def test_not_adjacent_to_table():
     body = parse_xml(f'<w:body xmlns:w="{SCHEMA}"><w:p><w:r><w:t>a</w:t></w:r></w:p><w:p><w:r><w:t>b</w:t></w:r></w:p></w:body>')
@@ -86,13 +105,16 @@ def test_not_adjacent_to_table():
 
 # ---- _has_seq_field / _ensure_seq_field ----
 
+
 def test_has_seq_field_true():
     para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:r><w:instrText> SEQ Table </w:instrText></w:r></w:p>')
     assert _has_seq_field(para) is True
 
+
 def test_has_seq_field_false():
     para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:r><w:t>Table 1</w:t></w:r></w:p>')
     assert _has_seq_field(para) is False
+
 
 def test_ensure_seq_field_replaces_plain_number():
     para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:pPr><w:pStyle w:val="Caption"/></w:pPr><w:r><w:t>Figure 1 Pic</w:t></w:r></w:p>')
@@ -100,9 +122,10 @@ def test_ensure_seq_field_replaces_plain_number():
     xml = etree.tostring(para, encoding="unicode")
     assert "SEQ Figure" in xml
     assert 'fldCharType="begin"' in xml
-    assert re.search(r'separate.*<w:t[^>]*>1</w:t>.*end', xml, re.S)
+    assert re.search(r"separate.*<w:t[^>]*>1</w:t>.*end", xml, re.S)
     assert "Figure " in xml
     assert " Pic" in xml
+
 
 def test_ensure_seq_field_skips_existing():
     para = parse_xml(f'''<w:p xmlns:w="{SCHEMA}">
@@ -114,6 +137,7 @@ def test_ensure_seq_field_skips_existing():
     _ensure_seq_field(para, "Table")
     assert etree.tostring(para, encoding="unicode") == xml_before
 
+
 def test_ensure_seq_field_no_number():
     para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:r><w:t>No number</w:t></w:r></w:p>')
     xml_before = etree.tostring(para, encoding="unicode")
@@ -122,6 +146,7 @@ def test_ensure_seq_field_no_number():
 
 
 # ---- _add_tc_field ----
+
 
 def test_add_tc_field_creates_field_with_bookmark():
     para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:r><w:t>Table 1</w:t></w:r></w:p>')
@@ -134,21 +159,25 @@ def test_add_tc_field_creates_field_with_bookmark():
 
 # ---- TOC/TOF/TOT field creation ----
 
+
 def test_create_toc_field():
     paras = _create_toc_field()
     assert len(paras) == 2
     instr = paras[0].find(".//w:instrText", namespaces={"w": SCHEMA})
     assert '\\o "1-9"' in instr.text
 
+
 def test_create_tof_field():
     paras = _create_tof_field()
     instr = paras[0].find(".//w:instrText", namespaces={"w": SCHEMA})
     assert "\\f F" in instr.text
 
+
 def test_create_tot_field():
     paras = _create_tot_field()
     instr = paras[0].find(".//w:instrText", namespaces={"w": SCHEMA})
     assert "\\f T" in instr.text
+
 
 def test_tot_with_entries_has_hyperlinks():
     entries = [("Table 1", "_Toc1"), ("Table 2", "_Toc2")]
@@ -156,6 +185,7 @@ def test_tot_with_entries_has_hyperlinks():
     assert 'w:anchor="_Toc1"' in xml
     assert 'w:anchor="_Toc2"' in xml
     assert "PAGEREF" in xml
+
 
 def test_tof_with_entries():
     entries = [("Figure 1", "_Toc10")]
@@ -165,6 +195,7 @@ def test_tof_with_entries():
 
 
 # ---- placeholder finding ----
+
 
 def test_find_placeholders_all_three():
     body = parse_xml(f'''<w:body xmlns:w="{SCHEMA}">
@@ -176,6 +207,7 @@ def test_find_placeholders_all_three():
     _find_placeholder_paragraphs(body, result)
     assert len(result) == 3
 
+
 def test_find_placeholders_ignores_heading():
     body = parse_xml(f'<w:body xmlns:w="{SCHEMA}"><w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>TOC_PLACEHOLDER</w:t></w:r></w:p></w:body>')
     result = []
@@ -185,12 +217,14 @@ def test_find_placeholders_ignores_heading():
 
 # ---- enable_auto_update_fields ----
 
+
 def test_enable_auto_update_fields():
     mock_doc = MagicMock(spec=DocumentObject)
     mock_update_fields = MagicMock()
     mock_doc.settings.element.find.return_value = mock_update_fields
     enable_auto_update_fields(mock_doc)
     mock_update_fields.set.assert_called_once()
+
 
 def test_enable_auto_update_fields_exception(caplog):
     mock_doc = MagicMock(spec=DocumentObject)
@@ -202,6 +236,7 @@ def test_enable_auto_update_fields_exception(caplog):
 
 # ---- Integration: add_table_of_contents_entries ----
 
+
 def test_figure_captions_found(caplog):
     mock_doc = MagicMock(spec=DocumentObject)
     body = parse_xml(f'<w:body xmlns:w="{SCHEMA}"><w:p><w:pPr><w:pStyle w:val="Caption"/></w:pPr><w:r><w:t>Figure 1</w:t></w:r></w:p></w:body>')
@@ -209,6 +244,7 @@ def test_figure_captions_found(caplog):
     with caplog.at_level(logging.INFO):
         add_table_of_contents_entries(mock_doc)
     assert "Found 1 figure captions" in caplog.text
+
 
 def test_table_captions_found(caplog):
     mock_doc = MagicMock(spec=DocumentObject)
@@ -218,6 +254,7 @@ def test_table_captions_found(caplog):
         add_table_of_contents_entries(mock_doc)
     assert "1 table captions" in caplog.text
 
+
 def test_non_caption_paragraphs_ignored(caplog):
     mock_doc = MagicMock(spec=DocumentObject)
     body = parse_xml(f'<w:body xmlns:w="{SCHEMA}"><w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>Table 1</w:t></w:r></w:p></w:body>')
@@ -225,6 +262,7 @@ def test_non_caption_paragraphs_ignored(caplog):
     with caplog.at_level(logging.INFO):
         add_table_of_contents_entries(mock_doc)
     assert "Found 0 figure captions and 0 table captions" in caplog.text
+
 
 def test_captions_get_unique_bookmarks():
     mock_doc = MagicMock(spec=DocumentObject)
@@ -239,6 +277,7 @@ def test_captions_get_unique_bookmarks():
     assert len(bookmarks) >= 2
     assert bookmarks[0] != bookmarks[1]
 
+
 def test_tot_placeholder_full_workflow():
     mock_doc = MagicMock(spec=DocumentObject)
     body = parse_xml(f'''<w:body xmlns:w="{SCHEMA}">
@@ -252,6 +291,7 @@ def test_tot_placeholder_full_workflow():
     assert "w:hyperlink" in xml
     assert "PAGEREF" in xml
     assert "\\f T" in xml
+
 
 def test_localized_caption_classified_by_table_adjacency():
     """Polish 'Tabela 1' next to a table should be classified as table caption."""
@@ -271,16 +311,185 @@ def test_localized_caption_classified_by_table_adjacency():
     xml = etree.tostring(body, encoding="unicode")
     assert "\\f T" in xml
 
+
 def test_full_workflow_empty():
     from docx import Document
+
     doc = Document()
     add_table_of_contents_entries(doc)
 
+
 def test_enable_auto_update_real():
     from docx import Document
+
     doc = Document()
     doc.add_paragraph("Test")
     enable_auto_update_fields(doc)
     uf = doc.settings.element.find(".//w:updateFields", namespaces={"w": SCHEMA})
     assert uf is not None
     assert uf.get(f"{{{SCHEMA}}}val") == "true"
+
+
+# ---- helper edge cases (coverage-complete) ----
+
+
+def test_parse_placeholder_variants():
+    assert _parse_placeholder("TOC_PLACEHOLDER") == KIND_TOC
+    assert _parse_placeholder("TOF_PLACEHOLDER") == KIND_TOF
+    assert _parse_placeholder("TOT_PLACEHOLDER") == KIND_TOT
+    assert _parse_placeholder("Regular text") is None
+
+
+def test_get_max_bookmark_id_skips_non_integer_ids():
+    body = parse_xml(f'''<w:body xmlns:w="{SCHEMA}">
+        <w:p><w:bookmarkStart w:id="5" w:name="a"/><w:bookmarkEnd w:id="5"/></w:p>
+        <w:p><w:bookmarkStart w:id="abc" w:name="b"/><w:bookmarkEnd w:id="abc"/></w:p>
+    </w:body>''')
+    assert _get_max_bookmark_id(body) == 5
+
+
+def test_image_caption_style_is_classified_as_figure():
+    mock_doc = MagicMock(spec=DocumentObject)
+    body = parse_xml(f'''<w:body xmlns:w="{SCHEMA}">
+        <w:p><w:pPr><w:pStyle w:val="ImageCaption"/></w:pPr><w:r><w:t>Abbildung 1 Bild</w:t></w:r></w:p>
+    </w:body>''')
+    mock_doc.element.body = body
+    add_table_of_contents_entries(mock_doc)
+    xml = etree.tostring(body, encoding="unicode")
+    assert "SEQ Figure" in xml
+
+
+def test_get_seq_name_reads_identifier():
+    para = parse_xml(f'''<w:p xmlns:w="{SCHEMA}">
+        <w:r><w:instrText xml:space="preserve"> SEQ Tabelle \\* ARABIC </w:instrText></w:r>
+    </w:p>''')
+    assert _get_seq_name(para) == "Tabelle"
+
+
+def test_get_seq_name_without_seq_field():
+    para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:r><w:t>Table 1</w:t></w:r></w:p>')
+    assert _get_seq_name(para) is None
+
+
+def test_get_seq_name_with_malformed_instruction():
+    # First instruction mentions SEQ without an identifier, second is valid:
+    # the scan must skip the malformed one and keep looking
+    para = parse_xml(f'''<w:p xmlns:w="{SCHEMA}">
+        <w:r><w:instrText xml:space="preserve"> PAGEREF _Toc1 \\h </w:instrText></w:r>
+        <w:r><w:instrText xml:space="preserve">SEQ</w:instrText></w:r>
+        <w:r><w:instrText xml:space="preserve"> SEQ Tabelle \\* ARABIC </w:instrText></w:r>
+    </w:p>''')
+    assert _get_seq_name(para) == "Tabelle"
+
+
+def test_ensure_seq_field_skips_runs_without_text_or_number():
+    para = parse_xml(f'''<w:p xmlns:w="{SCHEMA}">
+        <w:r></w:r>
+        <w:r><w:t>no number here</w:t></w:r>
+        <w:r><w:t>Table 7 caption</w:t></w:r>
+    </w:p>''')
+    _ensure_seq_field(para, "Table")
+    xml = etree.tostring(para, encoding="unicode")
+    assert "SEQ Table" in xml
+    assert "no number here" in _get_paragraph_text(para)
+
+
+def test_ensure_seq_field_number_at_run_start():
+    # No "before" text: run starts with the number itself
+    para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:r><w:t>7 caption tail</w:t></w:r></w:p>')
+    _ensure_seq_field(para, "Figure")
+    text = _get_paragraph_text(para)
+    assert text.startswith("7")
+    assert "caption tail" in text
+    assert "SEQ Figure" in etree.tostring(para, encoding="unicode")
+
+
+def test_ensure_seq_field_preserves_run_formatting():
+    para = parse_xml(f'''<w:p xmlns:w="{SCHEMA}">
+        <w:r><w:rPr><w:b/></w:rPr><w:t>Table 3 bold caption</w:t></w:r>
+    </w:p>''')
+    _ensure_seq_field(para, "Table")
+    # The cloned before/after runs keep the original bold rPr
+    runs_with_bold = [r for r in para.findall("w:r", namespaces={"w": SCHEMA}) if r.find("w:rPr/w:b", namespaces={"w": SCHEMA}) is not None]
+    assert len(runs_with_bold) >= 2
+
+
+def test_set_paragraph_style_inserts_into_existing_ppr():
+    para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:pPr><w:jc w:val="center"/></w:pPr></w:p>')
+    _set_paragraph_style(para, "Caption")
+    assert para.find(".//w:pStyle", namespaces={"w": SCHEMA}).get(f"{{{SCHEMA}}}val") == "Caption"
+    assert para.find(".//w:jc", namespaces={"w": SCHEMA}) is not None
+
+
+def test_find_placeholders_skips_non_paragraph_elements():
+    body = parse_xml(f'''<w:body xmlns:w="{SCHEMA}">
+        {_MINIMAL_TBL}
+        <w:p><w:r><w:t>TOC_PLACEHOLDER</w:t></w:r></w:p>
+    </w:body>''')
+    result = []
+    _find_placeholder_paragraphs(body, result)
+    assert len(result) == 1
+    assert result[0][2] == KIND_TOC
+
+
+def test_full_flow_prefills_tof_and_tot_with_entries():
+    mock_doc = MagicMock(spec=DocumentObject)
+    body = parse_xml(f'''<w:body xmlns:w="{SCHEMA}">
+        <w:p><w:r><w:t>TOF_PLACEHOLDER</w:t></w:r></w:p>
+        <w:p><w:r><w:t>TOT_PLACEHOLDER</w:t></w:r></w:p>
+        <w:p><w:pPr><w:pStyle w:val="Caption"/></w:pPr><w:r><w:t>Figure 1 A picture</w:t></w:r></w:p>
+        <w:p><w:pPr><w:pStyle w:val="Caption"/></w:pPr><w:r><w:t>Table 1 A table</w:t></w:r></w:p>{_MINIMAL_TBL}
+    </w:body>''')
+    mock_doc.element.body = body
+    add_table_of_contents_entries(mock_doc)
+    xml = etree.tostring(body, encoding="unicode")
+    assert "\\f F" in xml
+    assert "\\f T" in xml
+    # Pre-filled cached entries hyperlink to the captions via PAGEREF
+    assert xml.count("PAGEREF") == 2
+    assert "TOF_PLACEHOLDER" not in xml
+    assert "TOT_PLACEHOLDER" not in xml
+
+
+def test_placeholder_without_matching_captions_removed_without_field():
+    mock_doc = MagicMock(spec=DocumentObject)
+    body = parse_xml(f'''<w:body xmlns:w="{SCHEMA}">
+        <w:p><w:r><w:t>TOF_PLACEHOLDER</w:t></w:r></w:p>
+    </w:body>''')
+    mock_doc.element.body = body
+    add_table_of_contents_entries(mock_doc)
+    xml = etree.tostring(body, encoding="unicode")
+    assert "TOF_PLACEHOLDER" not in xml
+    assert "\\f F" not in xml
+
+
+def test_create_field_with_entries_empty_list_falls_back_to_plain_field():
+    paragraphs = _create_field_with_entries(TOF_FIELD_CODE, [])
+    assert len(paragraphs) == 2  # plain field + spacing paragraph
+    xml = etree.tostring(paragraphs[0], encoding="unicode")
+    assert "\\f F" in xml
+    assert "PAGEREF" not in xml
+
+
+def test_get_paragraph_text_skips_empty_t_elements():
+    para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:r><w:t/></w:r><w:r><w:t>x</w:t></w:r></w:p>')
+    assert _get_paragraph_text(para) == "x"
+
+
+def test_get_paragraph_style_ppr_without_pstyle():
+    para = parse_xml(f'<w:p xmlns:w="{SCHEMA}"><w:pPr><w:jc w:val="center"/></w:pPr></w:p>')
+    assert _get_paragraph_style(para) is None
+
+
+def test_full_flow_inserts_toc_field():
+    mock_doc = MagicMock(spec=DocumentObject)
+    body = parse_xml(f'''<w:body xmlns:w="{SCHEMA}">
+        <w:p><w:r><w:t>TOC_PLACEHOLDER</w:t></w:r></w:p>
+        <w:p><w:r><w:t>Ordinary body paragraph</w:t></w:r></w:p>
+    </w:body>''')
+    mock_doc.element.body = body
+    add_table_of_contents_entries(mock_doc)
+    xml = etree.tostring(body, encoding="unicode")
+    assert 'TOC \\o "1-9" \\h \\z \\u' in xml
+    assert "TOC_PLACEHOLDER" not in xml
+    assert "Ordinary body paragraph" in xml


### PR DESCRIPTION
Style-only follow-up to #200 — no behavior change.

- Shared constants for everything ToC/ToF/ToT: placeholder texts, placeholder kinds, caption styles (`CAPTION_STYLE_IDS` built from named constants), caption sequences, and all field instruction codes
- Shared helpers: single `_parse_placeholder` for all three placeholders, generic `_set_paragraph_style` (replaces `_ensure_caption_style`), `_insert_paragraphs`, `_create_listing_field`
- The `(idx, element, has_toc, has_tof, has_tot)` tuple of three mutually exclusive booleans becomes `(idx, element, kind)`
- Dead `if element is not None` check removed

Tests:
- `DocxReferencesPostProcess` unit coverage brought to **100 % (statements + branches)**, 51 tests
- New container e2e tests for **localized caption sequences** (German `Tabelle`, taken from a real docx-exporter fixture): SEQ fields keep the Polarion sequence identifier, captions land in the pre-filled Table of Tables, and prose starting with "Table" is not misdetected