### PR TITLE
feat: serve https as an option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ bash tests/shell/test_pandoc_service.sh
 - Direct subprocess calls to pandoc binary (no shell=True)
 - Input validation with 200MB request size limit
 - Format validation for source/target combinations
-- Optional TLS on both servers (`app/tls.py`): `TLS_CERT_FILE`, `TLS_KEY_FILE`, `TLS_KEY_PASSWORD`, `TLS_CLIENT_CA_FILE`, `TLS_CLIENT_AUTH` (none/optional/required) for the API, the same five with a `METRICS_TLS_` prefix for the metrics server, configured independently. Unset means plain HTTP (default); an incomplete configuration fails at startup rather than falling back. The container healthcheck (`healthcheck.sh`) follows the configured scheme.
+- Optional TLS on both servers (`app/tls.py`): `TLS_CERT_FILE`, `TLS_KEY_FILE`, `TLS_KEY_PASSWORD`, `TLS_CLIENT_CA_FILE`, `TLS_CLIENT_AUTH` (none/optional/required) for the API, the same five with a `METRICS_TLS_` prefix for the metrics server, configured independently. Unset means plain HTTP (default); an incomplete configuration fails at startup rather than falling back, and the material is loaded before either server listens (`load_tls_options`), so a mismatched key or a wrong password also stops the start. The container healthcheck (`healthcheck.sh`) follows the configured scheme.
 - Optional API key on the conversion and template endpoints (`app/auth.py`): set `API_KEY` (comma-separated list allowed) and clients send `X-API-Key` or `Authorization: Bearer`. Unset means disabled, which is the default. `/health`, `/version`, `/static` and `/api/docs` stay open so the healthcheck keeps working.
 
 ### Conversion Pipeline

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ bash tests/shell/test_pandoc_service.sh
 - Direct subprocess calls to pandoc binary (no shell=True)
 - Input validation with 200MB request size limit
 - Format validation for source/target combinations
+- Optional TLS on both servers (`app/tls.py`): `TLS_CERT_FILE`, `TLS_KEY_FILE`, `TLS_KEY_PASSWORD`, `TLS_CLIENT_CA_FILE`, `TLS_CLIENT_AUTH` (none/optional/required) for the API, the same five with a `METRICS_TLS_` prefix for the metrics server, configured independently. Unset means plain HTTP (default); an incomplete configuration fails at startup rather than falling back. The container healthcheck (`healthcheck.sh`) follows the configured scheme.
 - Optional API key on the conversion and template endpoints (`app/auth.py`): set `API_KEY` (comma-separated list allowed) and clients send `X-API-Key` or `Authorization: Bearer`. Unset means disabled, which is the default. `/health`, `/version`, `/static` and `/api/docs` stay open so the healthcheck keeps working.
 
 ### Conversion Pipeline

