### PR TITLE
build: use json notation in the healthcheck command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,6 +130,6 @@ COPY filters/html_captions.lua "/usr/local/share/pandoc/filters/html_captions.lu
 COPY filters/docx_caption_labels_to_latex.lua "/usr/local/share/pandoc/filters/docx_caption_labels_to_latex.lua"
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD curl -fsS http://localhost:9082/health || exit 1
+  CMD ["curl", "-fsS", "http://localhost:9082/health"]
 
 ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
## What

Write the `HEALTHCHECK` probe in JSON notation.

## Why

hadolint 2.15.0 applies `DL3025` to `HEALTHCHECK` as well as to `CMD` and `ENTRYPOINT`. The shell form therefore fails the lint step as soon as the hadolint action reaches v3.4.0, which is what blocks #210:

```
Dockerfile:132 DL3025 warning: Use arguments JSON notation for CMD and ENTRYPOINT arguments
```

The repo's own gate did not catch this, because the `hadolint` pre-commit hook runs the locally installed binary, and a local install can lag the version CI uses.

## The dropped `|| exit 1`

Not needed. Docker reads any non-zero exit code as unhealthy, and `curl -f` returns one.

## Verification

- `hadolint:v2.15.1` and `hadolint:v2.14.0` both report nothing.
- Built image: the container reaches `healthy` 8 seconds after start, probe `exit=0`, body `{"status":"healthy",...}`.
- An unreachable endpoint gives `curl exit=7`; a probe exiting 2 marks the container `unhealthy`, so a non-1 code still reads as a failure.

Unblocks #210.
