### PR TITLE
chore: keep the reason out of the noqa directive

### DIFF
--- a/app/chromium_manager.py
+++ b/app/chromium_manager.py
@@ -573,7 +573,8 @@ class ChromiumManager:
                 last_error = TimeoutError(f"Conversion timed out after {self.conversion_timeout} seconds")
                 self.log.error("SVG conversion timed out (attempt %d/%d): %d seconds", attempt + 1, self.max_conversion_retries, self.conversion_timeout)
                 await self._handle_conversion_retry(attempt, last_error, "timeout")
-            except Exception as e:  # noqa: BLE001 - any conversion failure feeds the retry loop
+            # Any conversion failure feeds the retry loop.
+            except Exception as e:  # noqa: BLE001
                 last_error = e
                 self.log.warning(
                     "SVG conversion failed (attempt %d/%d): %s. Attempting to restart Chromium...",
@@ -610,7 +611,8 @@ class ChromiumManager:
         try:
             await self.restart()
             self.log.info("Chromium restarted successfully after %s", error_type)
-        except Exception as restart_error:  # noqa: BLE001 - a failed restart is re-raised as RuntimeError
+        # A failed restart is re-raised as RuntimeError.
+        except Exception as restart_error:  # noqa: BLE001
             self.log.error("Failed to restart Chromium: %s", restart_error)
             raise RuntimeError(f"Chromium restart failed after {error_type}: {restart_error}") from error
 

--- a/app/docx_post_process.py
+++ b/app/docx_post_process.py
@@ -171,7 +171,8 @@ def _replace_image_placeholders(doc: DocumentObject) -> None:
             run_el.append(drawing_el)
 
             logger.debug(f"Replaced image placeholder with embedded image ({img.px_width}x{img.px_height})")
-        except Exception as e:  # noqa: BLE001 - a placeholder that will not embed leaves the document unchanged
+        # A placeholder that will not embed leaves the document unchanged.
+        except Exception as e:  # noqa: BLE001
             logger.warning(f"Could not embed image from placeholder: {e}")
             t_el.text = t_el.text.replace(match.group(0), "[image]")
 
@@ -184,7 +185,8 @@ def _resolve_image_src(src: str) -> bytes | None:
         if match:
             try:
                 return base64.b64decode(match.group(1))
-            except Exception:  # noqa: BLE001 - undecodable image data leaves the document unchanged
+            # Undecodable image data leaves the document unchanged.
+            except Exception:  # noqa: BLE001
                 logger.warning("Failed to decode base64 image data")
                 return None
     if src:
@@ -215,7 +217,8 @@ def _replace_link_placeholders(doc: DocumentObject) -> None:
             hyperlink.set(f"{ns_r}id", r_id)
             hyperlink.attrib.pop(f"{ns_w}tooltip", None)
             logger.debug(f"Resolved hyperlink placeholder to {url} (r:id={r_id})")
-        except Exception as e:  # noqa: BLE001 - an unresolvable hyperlink leaves the document unchanged
+        # An unresolvable hyperlink leaves the document unchanged.
+        except Exception as e:  # noqa: BLE001
             logger.warning(f"Could not resolve hyperlink placeholder: {e}")
             hyperlink.attrib.pop(f"{ns_w}tooltip", None)
 
@@ -243,7 +246,8 @@ def _replace_size_and_orientation(doc: DocumentObject, paper_size: str | None = 
         return
 
     for section in doc.sections:
-        sect_pr = section._sectPr  # noqa: SLF001 - python-docx exposes no public API for this element
+        # Python-docx exposes no public API for this element.
+        sect_pr = section._sectPr  # noqa: SLF001
         pg_sz = sect_pr.find(".//w:pgSz", namespaces={"w": SCHEMA})
 
         if paper_size is not None:
@@ -340,8 +344,10 @@ def _move_header_footer_references_to_first_section(doc: DocumentObject) -> None
     if len(doc.sections) <= 1:
         return  # Nothing to fix if there's only one section
 
-    first_sect_pr = doc.sections[0]._sectPr  # noqa: SLF001 - python-docx exposes no public API for this element
-    last_sect_pr = doc.sections[-1]._sectPr  # noqa: SLF001 - python-docx exposes no public API for this element
+    # Python-docx exposes no public API for this element.
+    first_sect_pr = doc.sections[0]._sectPr  # noqa: SLF001
+    # Python-docx exposes no public API for this element.
+    last_sect_pr = doc.sections[-1]._sectPr  # noqa: SLF001
 
     # Check if first section already has header/footer references
     existing_headers = first_sect_pr.findall("w:headerReference", namespaces={"w": SCHEMA})
@@ -400,7 +406,8 @@ def _replace_table_properties(doc: DocumentObject, table_layouts: list[TableLayo
             # Table element
             elif element.tag.endswith("tbl") and current_section_index == target_index:
                 for table in doc.tables:
-                    if table._element == element:  # noqa: SLF001 - python-docx exposes no public API for this element
+                    # Python-docx exposes no public API for this element.
+                    if table._element == element:  # noqa: SLF001
                         tables_in_section.append(table)
                         break
 
@@ -410,7 +417,8 @@ def _replace_table_properties(doc: DocumentObject, table_layouts: list[TableLayo
 
 
 def _process_table(table: Table, parent_columns_count: int, max_width: int, layout_iter: Iterator[TableLayout] | None = None) -> None:
-    tbl = table._element  # noqa: SLF001 - python-docx exposes no public API for this element
+    # Python-docx exposes no public API for this element.
+    tbl = table._element  # noqa: SLF001
     # Pull this table's layout first, before recursing into nested tables, so
     # consumption order stays depth-first and matches html_table_layout.extract.
     layout = next(layout_iter, None) if layout_iter is not None else None
@@ -549,7 +557,8 @@ def _get_available_content_width_for_section(section: Section) -> int:
 
 
 def _resize_images_in_cell(cell: _Cell, max_image_width: float) -> None:
-    cell_xml = cell._tc.xml  # noqa: SLF001 - python-docx exposes no public API for this element
+    # Python-docx exposes no public API for this element.
+    cell_xml = cell._tc.xml  # noqa: SLF001
     # Use huge_tree parser to handle cells with large content (e.g., base64-encoded images > 10MB)
     tree = etree.fromstring(cell_xml, docx_parser.oxml_parser)
 
@@ -581,9 +590,11 @@ def _resize_images_in_cell(cell: _Cell, max_image_width: float) -> None:
 
     # If any modification was made, update the cell XML
     if modified:
-        cell._tc.clear_content()  # noqa: SLF001 - python-docx exposes no public API for this element
+        # Python-docx exposes no public API for this element.
+        cell._tc.clear_content()  # noqa: SLF001
         for child in tree.iterchildren():
-            cell._tc.append(child)  # noqa: SLF001 - python-docx exposes no public API for this element
+            # Python-docx exposes no public API for this element.
+            cell._tc.append(child)  # noqa: SLF001
 
 
 # Command line shape for the manual entry point below.

--- a/app/docx_references_post_process.py
+++ b/app/docx_references_post_process.py
@@ -101,7 +101,8 @@ def enable_auto_update_fields(doc: DocumentObject) -> None:
         else:
             update_fields.set(f"{{{SCHEMA}}}val", "true")
             logger.info("Updated existing auto-update fields setting")
-    except Exception as e:  # noqa: BLE001 - auto-update fields is a nice-to-have, not a requirement
+    # Auto-update fields is a nice-to-have, not a requirement.
+    except Exception as e:  # noqa: BLE001
         logger.warning(f"Could not enable auto-update fields: {e}")
 
 

--- a/app/pandoc_controller.py
+++ b/app/pandoc_controller.py
@@ -309,7 +309,8 @@ def get_pandoc_version() -> str | None:
         # Extract version from the first line of output
         version_line = result.stdout.splitlines()[0]
         return version_line.split()[-1]  # Last word on the first line is the version
-    except Exception as e:  # noqa: BLE001 - a missing pandoc version must not fail the request
+    # A missing pandoc version must not fail the request.
+    except Exception as e:  # noqa: BLE001
         logger.error(f"Error getting pandoc version: {e}")
         return None
 
@@ -846,15 +847,18 @@ async def convert_docx_with_ref(
         if has_template:
             increment_template_conversion("docx")
 
-    except Exception as e:  # noqa: BLE001 - the HTTP boundary must answer, not leak
+    # The HTTP boundary must answer, not leak.
+    except Exception as e:  # noqa: BLE001
         pandoc_metrics.record_conversion_failure()
         increment_conversion_failure(source_format, "docx")
         return process_error(e, HTTPStatus.BAD_REQUEST.phrase, HTTPStatus.BAD_REQUEST.value)
     else:
         return response
     finally:
-        if temp_template_filename is not None and Path(temp_template_filename).exists():  # noqa: ASYNC240 - a local stat costs less than a thread hop
-            Path(temp_template_filename).unlink()  # noqa: ASYNC240 - same, for the unlink
+        # A local stat costs less than a thread hop.
+        if temp_template_filename is not None and Path(temp_template_filename).exists():  # noqa: ASYNC240
+            # Same, for the unlink.
+            Path(temp_template_filename).unlink()  # noqa: ASYNC240
 
 
 @app.post(
@@ -937,15 +941,18 @@ async def convert_pptx_with_ref(
         if has_template:
             increment_template_conversion("pptx")
 
-    except Exception as e:  # noqa: BLE001 - same, for the second conversion endpoint
+    # Same, for the second conversion endpoint.
+    except Exception as e:  # noqa: BLE001
         pandoc_metrics.record_conversion_failure()
         increment_conversion_failure(source_format, "pptx")
         return process_error(e, "Bad request", 400)
     else:
         return response
     finally:
-        if temp_template_filename is not None and Path(temp_template_filename).exists():  # noqa: ASYNC240 - a local stat costs less than a thread hop
-            Path(temp_template_filename).unlink()  # noqa: ASYNC240 - same, for the unlink
+        # A local stat costs less than a thread hop.
+        if temp_template_filename is not None and Path(temp_template_filename).exists():  # noqa: ASYNC240
+            # Same, for the unlink.
+            Path(temp_template_filename).unlink()  # noqa: ASYNC240
 
 
 @app.post(
@@ -1023,7 +1030,8 @@ async def convert(
         pandoc_metrics.record_conversion_success(duration_seconds * 1000)
         increment_conversion_success(source_format, target_format, duration_seconds)
 
-    except Exception as e:  # noqa: BLE001 - same, for the third conversion endpoint
+    # Same, for the third conversion endpoint.
+    except Exception as e:  # noqa: BLE001
         pandoc_metrics.record_conversion_failure()
         increment_conversion_failure(source_format, target_format)
         return process_error(e, HTTPStatus.BAD_REQUEST.phrase, HTTPStatus.BAD_REQUEST.value)

--- a/app/schema.py
+++ b/app/schema.py
@@ -2,9 +2,11 @@ from pydantic import BaseModel, Field
 
 
 class VersionSchema(BaseModel):
-    apiVersion: int = Field(title="API Version", description="API version for compatibility checking with docx-exporter")  # noqa: N815 - this is the JSON field name clients read
+    # This is the JSON field name clients read.
+    apiVersion: int = Field(title="API Version", description="API version for compatibility checking with docx-exporter")  # noqa: N815
     python: str = Field()
     pandoc: str | None = Field()
-    pandocService: str | None = Field()  # noqa: N815 - this is the JSON field name clients read
+    # This is the JSON field name clients read.
+    pandocService: str | None = Field()  # noqa: N815
     timestamp: str | None = Field()
     chromium: str | None = Field()

--- a/app/svg_processor.py
+++ b/app/svg_processor.py
@@ -22,7 +22,9 @@ import xml.etree.ElementTree as ET
 from typing import TYPE_CHECKING
 
 from bs4 import BeautifulSoup, Tag
-from defusedxml import ElementTree as det  # noqa: N813 - defusedxml exposes ElementTree as a module
+
+# Defusedxml exposes ElementTree as a module.
+from defusedxml import ElementTree as det  # noqa: N813
 
 if TYPE_CHECKING:  # used only for type hints
     from xml.etree.ElementTree import Element
@@ -357,7 +359,8 @@ class SvgProcessor:
     def convert_to_px(self, value: str | None, unit: str | None) -> int | None:
         try:
             if value is None:
-                raise ValueError  # noqa: TRY301 - the try converts, this guard rejects a missing value
+                # The try converts, this guard rejects a missing value.
+                raise ValueError  # noqa: TRY301
             value_f64 = float(value)
 
             if unit in self.SPECIAL_UNITS:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,8 @@ def cleanup_session():
     """Session-level fixture to ensure cleanup happens before and after all tests."""
     try:
         cleanup_docker_resources()
-    except Exception as e:  # noqa: BLE001 - pre-test cleanup is best effort
+    # Pre-test cleanup is best effort.
+    except Exception as e:  # noqa: BLE001
         logger.error(f"Error in pre-test cleanup: {e}")
 
     yield
@@ -89,7 +90,8 @@ def pandoc_container():
 
             cleanup_docker_resources()
 
-        except Exception as e:  # noqa: BLE001 - container cleanup is best effort
+        # Container cleanup is best effort.
+        except Exception as e:  # noqa: BLE001
             logger.error(f"Error in container cleanup: {e}")
 
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -149,7 +149,8 @@ def _verify_containers(client: docker.DockerClient) -> None:
             for container in remaining_test:
                 logger.warning(f"Remaining container: {container.name} ({container.id})")
                 _stop_and_remove_container(container)
-    except Exception as e:  # noqa: BLE001 - verification reports rather than raises
+    # Verification reports rather than raises.
+    except Exception as e:  # noqa: BLE001
         logger.error(f"Error in container verification: {e}")
 
 
@@ -164,7 +165,8 @@ def _verify_images(client: docker.DockerClient) -> None:
             for image in remaining_test_images:
                 logger.warning(f"Remaining image: {image.id} (tags: {image.tags})")
                 _remove_image(image)
-    except Exception as e:  # noqa: BLE001 - same, for the image check
+    # Same, for the image check.
+    except Exception as e:  # noqa: BLE001
         logger.error(f"Error in image verification: {e}")
 
 

--- a/tests/test_svg_processor.py
+++ b/tests/test_svg_processor.py
@@ -12,7 +12,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from bs4 import BeautifulSoup
-from defusedxml import ElementTree as det  # noqa: N813 - defusedxml exposes ElementTree as a module
+
+# Defusedxml exposes ElementTree as a module.
+from defusedxml import ElementTree as det  # noqa: N813
 
 from app import pandoc_controller
 from app.chromium_manager import ChromiumManager


### PR DESCRIPTION
Sonar's `python:S7632` reads trailing text inside a suppression comment as broken
syntax. Ruff parses the codes and ignores the rest, so the two disagreed wherever
a `# noqa` carried its reason inline:

```python
except Exception:  # noqa: BLE001 - sanitization must never fail
```

The directive now carries codes only and the reason moves to the line above,
which both tools accept. Verified that ruff still suppresses in that shape.

The reasons themselves are unchanged; this is where they sit, not what they say.

Verified: ruff clean, format clean, mypy clean, tests pass.