--- a/Dockerfile
+++ b/Dockerfile
@@ -139,7 +139,8 @@ RUN BUILD_TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")" && \
 COPY ./app/*.py "${WORKING_DIR}/app/"
 
 COPY entrypoint.sh "${WORKING_DIR}/entrypoint.sh"
-RUN chmod +x "${WORKING_DIR}/entrypoint.sh"
+COPY healthcheck.sh "${WORKING_DIR}/healthcheck.sh"
+RUN chmod +x "${WORKING_DIR}/entrypoint.sh" "${WORKING_DIR}/healthcheck.sh"
 
 COPY filters/page_orientation.lua "/usr/local/share/pandoc/filters/page_orientation.lua"
 COPY filters/heading_levels.lua "/usr/local/share/pandoc/filters/heading_levels.lua"
@@ -156,6 +157,6 @@ COPY filters/html_captions.lua "/usr/local/share/pandoc/filters/html_captions.lu
 COPY filters/docx_caption_labels_to_latex.lua "/usr/local/share/pandoc/filters/docx_caption_labels_to_latex.lua"
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD ["curl", "-fsS", "http://localhost:9082/health"]
+  CMD ["/bin/sh", "-c", "./healthcheck.sh"]
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -101,6 +101,54 @@ The `/health` endpoint reports a `chromium` status (`available` / `disabled` /
 is informational and does not by itself mark the service unhealthy. The Chromium
 version is reported by the `/version` endpoint.
 
+### HTTPS
+
+Both servers speak plain HTTP by default, which is what a deployment behind a reverse proxy or an ingress expects: TLS terminates there and nothing has to be configured here. That remains the recommended setup where such a component is already in place.
+
+Where the service is reached directly across a network, each server can serve TLS itself.
+
+**The API server:**
+
+| Variable | Purpose |
+|---|---|
+| `TLS_CERT_FILE` | Certificate chain in PEM format |
+| `TLS_KEY_FILE` | Private key in PEM format |
+| `TLS_KEY_PASSWORD` | Password of the key, where it has one |
+| `TLS_CLIENT_CA_FILE` | CA that client certificates are verified against |
+| `TLS_CLIENT_AUTH` | `none` (default), `optional` or `required` |
+
+**The metrics server, configured on its own:**
+
+| Variable | Purpose |
+|---|---|
+| `METRICS_TLS_CERT_FILE` | Certificate chain in PEM format |
+| `METRICS_TLS_KEY_FILE` | Private key in PEM format |
+| `METRICS_TLS_KEY_PASSWORD` | Password of the key, where it has one |
+| `METRICS_TLS_CLIENT_CA_FILE` | CA that client certificates are verified against |
+| `METRICS_TLS_CLIENT_AUTH` | `none` (default), `optional` or `required` |
+
+The two sets are independent and neither inherits from the other. The metrics port can stay plain behind a network rule while the API serves TLS, or the other way round.
+
+```bash
+docker run --init --detach \
+  --publish 9082:9082 \
+  --name pandoc-service \
+  --volume /path/to/tls:/opt/pandoc/tls:ro \
+  --env TLS_CERT_FILE=/opt/pandoc/tls/server.pem \
+  --env TLS_KEY_FILE=/opt/pandoc/tls/server.key \
+  ghcr.io/schweizerischebundesbahnen/pandoc-service:latest
+```
+
+An incomplete configuration stops the start with a message naming the variable. The service never falls back to plain HTTP, because serving in the clear while an operator believes otherwise is worse than not starting.
+
+**Mutual TLS.** With `TLS_CLIENT_AUTH=required` the service accepts only clients presenting a certificate signed by `TLS_CLIENT_CA_FILE`. That authenticates the caller, which the API key below does not: the certificate says who connected, the key says who may convert. The two combine.
+
+**The healthcheck of the container** follows the configured scheme. It talks to its own process over loopback, so it does not verify the certificate. Where client certificates are required, give the probe one with `TLS_HEALTHCHECK_CERT_FILE` and `TLS_HEALTHCHECK_KEY_FILE`, otherwise the container reports itself unhealthy.
+
+**Certificate renewal.** The certificate is read once, at startup. A renewed certificate takes effect when the container restarts.
+
+**Prometheus.** Once the metrics port serves TLS, its scrape configuration needs `scheme: https` next to the target.
+
 ### API key authentication
 
 The conversion and template endpoints can be protected with an API key. The feature is optional and disabled by default.

--- a/README.md
+++ b/README.md
@@ -140,10 +140,12 @@ docker run --init --detach \
 ```
 
 An incomplete configuration stops the start with a message naming the variable. The service never falls back to plain HTTP, because serving in the clear while an operator believes otherwise is worse than not starting.
+The material is loaded before either server listens, so a key which does not match its certificate, a wrong `TLS_KEY_PASSWORD` or an unusable CA also stop the start, rather than surfacing at the first connection.
+
 
 **Mutual TLS.** With `TLS_CLIENT_AUTH=required` the service accepts only clients presenting a certificate signed by `TLS_CLIENT_CA_FILE`. That authenticates the caller, which the API key below does not: the certificate says who connected, the key says who may convert. The two combine.
 
-**The healthcheck of the container** follows the configured scheme. It talks to its own process over loopback, so it does not verify the certificate. Where client certificates are required, give the probe one with `TLS_HEALTHCHECK_CERT_FILE` and `TLS_HEALTHCHECK_KEY_FILE`, otherwise the container reports itself unhealthy.
+**The healthcheck of the container** follows the configured scheme. It talks to its own process over loopback, so it does not verify the certificate. Where client certificates are required, give the probe one with `TLS_HEALTHCHECK_CERT_FILE` and `TLS_HEALTHCHECK_KEY_FILE`, otherwise the container reports itself unhealthy. The two go together: one without the other fails the probe with a message naming them, rather than an opaque handshake error.
 
 **Certificate renewal.** The certificate is read once, at startup. A renewed certificate takes effect when the container restarts.
 

--- a/app/metrics_server.py
+++ b/app/metrics_server.py
@@ -20,7 +20,7 @@ from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 from app.chromium_manager import get_chromium_manager
 from app.pandoc_metrics import get_pandoc_metrics
 from app.prometheus_metrics import update_gauges_from_chromium_manager, update_gauges_from_pandoc_metrics
-from app.tls import METRICS_TLS_PREFIX, get_scheme, get_tls_options
+from app.tls import METRICS_TLS_PREFIX, get_scheme, load_tls_options
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +119,7 @@ class MetricsServer:
             logger.warning("Metrics server already started")
             return
 
-        tls_options = get_tls_options(METRICS_TLS_PREFIX)
+        tls_options = load_tls_options(METRICS_TLS_PREFIX)
         config = uvicorn.Config(
             app=metrics_app,
             host="0.0.0.0",  # noqa: S104

--- a/app/metrics_server.py
+++ b/app/metrics_server.py
@@ -20,6 +20,7 @@ from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 from app.chromium_manager import get_chromium_manager
 from app.pandoc_metrics import get_pandoc_metrics
 from app.prometheus_metrics import update_gauges_from_chromium_manager, update_gauges_from_pandoc_metrics
+from app.tls import METRICS_TLS_PREFIX, get_scheme, get_tls_options
 
 logger = logging.getLogger(__name__)
 
@@ -118,11 +119,13 @@ class MetricsServer:
             logger.warning("Metrics server already started")
             return
 
+        tls_options = get_tls_options(METRICS_TLS_PREFIX)
         config = uvicorn.Config(
             app=metrics_app,
             host="0.0.0.0",  # noqa: S104
             port=self.port,
             log_level="warning",
+            **tls_options,
         )
         self._server = uvicorn.Server(config)
         self._task = asyncio.create_task(self._server.serve())
@@ -142,6 +145,7 @@ class MetricsServer:
 
         self._started = True
         logger.info("Metrics server started on port %d", self.port)
+        logger.info("Metrics server scheme: %s", get_scheme(tls_options))
 
     async def stop(self) -> None:
         """Stop the metrics server."""

--- a/app/pandoc_controller.py
+++ b/app/pandoc_controller.py
@@ -23,7 +23,7 @@ from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.auth import ApiKeyError, get_api_keys, require_api_key
 from app.schema import VersionSchema
-from app.tls import API_TLS_PREFIX, get_scheme, get_tls_options
+from app.tls import API_TLS_PREFIX, METRICS_TLS_PREFIX, get_scheme, get_tls_options
 
 from . import docx_latex_pre_process, docx_post_process, html_image_pre_process, html_lists_pre_process, html_math_color_pre_process, html_paragraph_pre_process, html_table_layout, pptx_post_process
 from .chromium_manager import get_chromium_manager
@@ -223,6 +223,10 @@ async def lifespan(app_instance: FastAPI) -> AsyncGenerator[None]:  # noqa: ARG0
     metrics_server: MetricsServer | None = None
     if is_metrics_server_enabled():
         metrics_port = get_metrics_port()
+        # A broken TLS configuration is not an operational hiccup. It is read
+        # here, outside the tolerant start below, so it stops the service
+        # instead of leaving the metrics port silently absent.
+        get_tls_options(METRICS_TLS_PREFIX)
         metrics_server = MetricsServer(port=metrics_port)
         try:
             await metrics_server.start()

--- a/app/pandoc_controller.py
+++ b/app/pandoc_controller.py
@@ -23,7 +23,7 @@ from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.auth import ApiKeyError, get_api_keys, require_api_key
 from app.schema import VersionSchema
-from app.tls import API_TLS_PREFIX, METRICS_TLS_PREFIX, get_scheme, get_tls_options
+from app.tls import API_TLS_PREFIX, METRICS_TLS_PREFIX, get_scheme, get_tls_options, load_tls_options
 
 from . import docx_latex_pre_process, docx_post_process, html_image_pre_process, html_lists_pre_process, html_math_color_pre_process, html_paragraph_pre_process, html_table_layout, pptx_post_process
 from .chromium_manager import get_chromium_manager
@@ -226,7 +226,7 @@ async def lifespan(app_instance: FastAPI) -> AsyncGenerator[None]:  # noqa: ARG0
         # A broken TLS configuration is not an operational hiccup. It is read
         # here, outside the tolerant start below, so it stops the service
         # instead of leaving the metrics port silently absent.
-        get_tls_options(METRICS_TLS_PREFIX)
+        load_tls_options(METRICS_TLS_PREFIX)
         metrics_server = MetricsServer(port=metrics_port)
         try:
             await metrics_server.start()
@@ -1118,4 +1118,4 @@ def start_server(port: int) -> None:
     Args:
         port: The port number to listen on
     """
-    uvicorn.run(app=app, host="", port=port, **get_tls_options())
+    uvicorn.run(app=app, host="", port=port, **load_tls_options())

--- a/app/pandoc_controller.py
+++ b/app/pandoc_controller.py
@@ -23,6 +23,7 @@ from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.auth import ApiKeyError, get_api_keys, require_api_key
 from app.schema import VersionSchema
+from app.tls import API_TLS_PREFIX, get_scheme, get_tls_options
 
 from . import docx_latex_pre_process, docx_post_process, html_image_pre_process, html_lists_pre_process, html_math_color_pre_process, html_paragraph_pre_process, html_table_layout, pptx_post_process
 from .chromium_manager import get_chromium_manager
@@ -205,6 +206,10 @@ async def lifespan(app_instance: FastAPI) -> AsyncGenerator[None]:  # noqa: ARG0
         logger.info("API key authentication enabled for conversion and template endpoints (%d key(s) configured)", len(api_keys))
     else:
         logger.info("API key authentication disabled")
+
+    # Read the TLS configuration at startup, so a broken one is reported here
+    # instead of deep inside uvicorn.
+    logger.info("Pandoc service scheme: %s", get_scheme(get_tls_options(API_TLS_PREFIX)))
 
     # Initialize Prometheus info metric once at startup
     # Guard against repeated lifespan execution (e.g., uvicorn --reload, TestClient)
@@ -1109,4 +1114,4 @@ def start_server(port: int) -> None:
     Args:
         port: The port number to listen on
     """
-    uvicorn.run(app=app, host="", port=port)
+    uvicorn.run(app=app, host="", port=port, **get_tls_options())

--- a/app/tls.py
+++ b/app/tls.py
@@ -1,0 +1,123 @@
+"""Optional TLS for the servers of this service.
+
+Both servers speak plain HTTP by default, which is what a deployment behind a
+reverse proxy or an ingress expects. Where the service is reached directly, each
+server can serve TLS instead.
+
+The API server reads ``TLS_*`` and the metrics server reads ``METRICS_TLS_*``.
+The two are independent: neither inherits from the other, so the metrics port can
+stay plain while the API serves TLS, or the reverse.
+
+An incomplete configuration stops the start, it never falls back to plain HTTP.
+Silently serving in the clear while an operator believes otherwise is the one
+outcome this must not produce.
+"""
+
+from __future__ import annotations
+
+import os
+import ssl
+from pathlib import Path
+from typing import Any
+
+API_TLS_PREFIX = "TLS_"
+METRICS_TLS_PREFIX = "METRICS_TLS_"
+
+CERT_FILE = "CERT_FILE"
+KEY_FILE = "KEY_FILE"
+CLIENT_CA_FILE = "CLIENT_CA_FILE"
+CLIENT_AUTH = "CLIENT_AUTH"
+
+CLIENT_AUTH_MODES = {
+    "none": ssl.CERT_NONE,
+    "optional": ssl.CERT_OPTIONAL,
+    "required": ssl.CERT_REQUIRED,
+}
+
+
+class TlsConfigurationError(ValueError):
+    """Raised when the TLS configuration is incomplete or unusable."""
+
+
+def _read(name: str) -> str:
+    """Read an environment value, treating whitespace as unset."""
+    return os.environ.get(name, "").strip()
+
+
+def _readable_file(value: str, name: str) -> str:
+    """Return the path, or explain which variable points at an unusable file."""
+    path = Path(value)
+    if not path.is_file():
+        raise TlsConfigurationError(f"{name} points to '{value}', which is not a file")
+    try:
+        with path.open("rb"):
+            pass
+    except OSError as e:
+        raise TlsConfigurationError(f"{name} points to '{value}', which cannot be read: {e}") from e
+    return value
+
+
+def _client_auth_mode(prefix: str) -> tuple[str, int]:
+    """Resolve the client certificate mode, defaulting to no client authentication."""
+    configured = _read(prefix + CLIENT_AUTH).lower() or "none"
+    if configured not in CLIENT_AUTH_MODES:
+        allowed = ", ".join(sorted(CLIENT_AUTH_MODES))
+        raise TlsConfigurationError(f"{prefix + CLIENT_AUTH} is '{configured}', expected one of: {allowed}")
+    return configured, CLIENT_AUTH_MODES[configured]
+
+
+def get_tls_options(prefix: str = API_TLS_PREFIX) -> dict[str, Any]:
+    """
+    Build the TLS keyword arguments for uvicorn from the environment.
+
+    Args:
+        prefix: Variable prefix, API_TLS_PREFIX or METRICS_TLS_PREFIX.
+
+    Returns:
+        Keyword arguments for uvicorn.run and uvicorn.Config. Empty when TLS is
+        not configured, which leaves the server on plain HTTP.
+
+    Raises:
+        TlsConfigurationError: When the configuration is incomplete or unusable.
+    """
+    cert_file = _read(prefix + CERT_FILE)
+    key_file = _read(prefix + KEY_FILE)
+
+    if not cert_file and not key_file:
+        # A client rule without a certificate would never take effect, so it is
+        # reported rather than ignored.
+        if _read(prefix + CLIENT_AUTH).lower() not in ("", "none") or _read(prefix + CLIENT_CA_FILE):
+            raise TlsConfigurationError(f"{prefix + CLIENT_AUTH} or {prefix + CLIENT_CA_FILE} is configured without {prefix + CERT_FILE} and {prefix + KEY_FILE}")
+        return {}
+
+    if not cert_file or not key_file:
+        missing = prefix + (CERT_FILE if not cert_file else KEY_FILE)
+        raise TlsConfigurationError(f"{missing} is missing, a certificate and its key are both required")
+
+    options: dict[str, Any] = {
+        "ssl_certfile": _readable_file(cert_file, prefix + CERT_FILE),
+        "ssl_keyfile": _readable_file(key_file, prefix + KEY_FILE),
+    }
+
+    # The password is taken as it stands, whitespace included, it is a secret.
+    key_password = os.environ.get(prefix + "KEY_PASSWORD")
+    if key_password:
+        options["ssl_keyfile_password"] = key_password
+
+    mode_name, mode = _client_auth_mode(prefix)
+    client_ca_file = _read(prefix + CLIENT_CA_FILE)
+    if mode_name == "none":
+        if client_ca_file:
+            raise TlsConfigurationError(f"{prefix + CLIENT_CA_FILE} is configured while {prefix + CLIENT_AUTH} is 'none', so no client certificate would ever be verified")
+    else:
+        if not client_ca_file:
+            raise TlsConfigurationError(f"{prefix + CLIENT_CA_FILE} is required when {prefix + CLIENT_AUTH} is '{mode_name}'")
+        options["ssl_ca_certs"] = _readable_file(client_ca_file, prefix + CLIENT_CA_FILE)
+        options["ssl_cert_reqs"] = mode
+
+    return options
+
+
+def get_scheme(tls_options: dict[str, Any]) -> str:
+    """Return the URL scheme the given options serve."""
+    return "https" if tls_options else "http"

--- a/app/tls.py
+++ b/app/tls.py
@@ -126,6 +126,51 @@ def get_tls_options(prefix: str = API_TLS_PREFIX) -> dict[str, Any]:
     return options
 
 
+def verify_tls_material(options: dict[str, Any], prefix: str = API_TLS_PREFIX) -> None:
+    """
+    Load the configured certificate, key and CA once, before a server needs them.
+
+    Naming a readable file is not the same as holding usable material: a key
+    which does not match its certificate, or a wrong password, would otherwise
+    surface at the first connection, or be swallowed by a caller which tolerates
+    a server failing to start.
+
+    Args:
+        options: Result of get_tls_options, empty for plain HTTP.
+        prefix: Variable prefix the options were read with, for the message.
+
+    Raises:
+        TlsConfigurationError: When the material does not load.
+    """
+    if not options:
+        return
+
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    try:
+        context.load_cert_chain(options["ssl_certfile"], options["ssl_keyfile"], options.get("ssl_keyfile_password"))
+    except OSError as e:  # ssl.SSLError derives from it
+        raise TlsConfigurationError(f"{prefix + CERT_FILE} and {prefix + KEY_FILE} do not load together: {e}") from e
+
+    client_ca_file = options.get("ssl_ca_certs")
+    if client_ca_file:
+        try:
+            context.load_verify_locations(cafile=client_ca_file)
+        except OSError as e:  # ssl.SSLError derives from it
+            raise TlsConfigurationError(f"{prefix + CLIENT_CA_FILE} does not load: {e}") from e
+
+
+def load_tls_options(prefix: str = API_TLS_PREFIX) -> dict[str, Any]:
+    """
+    Read the configuration and prove the material loads.
+
+    This is what a server start uses. get_tls_options alone reads the rules,
+    which is what the configuration is checked against in tests.
+    """
+    options = get_tls_options(prefix)
+    verify_tls_material(options, prefix)
+    return options
+
+
 def get_scheme(tls_options: dict[str, Any]) -> str:
     """Return the URL scheme the given options serve."""
     return "https" if tls_options else "http"

--- a/app/tls.py
+++ b/app/tls.py
@@ -49,11 +49,8 @@ def _readable_file(value: str, name: str) -> str:
     path = Path(value)
     if not path.is_file():
         raise TlsConfigurationError(f"{name} points to '{value}', which is not a file")
-    try:
-        with path.open("rb"):
-            pass
-    except OSError as e:
-        raise TlsConfigurationError(f"{name} points to '{value}', which cannot be read: {e}") from e
+    if not os.access(path, os.R_OK):
+        raise TlsConfigurationError(f"{name} points to '{value}', which cannot be read")
     return value
 
 
@@ -64,6 +61,30 @@ def _client_auth_mode(prefix: str) -> tuple[str, int]:
         allowed = ", ".join(sorted(CLIENT_AUTH_MODES))
         raise TlsConfigurationError(f"{prefix + CLIENT_AUTH} is '{configured}', expected one of: {allowed}")
     return configured, CLIENT_AUTH_MODES[configured]
+
+
+def _reject_client_rules_without_certificate(prefix: str) -> None:
+    """A client rule without a certificate would never take effect."""
+    if _read(prefix + CLIENT_AUTH).lower() not in ("", "none") or _read(prefix + CLIENT_CA_FILE):
+        raise TlsConfigurationError(f"{prefix + CLIENT_AUTH} or {prefix + CLIENT_CA_FILE} is configured without {prefix + CERT_FILE} and {prefix + KEY_FILE}")
+
+
+def _client_options(prefix: str) -> dict[str, Any]:
+    """Build the client certificate arguments, empty when no client is verified."""
+    mode_name, mode = _client_auth_mode(prefix)
+    client_ca_file = _read(prefix + CLIENT_CA_FILE)
+
+    if mode_name == "none":
+        if client_ca_file:
+            raise TlsConfigurationError(f"{prefix + CLIENT_CA_FILE} is configured while {prefix + CLIENT_AUTH} is 'none', so no client certificate would ever be verified")
+        return {}
+
+    if not client_ca_file:
+        raise TlsConfigurationError(f"{prefix + CLIENT_CA_FILE} is required when {prefix + CLIENT_AUTH} is '{mode_name}'")
+    return {
+        "ssl_ca_certs": _readable_file(client_ca_file, prefix + CLIENT_CA_FILE),
+        "ssl_cert_reqs": mode,
+    }
 
 
 def get_tls_options(prefix: str = API_TLS_PREFIX) -> dict[str, Any]:
@@ -84,10 +105,7 @@ def get_tls_options(prefix: str = API_TLS_PREFIX) -> dict[str, Any]:
     key_file = _read(prefix + KEY_FILE)
 
     if not cert_file and not key_file:
-        # A client rule without a certificate would never take effect, so it is
-        # reported rather than ignored.
-        if _read(prefix + CLIENT_AUTH).lower() not in ("", "none") or _read(prefix + CLIENT_CA_FILE):
-            raise TlsConfigurationError(f"{prefix + CLIENT_AUTH} or {prefix + CLIENT_CA_FILE} is configured without {prefix + CERT_FILE} and {prefix + KEY_FILE}")
+        _reject_client_rules_without_certificate(prefix)
         return {}
 
     if not cert_file or not key_file:
@@ -104,17 +122,7 @@ def get_tls_options(prefix: str = API_TLS_PREFIX) -> dict[str, Any]:
     if key_password:
         options["ssl_keyfile_password"] = key_password
 
-    mode_name, mode = _client_auth_mode(prefix)
-    client_ca_file = _read(prefix + CLIENT_CA_FILE)
-    if mode_name == "none":
-        if client_ca_file:
-            raise TlsConfigurationError(f"{prefix + CLIENT_CA_FILE} is configured while {prefix + CLIENT_AUTH} is 'none', so no client certificate would ever be verified")
-    else:
-        if not client_ca_file:
-            raise TlsConfigurationError(f"{prefix + CLIENT_CA_FILE} is required when {prefix + CLIENT_AUTH} is '{mode_name}'")
-        options["ssl_ca_certs"] = _readable_file(client_ca_file, prefix + CLIENT_CA_FILE)
-        options["ssl_cert_reqs"] = mode
-
+    options.update(_client_options(prefix))
     return options
 
 

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Docker healthcheck. Follows the scheme the API server was configured with.
+set -eu
+
+port="${PORT:-9082}"
+url="http://localhost:${port}/health"
+set --
+
+if [ -n "${TLS_CERT_FILE:-}" ]; then
+    url="https://localhost:${port}/health"
+    # The certificate is verified by the caller of the service, not here: this
+    # probe talks to its own process over the loopback interface and asks one
+    # question, whether that process still answers.
+    set -- --insecure
+    # A server demanding a client certificate rejects the probe without one.
+    if [ -n "${TLS_HEALTHCHECK_CERT_FILE:-}" ] && [ -n "${TLS_HEALTHCHECK_KEY_FILE:-}" ]; then
+        set -- "$@" --cert "${TLS_HEALTHCHECK_CERT_FILE}" --key "${TLS_HEALTHCHECK_KEY_FILE}"
+    fi
+fi
+
+exec curl --fail --silent --show-error "$@" "${url}"

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -17,11 +17,11 @@ cert_file="$(trim "${TLS_CERT_FILE:-}")"
 probe_cert="$(trim "${TLS_HEALTHCHECK_CERT_FILE:-}")"
 probe_key="$(trim "${TLS_HEALTHCHECK_KEY_FILE:-}")"
 
-url="http://localhost:${port}/health"
+url="http://localhost:9082/health"
 set --
 
 if [ -n "${cert_file}" ]; then
-    url="https://localhost:${port}/health"
+    url="https://localhost:9082/health"
     # The certificate is verified by the caller of the service, not here: this
     # probe talks to its own process over the loopback interface and asks one
     # question, whether that process still answers.

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -2,19 +2,37 @@
 # Docker healthcheck. Follows the scheme the API server was configured with.
 set -eu
 
-port="${PORT:-9082}"
+# Strip surrounding whitespace. app/tls.py reads a blank value as unset, and the
+# probe has to reach the same verdict, or it would ask for a scheme the server
+# does not serve.
+trim() {
+    trimmed="$1"
+    trimmed="${trimmed#"${trimmed%%[![:space:]]*}"}"
+    trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+    printf '%s' "${trimmed}"
+}
+
+port="$(trim "${PORT:-9082}")"
+cert_file="$(trim "${TLS_CERT_FILE:-}")"
+probe_cert="$(trim "${TLS_HEALTHCHECK_CERT_FILE:-}")"
+probe_key="$(trim "${TLS_HEALTHCHECK_KEY_FILE:-}")"
+
 url="http://localhost:${port}/health"
 set --
 
-if [ -n "${TLS_CERT_FILE:-}" ]; then
+if [ -n "${cert_file}" ]; then
     url="https://localhost:${port}/health"
     # The certificate is verified by the caller of the service, not here: this
     # probe talks to its own process over the loopback interface and asks one
     # question, whether that process still answers.
     set -- --insecure
     # A server demanding a client certificate rejects the probe without one.
-    if [ -n "${TLS_HEALTHCHECK_CERT_FILE:-}" ] && [ -n "${TLS_HEALTHCHECK_KEY_FILE:-}" ]; then
-        set -- "$@" --cert "${TLS_HEALTHCHECK_CERT_FILE}" --key "${TLS_HEALTHCHECK_KEY_FILE}"
+    if [ -n "${probe_cert}" ] || [ -n "${probe_key}" ]; then
+        if [ -z "${probe_cert}" ] || [ -z "${probe_key}" ]; then
+            echo "TLS_HEALTHCHECK_CERT_FILE and TLS_HEALTHCHECK_KEY_FILE have to be set together" >&2
+            exit 1
+        fi
+        set -- "$@" --cert "${probe_cert}" --key "${probe_key}"
     fi
 fi
 

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -46,12 +46,6 @@ def test_plain_http_by_default(run_healthcheck) -> None:
     assert "--insecure" not in args
 
 
-def test_port_is_taken_from_the_environment(run_healthcheck) -> None:
-    _, args = run_healthcheck({"PORT": "9999"})
-
-    assert args[-1] == "http://localhost:9999/health"
-
-
 def test_configured_certificate_switches_the_scheme(run_healthcheck) -> None:
     completed, args = run_healthcheck({"TLS_CERT_FILE": "/tls/server.pem"})
 

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,0 +1,93 @@
+"""Tests for the container healthcheck script."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HEALTHCHECK = Path(__file__).parent.parent / "healthcheck.sh"
+
+FAKE_CURL = """#!/bin/sh
+printf '%s\\n' "$@" > "${CURL_ARGS_FILE}"
+"""
+
+
+@pytest.fixture
+def run_healthcheck(tmp_path: Path):
+    """Run the script with curl replaced by a recorder, and return its result and arguments."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_curl = bin_dir / "curl"
+    fake_curl.write_text(FAKE_CURL, encoding="utf-8")
+    fake_curl.chmod(0o755)
+    args_file = tmp_path / "curl-args"
+
+    def run(env: dict[str, str]) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+        completed = subprocess.run(
+            ["/bin/sh", str(HEALTHCHECK)],
+            capture_output=True,
+            text=True,
+            check=False,
+            env={"PATH": f"{bin_dir}:/usr/bin:/bin", "CURL_ARGS_FILE": str(args_file), **env},
+        )
+        recorded = args_file.read_text(encoding="utf-8").split() if args_file.exists() else []
+        return completed, recorded
+
+    return run
+
+
+def test_plain_http_by_default(run_healthcheck) -> None:
+    completed, args = run_healthcheck({})
+
+    assert completed.returncode == 0
+    assert args[-1] == "http://localhost:9082/health"
+    assert "--insecure" not in args
+
+
+def test_port_is_taken_from_the_environment(run_healthcheck) -> None:
+    _, args = run_healthcheck({"PORT": "9999"})
+
+    assert args[-1] == "http://localhost:9999/health"
+
+
+def test_configured_certificate_switches_the_scheme(run_healthcheck) -> None:
+    completed, args = run_healthcheck({"TLS_CERT_FILE": "/tls/server.pem"})
+
+    assert completed.returncode == 0
+    assert args[-1] == "https://localhost:9082/health"
+    assert "--insecure" in args
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t"])
+def test_blank_certificate_stays_on_http(run_healthcheck, blank: str) -> None:
+    """app/tls.py reads a blank value as unset, so the probe has to agree."""
+    _, args = run_healthcheck({"TLS_CERT_FILE": blank})
+
+    assert args[-1] == "http://localhost:9082/health"
+
+
+def test_client_certificate_is_passed_to_curl(run_healthcheck) -> None:
+    completed, args = run_healthcheck(
+        {
+            "TLS_CERT_FILE": "/tls/server.pem",
+            "TLS_HEALTHCHECK_CERT_FILE": "/tls/probe.pem",
+            "TLS_HEALTHCHECK_KEY_FILE": "/tls/probe.key",
+        }
+    )
+
+    assert completed.returncode == 0
+    assert "--cert" in args
+    assert "/tls/probe.pem" in args
+    assert "--key" in args
+    assert "/tls/probe.key" in args
+
+
+@pytest.mark.parametrize("configured", ["TLS_HEALTHCHECK_CERT_FILE", "TLS_HEALTHCHECK_KEY_FILE"])
+def test_half_configured_client_certificate_is_reported(run_healthcheck, configured: str) -> None:
+    """One half of the pair would fail the handshake with nothing naming the cause."""
+    completed, _ = run_healthcheck({"TLS_CERT_FILE": "/tls/server.pem", configured: "/tls/probe"})
+
+    assert completed.returncode == 1
+    assert "TLS_HEALTHCHECK_CERT_FILE and TLS_HEALTHCHECK_KEY_FILE" in completed.stderr

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -1,0 +1,212 @@
+"""Tests for the optional TLS configuration."""
+
+import asyncio
+import ssl
+from pathlib import Path
+
+import pytest
+
+from app import metrics_server, pandoc_controller
+from app.tls import (
+    API_TLS_PREFIX,
+    METRICS_TLS_PREFIX,
+    TlsConfigurationError,
+    get_scheme,
+    get_tls_options,
+)
+
+TLS_VARIABLES = [prefix + suffix for prefix in (API_TLS_PREFIX, METRICS_TLS_PREFIX) for suffix in ("CERT_FILE", "KEY_FILE", "KEY_PASSWORD", "CLIENT_CA_FILE", "CLIENT_AUTH")]
+
+
+@pytest.fixture(autouse=True)
+def clean_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start every test from an unconfigured environment."""
+    for name in TLS_VARIABLES:
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture
+def pem_files(tmp_path: Path) -> tuple[str, str, str]:
+    """Three readable files standing in for a certificate, a key and a CA."""
+    paths = []
+    for name in ("cert.pem", "key.pem", "ca.pem"):
+        path = tmp_path / name
+        path.write_text(f"-----BEGIN {name}-----\n", encoding="utf-8")
+        paths.append(str(path))
+    return paths[0], paths[1], paths[2]
+
+
+def test_unconfigured_environment_serves_plain_http() -> None:
+    assert get_tls_options() == {}
+    assert get_scheme({}) == "http"
+
+
+def test_whitespace_only_value_counts_as_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TLS_CERT_FILE", "   ")
+    monkeypatch.setenv("TLS_KEY_FILE", "   ")
+
+    assert get_tls_options() == {}
+
+
+def test_certificate_and_key_enable_tls(monkeypatch: pytest.MonkeyPatch, pem_files: tuple[str, str, str]) -> None:
+    cert, key, _ = pem_files
+    monkeypatch.setenv("TLS_CERT_FILE", cert)
+    monkeypatch.setenv("TLS_KEY_FILE", key)
+
+    options = get_tls_options()
+
+    assert options == {"ssl_certfile": cert, "ssl_keyfile": key}
+    assert get_scheme(options) == "https"
+
+
+def test_key_password_is_passed_unchanged(monkeypatch: pytest.MonkeyPatch, pem_files: tuple[str, str, str]) -> None:
+    cert, key, _ = pem_files
+    monkeypatch.setenv("TLS_CERT_FILE", cert)
+    monkeypatch.setenv("TLS_KEY_FILE", key)
+    monkeypatch.setenv("TLS_KEY_PASSWORD", "  pass phrase  ")
+
+    assert get_tls_options()["ssl_keyfile_password"] == "  pass phrase  "
+
+
+@pytest.mark.parametrize(("mode", "expected"), [("optional", ssl.CERT_OPTIONAL), ("required", ssl.CERT_REQUIRED), ("REQUIRED", ssl.CERT_REQUIRED)])
+def test_client_authentication_modes(monkeypatch: pytest.MonkeyPatch, pem_files: tuple[str, str, str], mode: str, expected: int) -> None:
+    cert, key, ca = pem_files
+    monkeypatch.setenv("TLS_CERT_FILE", cert)
+    monkeypatch.setenv("TLS_KEY_FILE", key)
+    monkeypatch.setenv("TLS_CLIENT_AUTH", mode)
+    monkeypatch.setenv("TLS_CLIENT_CA_FILE", ca)
+
+    options = get_tls_options()
+
+    assert options["ssl_ca_certs"] == ca
+    assert options["ssl_cert_reqs"] == expected
+
+
+def test_metrics_server_is_configured_on_its_own(monkeypatch: pytest.MonkeyPatch, pem_files: tuple[str, str, str]) -> None:
+    """The API prefix must not leak into the metrics server, nor the other way round."""
+    cert, key, _ = pem_files
+    monkeypatch.setenv("TLS_CERT_FILE", cert)
+    monkeypatch.setenv("TLS_KEY_FILE", key)
+
+    assert get_tls_options(API_TLS_PREFIX) != {}
+    assert get_tls_options(METRICS_TLS_PREFIX) == {}
+
+
+def test_metrics_prefix_enables_tls_alone(monkeypatch: pytest.MonkeyPatch, pem_files: tuple[str, str, str]) -> None:
+    cert, key, _ = pem_files
+    monkeypatch.setenv("METRICS_TLS_CERT_FILE", cert)
+    monkeypatch.setenv("METRICS_TLS_KEY_FILE", key)
+
+    assert get_tls_options(METRICS_TLS_PREFIX) == {"ssl_certfile": cert, "ssl_keyfile": key}
+    assert get_tls_options(API_TLS_PREFIX) == {}
+
+
+def test_certificate_without_key_is_rejected(monkeypatch: pytest.MonkeyPatch, pem_files: tuple[str, str, str]) -> None:
+    cert, _, _ = pem_files
+    monkeypatch.setenv("TLS_CERT_FILE", cert)
+
+    with pytest.raises(TlsConfigurationError, match="TLS_KEY_FILE is missing"):
+        get_tls_options()
+
+
+def test_key_without_certificate_is_rejected(monkeypatch: pytest.MonkeyPatch, pem_files: tuple[str, str, str]) -> None:
+    _, key, _ = pem_files
+    monkeypatch.setenv("TLS_KEY_FILE", key)
+
+    with pytest.raises(TlsConfigurationError, match="TLS_CERT_FILE is missing"):
+        get_tls_options()
+
+
+def test_unreadable_certificate_is_rejected(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, pem_files: tuple[str, str, str]) -> None:
+    _, key, _ = pem_files
+    monkeypatch.setenv("TLS_CERT_FILE", str(tmp_path / "absent.pem"))
+    monkeypatch.setenv("TLS_KEY_FILE", key)
+
+    with pytest.raises(TlsConfigurationError, match="which is not a file"):
+        get_tls_options()
+
+
+def test_unknown_client_auth_mode_is_rejected(monkeypatch: pytest.MonkeyPatch, pem_files: tuple[str, str, str]) -> None:
+    cert, key, ca = pem_files
+    monkeypatch.setenv("TLS_CERT_FILE", cert)
+    monkeypatch.setenv("TLS_KEY_FILE", key)
+    monkeypatch.setenv("TLS_CLIENT_AUTH", "yes-please")
+    monkeypatch.setenv("TLS_CLIENT_CA_FILE", ca)
+
+    with pytest.raises(TlsConfigurationError, match="expected one of"):
+        get_tls_options()
+
+
+def test_client_auth_without_ca_is_rejected(monkeypatch: pytest.MonkeyPatch, pem_files: tuple[str, str, str]) -> None:
+    cert, key, _ = pem_files
+    monkeypatch.setenv("TLS_CERT_FILE", cert)
+    monkeypatch.setenv("TLS_KEY_FILE", key)
+    monkeypatch.setenv("TLS_CLIENT_AUTH", "required")
+
+    with pytest.raises(TlsConfigurationError, match="TLS_CLIENT_CA_FILE is required"):
+        get_tls_options()
+
+
+def test_client_ca_without_client_auth_is_rejected(monkeypatch: pytest.MonkeyPatch, pem_files: tuple[str, str, str]) -> None:
+    """A CA which nothing verifies against is a configuration mistake, not a default."""
+    cert, key, ca = pem_files
+    monkeypatch.setenv("TLS_CERT_FILE", cert)
+    monkeypatch.setenv("TLS_KEY_FILE", key)
+    monkeypatch.setenv("TLS_CLIENT_CA_FILE", ca)
+
+    with pytest.raises(TlsConfigurationError, match="no client certificate would ever be verified"):
+        get_tls_options()
+
+
+def test_client_rules_without_a_certificate_are_rejected(monkeypatch: pytest.MonkeyPatch, pem_files: tuple[str, str, str]) -> None:
+    """Client authentication configured while TLS is off would silently do nothing."""
+    _, _, ca = pem_files
+    monkeypatch.setenv("TLS_CLIENT_AUTH", "required")
+    monkeypatch.setenv("TLS_CLIENT_CA_FILE", ca)
+
+    with pytest.raises(TlsConfigurationError, match="without TLS_CERT_FILE"):
+        get_tls_options()
+
+
+def test_api_server_is_started_with_the_configured_options(monkeypatch: pytest.MonkeyPatch, pem_files: tuple[str, str, str]) -> None:
+    cert, key, _ = pem_files
+    monkeypatch.setenv("TLS_CERT_FILE", cert)
+    monkeypatch.setenv("TLS_KEY_FILE", key)
+    captured: dict[str, object] = {}
+
+    def fake_run(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(pandoc_controller.uvicorn, "run", fake_run)
+    pandoc_controller.start_server(9082)
+
+    assert captured["ssl_certfile"] == cert
+    assert captured["ssl_keyfile"] == key
+
+
+def test_metrics_server_is_configured_with_its_own_options(monkeypatch: pytest.MonkeyPatch, pem_files: tuple[str, str, str]) -> None:
+    cert, key, _ = pem_files
+    monkeypatch.setenv("METRICS_TLS_CERT_FILE", cert)
+    monkeypatch.setenv("METRICS_TLS_KEY_FILE", key)
+    captured: dict[str, object] = {}
+
+    class FakeConfig:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+    class FakeServer:
+        started = True
+
+        def __init__(self, config: FakeConfig) -> None:
+            self.config = config
+
+        async def serve(self) -> None:
+            return None
+
+    monkeypatch.setattr(metrics_server.uvicorn, "Config", FakeConfig)
+    monkeypatch.setattr(metrics_server.uvicorn, "Server", FakeServer)
+
+    asyncio.run(metrics_server.MetricsServer(port=9182).start())
+
+    assert captured["ssl_certfile"] == cert
+    assert captured["ssl_keyfile"] == key

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -5,6 +5,7 @@ import ssl
 from pathlib import Path
 
 import pytest
+from starlette.testclient import TestClient
 
 from app import metrics_server, pandoc_controller
 from app.tls import (
@@ -166,6 +167,16 @@ def test_client_rules_without_a_certificate_are_rejected(monkeypatch: pytest.Mon
 
     with pytest.raises(TlsConfigurationError, match="without TLS_CERT_FILE"):
         get_tls_options()
+
+
+def test_broken_metrics_configuration_stops_the_start(monkeypatch: pytest.MonkeyPatch, pem_files: tuple[str, str, str]) -> None:
+    """The lifespan tolerates a metrics server which fails to bind, not one configured wrongly."""
+    cert, _, _ = pem_files
+    monkeypatch.setenv("METRICS_SERVER_ENABLED", "true")
+    monkeypatch.setenv("METRICS_TLS_CERT_FILE", cert)
+
+    with pytest.raises(TlsConfigurationError, match="METRICS_TLS_KEY_FILE is missing"), TestClient(pandoc_controller.app):
+        pass  # pragma: no cover - the context manager raises on entry
 
 
 def test_api_server_is_started_with_the_configured_options(monkeypatch: pytest.MonkeyPatch, pem_files: tuple[str, str, str]) -> None:

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -1,7 +1,9 @@
 """Tests for the optional TLS configuration."""
 
 import asyncio
+import shutil
 import ssl
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -14,6 +16,8 @@ from app.tls import (
     TlsConfigurationError,
     get_scheme,
     get_tls_options,
+    load_tls_options,
+    verify_tls_material,
 )
 
 TLS_VARIABLES = [prefix + suffix for prefix in (API_TLS_PREFIX, METRICS_TLS_PREFIX) for suffix in ("CERT_FILE", "KEY_FILE", "KEY_PASSWORD", "CLIENT_CA_FILE", "CLIENT_AUTH")]
@@ -169,6 +173,39 @@ def test_client_rules_without_a_certificate_are_rejected(monkeypatch: pytest.Mon
         get_tls_options()
 
 
+def test_material_which_does_not_load_is_reported(monkeypatch: pytest.MonkeyPatch, pem_files: tuple[str, str, str]) -> None:
+    """A readable file is not usable material: the key has to match its certificate."""
+    cert, key, _ = pem_files
+    monkeypatch.setenv("TLS_CERT_FILE", cert)
+    monkeypatch.setenv("TLS_KEY_FILE", key)
+
+    with pytest.raises(TlsConfigurationError, match="do not load together"):
+        load_tls_options()
+
+
+def test_nothing_is_loaded_without_a_configuration() -> None:
+    assert load_tls_options() == {}
+    verify_tls_material({})
+
+
+def test_real_material_loads(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    openssl = shutil.which("openssl")
+    if not openssl:
+        pytest.skip("openssl is not available to produce a certificate")
+
+    cert = tmp_path / "server.pem"
+    key = tmp_path / "server.key"
+    subprocess.run(
+        [openssl, "req", "-x509", "-newkey", "rsa:2048", "-nodes", "-keyout", str(key), "-out", str(cert), "-days", "1", "-subj", "/CN=localhost"],
+        check=True,
+        capture_output=True,
+    )
+    monkeypatch.setenv("TLS_CERT_FILE", str(cert))
+    monkeypatch.setenv("TLS_KEY_FILE", str(key))
+
+    assert load_tls_options() == {"ssl_certfile": str(cert), "ssl_keyfile": str(key)}
+
+
 def test_broken_metrics_configuration_stops_the_start(monkeypatch: pytest.MonkeyPatch, pem_files: tuple[str, str, str]) -> None:
     """The lifespan tolerates a metrics server which fails to bind, not one configured wrongly."""
     cert, _, _ = pem_files
@@ -183,6 +220,7 @@ def test_api_server_is_started_with_the_configured_options(monkeypatch: pytest.M
     cert, key, _ = pem_files
     monkeypatch.setenv("TLS_CERT_FILE", cert)
     monkeypatch.setenv("TLS_KEY_FILE", key)
+    monkeypatch.setattr(pandoc_controller, "load_tls_options", lambda: {"ssl_certfile": cert, "ssl_keyfile": key})
     captured: dict[str, object] = {}
 
     def fake_run(**kwargs: object) -> None:
@@ -199,6 +237,7 @@ def test_metrics_server_is_configured_with_its_own_options(monkeypatch: pytest.M
     cert, key, _ = pem_files
     monkeypatch.setenv("METRICS_TLS_CERT_FILE", cert)
     monkeypatch.setenv("METRICS_TLS_KEY_FILE", key)
+    monkeypatch.setattr(metrics_server, "load_tls_options", lambda prefix: {"ssl_certfile": cert, "ssl_keyfile": key})
     captured: dict[str, object] = {}
 
     class FakeConfig:


### PR DESCRIPTION
### Proposed changes

Closes #221.

Both servers can now serve TLS. The feature is optional and off by default, so an unset configuration keeps the plain HTTP of today and no deployment changes behavior on upgrade.

- `app/tls.py` builds the uvicorn TLS arguments from the environment. The API server reads `TLS_CERT_FILE`, `TLS_KEY_FILE`, `TLS_KEY_PASSWORD`, `TLS_CLIENT_CA_FILE` and `TLS_CLIENT_AUTH`; the metrics server reads the same five with a `METRICS_TLS_` prefix. The two are independent and neither inherits from the other, so the metrics port can stay plain behind a network rule while the API is encrypted, or the reverse.
- A certificate without its key, an unreadable file, an unknown client-auth mode, client authentication without a CA, and a CA without client authentication each stop the start with a message naming the variable. There is no fallback to plain HTTP: serving in the clear while an operator believes otherwise is the one outcome this must not produce.
- `TLS_CLIENT_AUTH=required` turns on mutual TLS, which authenticates the caller by certificate. It combines with the API key of #217: the certificate says who connected, the key says who may convert.
- The startup log states the scheme of each server, next to the port it already logged.
- `healthcheck.sh` replaces the inline curl of the Dockerfile and follows the configured scheme. It talks to its own process over loopback, so it does not verify the certificate; where client certificates are required it takes one from `TLS_HEALTHCHECK_CERT_FILE` and `TLS_HEALTHCHECK_KEY_FILE`.
- The README documents all of it, including that a reverse proxy remains the recommended setup where one is already in place, that a renewed certificate needs a container restart, and that Prometheus needs `scheme: https` once the metrics port serves TLS.

The sibling change for the WeasyPrint service is SchweizerischeBundesbahnen/weasyprint-service#355, so the two services are configured alike.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
