### PR TITLE
fix: keep a document from reaching the resources of this container

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ bash tests/shell/test_pandoc_service.sh
 - **app/prometheus_metrics.py**, **app/pandoc_metrics.py**, **app/metrics_server.py**: Prometheus metrics instrumentation (incl. SVG/Chromium metrics)
 
 ### Security Model
+- Pandoc runs with `--sandbox` by default (`PANDOC_SANDBOX`, see `is_sandbox_enabled`), so a document cannot make it read a network address or a container path. Lua filters, `--reference-doc`, tectonic and `data:` URI images are unaffected. tectonic runs outside that sandbox and reads what the TeX names, so on the pdf and latex targets `filters/strip_raw_tex.lua` drops the raw TeX of the document and the file-reading primitives inside math, and `filters/strip_document_images.lua` drops images whose address is neither a `data:` URI nor in pandoc's media bag, which covers every source format. Both run before the docx filters emit their own raw LaTeX.
 - Uses allowlisted pandoc options to prevent command injection
 - Direct subprocess calls to pandoc binary (no shell=True)
 - Input validation with 200MB request size limit

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,6 +144,8 @@ RUN chmod +x "${WORKING_DIR}/entrypoint.sh" "${WORKING_DIR}/healthcheck.sh"
 
 COPY filters/page_orientation.lua "/usr/local/share/pandoc/filters/page_orientation.lua"
 COPY filters/heading_levels.lua "/usr/local/share/pandoc/filters/heading_levels.lua"
+COPY filters/strip_raw_tex.lua "/usr/local/share/pandoc/filters/strip_raw_tex.lua"
+COPY filters/strip_document_images.lua "/usr/local/share/pandoc/filters/strip_document_images.lua"
 COPY filters/inline_styles.lua "/usr/local/share/pandoc/filters/inline_styles.lua"
 COPY filters/docx_text_decorations.lua "/usr/local/share/pandoc/filters/docx_text_decorations.lua"
 COPY filters/docx_colors_to_latex.lua "/usr/local/share/pandoc/filters/docx_colors_to_latex.lua"

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ resolves what the TeX names. These routes reach it, and every one of them is clo
 | raw TeX, `\input{/etc/passwd}` as a raw block or inline | dropped before the LaTeX writer |
 | the same primitive inside math, `$\input{...}$`, which the writer emits verbatim | that formula is dropped, every other one renders as before |
 | an image the document points at by address, which becomes `\includegraphics{...}` | dropped, whatever the source format |
+| TeX in the name of a DOCX character style, which the colour filters build raw LaTeX from | only six hex digits are written out, the rest of the name is dropped |
 
 Math is the one thing the writer emits verbatim, so it is held to a rule rather than to a list of the
 spellings which have been thought of. A formula is dropped when it does any of three things, and what

--- a/README.md
+++ b/README.md
@@ -101,6 +101,55 @@ The `/health` endpoint reports a `chromium` status (`available` / `disabled` /
 is informational and does not by itself mark the service unhealthy. The Chromium
 version is reported by the `/version` endpoint.
 
+### External resources of a document
+
+A document names its own resources: an image, a stylesheet, a font. The writers which embed media
+fetch what it names, so a document reaching this service can ask it to read an address on the network
+or a path inside its container, and the answer lands in the converted result.
+
+The service therefore runs pandoc sandboxed, and does so by default. Sandboxed, pandoc reads nothing
+a document names: no host of the network it sits in, no file of the container. What still works is
+everything the conversion itself needs, verified against this image: the lua filters, `--reference-doc`
+templates, the tectonic PDF engine, and images carried inside the document as `data:` URIs, which is
+how `docx-exporter` sends them.
+
+A PDF is produced by handing the generated LaTeX to tectonic, which runs outside that sandbox and
+resolves what the TeX names. These routes reach it, and every one of them is closed on the `pdf` and
+`latex` targets:
+
+| Route | What is done |
+|---|---|
+| raw TeX, `\input{/etc/passwd}` as a raw block or inline | dropped before the LaTeX writer |
+| the same primitive inside math, `$\input{...}$`, which the writer emits verbatim | that formula is dropped, every other one renders as before |
+| an image the document points at by address, which becomes `\includegraphics{...}` | dropped, whatever the source format |
+
+Math is the one thing the writer emits verbatim, so it is held to a rule rather than to a list of the
+spellings which have been thought of. A formula is dropped when it does any of three things, and what
+is left cannot reach a file:
+
+| A formula may not | Why |
+|---|---|
+| name a primitive which reads, writes or runs something: `\input`, `\openin`, `\write`, `\font`, `\usepackage`, `\includegraphics` and the rest | these are what resolve a path |
+| build a name, alias one, or read a character as another: `\csname`, `\expandafter`, `\scantokens`, `\def`, `\let`, `\catcode`, and the `^^` notation TeX reads as a character | a formula which cannot make a name cannot reach a primitive the first rule does not list |
+| carry `@`, which is a letter only under `\makeatletter` | that is how the LaTeX kernel keeps its own names, `\@@input` among them, away from a document |
+
+The `@` rule costs the commutative diagrams of amsmath, which spell their arrows `@>>>`. Every other
+formula renders as before, verified against this image: fractions, greek letters, sums, integrals,
+matrices, `aligned`, and text inside math.
+
+What the DOCX filters of this service emit afterwards is untouched, so the colors, lists and tables of
+a DOCX export are unaffected. An image is kept when it travels inside the document: a `data:` URI, or
+media pandoc extracted itself, which is what it asks its media bag rather than the source format, so
+an EPUB naming an address of its own is covered like a markdown source is. A document which needs its
+own TeX macros, or which points at an image by address, loses them in the PDF.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `PANDOC_SANDBOX` | `true` | Run pandoc with `--sandbox`. Set it to `false` to let a document load its own resources again. |
+
+Turning it off restores the reach of a document into the network and the file system of the container,
+so it belongs to a deployment where every caller is trusted and remote images are needed.
+
 ### HTTPS
 
 Both servers speak plain HTTP by default, which is what a deployment behind a reverse proxy or an ingress expects: TLS terminates there and nothing has to be configured here. That remains the recommended setup where such a component is already in place.

--- a/app/pandoc_controller.py
+++ b/app/pandoc_controller.py
@@ -66,6 +66,8 @@ FILTERS = {
     "html_tables_to_latex": f"{FILTER_BASE_PATH}/html_tables_to_latex.lua",
     "html_captions": f"{FILTER_BASE_PATH}/html_captions.lua",
     "docx_caption_labels_to_latex": f"{FILTER_BASE_PATH}/docx_caption_labels_to_latex.lua",
+    "strip_raw_tex": f"{FILTER_BASE_PATH}/strip_raw_tex.lua",
+    "strip_document_images": f"{FILTER_BASE_PATH}/strip_document_images.lua",
 }
 
 # List of allowed pandoc options for security
@@ -95,6 +97,10 @@ ALLOWED_PANDOC_OPTIONS = [
 # helps for these targets — for DOCX -> DOCX/HTML/etc. we leave the input
 # alone.
 _LATEX_TARGET_FORMATS = frozenset({"pdf", "latex"})
+
+# Only these turn the sandbox off, everything else keeps it on.
+_SANDBOX_OFF_VALUES = frozenset({"false", "0", "no", "off"})
+_SANDBOX_ON_VALUES = frozenset({"true", "1", "yes", "on"})
 
 # Add other allowed formats as needed
 ALLOWED_SOURCE_FORMATS = ["docx", "epub", "fb2", "html", "json", "latex", "markdown", "rtf", "textile"]
@@ -565,6 +571,23 @@ def _build_pandoc_command(
     pandoc_source_format = f"{source_format}+styles" if apply_docx_latex_filters else source_format
     cmd = [PANDOC_PATH, "-f", pandoc_source_format, "-t", target_format, "-o", output_path, source_path]
 
+    # A document names its own resources, and the writers embedding media fetch
+    # them: an address on the network, or a path in this container. The sandbox
+    # closes both. Lua filters, --reference-doc, the tectonic PDF engine and
+    # images carried as data: URIs all keep working inside it.
+    if is_sandbox_enabled():
+        cmd.append("--sandbox")
+        # A PDF is produced by handing the generated LaTeX to tectonic, which
+        # runs outside the sandbox and reads what the TeX names. The raw TeX of
+        # the document is dropped before it can get there. This filter runs
+        # first, so the raw LaTeX the docx filters emit later survives.
+        if target_format in _LATEX_TARGET_FORMATS:
+            cmd.append(f"--lua-filter={FILTERS['strip_raw_tex']}")
+            # An image becomes \includegraphics, which the engine resolves, so a
+            # document may not point at an address of its own. What it carries
+            # inside itself is kept, whatever the source format.
+            cmd.append(f"--lua-filter={FILTERS['strip_document_images']}")
+
     # Convert inline CSS on HTML <span style="..."> into raw OOXML runs for
     # the DOCX writer. The filter emits RawInline("openxml", ...) nodes which
     # only render when the target writer is docx; for any other target
@@ -619,6 +642,28 @@ def _build_pandoc_command(
     if validated_options:
         cmd.extend(validated_options)
     return cmd
+
+
+def is_sandbox_enabled() -> bool:
+    """
+    Whether pandoc runs sandboxed, which is the default.
+
+    Sandboxed, pandoc reads no address and no path the document names. Turning
+    it off restores the behavior of a service which loads whatever a document
+    asks for, including a file of this container and a host of its network.
+
+    Only an understood value turns it off. A typo keeps the sandbox and says so,
+    because the other way round a misspelled variable would open the service
+    without anyone noticing.
+    """
+    configured = os.environ.get("PANDOC_SANDBOX", "").strip().lower()
+    if not configured:
+        return True
+    if configured in _SANDBOX_OFF_VALUES:
+        return False
+    if configured not in _SANDBOX_ON_VALUES:
+        logger.warning("PANDOC_SANDBOX is '%s', which is not understood. Keeping pandoc sandboxed.", configured)
+    return True
 
 
 def is_svg_conversion_enabled() -> bool:

--- a/filters/docx_colors_to_latex.lua
+++ b/filters/docx_colors_to_latex.lua
@@ -129,15 +129,26 @@ end
 -- Each segment is "<KEY>_<value>" with KEY in {FG, BG, HL, SZ} and value with
 -- no internal underscore (6-char hex, a Word highlight identifier, or — for
 -- SZ — the font size in half-points).
+-- Valid 6-char hex colour, the same guard docx_tables_to_latex.lua puts in
+-- front of \cellcolor. A style name is document controlled: the preprocessor
+-- writes these names, but a DOCX may carry a character style of its own called
+-- "PandocColor__FG_AAAAAA}{\input{/etc/passwd}", and the value reaches a raw
+-- LaTeX node which this filter emits after the strip filter has run. Anything
+-- which is not a colour is dropped rather than written out. Verified against
+-- this image.
+local function valid_hex(s)
+  return s and #s == 6 and s:match("^%x%x%x%x%x%x$") ~= nil
+end
+
 local function parse_style(name)
   if name:sub(1, #STYLE_PREFIX) ~= STYLE_PREFIX then
     return nil
   end
   local props = {}
   for key, value in name:gmatch("__(%a+)_([^_]+)") do
-    if key == "FG" then
+    if key == "FG" and valid_hex(value) then
       props.fg = value
-    elseif key == "BG" then
+    elseif key == "BG" and valid_hex(value) then
       props.bg = value
     elseif key == "HL" then
       props.hl = value

--- a/filters/strip_document_images.lua
+++ b/filters/strip_document_images.lua
@@ -1,0 +1,23 @@
+--[[
+Drop the images a document points at by address, on the paths which end in a TeX
+engine.
+
+An image becomes `\includegraphics{...}` in the generated LaTeX, and tectonic
+runs outside the pandoc sandbox: a document naming a file of the container
+therefore puts that file into the PDF. Verified against this image.
+
+What travels inside the document is kept: a `data:` URI, and anything pandoc
+extracted itself, which it holds in the media bag. Asking the media bag rather
+than the source format covers every reader, an EPUB among them, whose XHTML can
+name an address of its own just like a markdown source can.
+]]
+
+function Image(element)
+  if element.src:match("^data:") then
+    return nil
+  end
+  if pandoc.mediabag.lookup(element.src) then
+    return nil
+  end
+  return {}
+end

--- a/filters/strip_raw_tex.lua
+++ b/filters/strip_raw_tex.lua
@@ -1,0 +1,108 @@
+--[[
+Keep the TeX a document carries away from the engine which runs it.
+
+`--sandbox` keeps pandoc itself from reading an address or a path a document
+names, but a PDF is produced by handing the generated LaTeX to tectonic, which
+runs outside that sandbox and resolves what the TeX names. Three routes reach
+it, all verified against this image:
+
+  * raw TeX,          `\input{/etc/passwd}` written as a raw block or inline,
+  * math,             the same primitive inside `$...$`, which the writer emits
+                      verbatim, however the formula spells it,
+  * an image path,    which becomes `\includegraphics{...}` and puts the file
+                      into the PDF.
+
+This filter runs first, so it removes what the reader produced from the
+document. The raw LaTeX the docx filters emit afterwards is untouched, which is
+what keeps the colors, lists and tables of a DOCX export working.
+
+A formula which reaches for such a primitive is dropped whole: editing TeX to
+keep the rest of it would be guesswork, and a formula is not where a document
+reads a file. Every other formula renders as before. Images are handled by
+strip_document_images.lua.
+]]
+
+local TEX_FORMATS = {tex = true, latex = true, context = true}
+
+-- Pandoc folds the case of a format, and the markdown raw_attribute parser keeps
+-- it as written, so `{=LaTeX}` has to match too.
+local function is_tex(format)
+  return TEX_FORMATS[format:lower()] == true
+end
+
+-- A formula is the one thing of a document which the LaTeX writer emits
+-- verbatim, so it is held to a closed rule rather than to a list of the names
+-- which have been thought of. Two of the three rules below remove the ways a
+-- formula can name something it does not spell out, which is what makes the
+-- third one, a list, complete: what is left is the primitives themselves, and
+-- a formula cannot make more of those.
+
+-- 1. Names which the engine resolves to a file, and the machinery which builds
+--    a name out of parts, aliases one, or reads a character as another. Losing
+--    the machinery is what closes the list: `\@@input` was reached through
+--    `\makeatletter`, and `\input` spelled `^^5cinput` through the notation.
+local DENIED = {}
+for _, name in ipairs({
+  -- the engine reads, writes or runs something
+  "input", "endinput", "include", "includegraphics", "openin", "closein",
+  "read", "readline", "openout", "closeout", "write", "immediate", "special",
+  "font", "XeTeXpdffile", "XeTeXpicfile", "shellescape", "batchmode",
+  "usepackage", "RequirePackage", "InputIfFileExists", "IfFileExists",
+  "subfile", "import", "lstinputlisting", "verbatiminput",
+  -- a name is built, aliased, or a character is read as another
+  "csname", "expandafter", "scantokens", "string", "detokenize", "noexpand",
+  "primitive", "meaning", "catcode", "endlinechar", "newread", "newwrite",
+  "def", "edef", "gdef", "xdef", "let", "futurelet", "newcommand",
+  "renewcommand", "providecommand", "DeclareRobustCommand", "makeatletter",
+  "uppercase", "lowercase",
+}) do
+  DENIED[name] = true
+end
+
+local function names_a_denied_primitive(text)
+  for name in text:gmatch("\\([A-Za-z]+)") do
+    if DENIED[name] then
+      return true
+    end
+  end
+  return false
+end
+
+-- 2. `@` is a letter only while `\makeatletter` is in force, and that is how the
+--    kernel keeps its own names, `\@@input` among them, out of a document. A
+--    formula which carries the character is asking for that half of the kernel,
+--    so it is dropped. The commutative diagrams of amsmath use `@` too and are
+--    lost with it, which is the one thing this rule costs.
+local function reaches_for_the_kernel(text)
+  return text:find("@", 1, true) ~= nil
+end
+
+-- 3. TeX reads `^^` as the spelling of a character rather than as a superscript:
+--    `^^5c` is a backslash, and the wider forms of the engine tectonic builds on
+--    spell the same character as `^^^^005c`. A superscript of a superscript is
+--    an error in TeX, so no formula which renders today is lost.
+local function spells_a_character(text)
+  return text:find("^^", 1, true) ~= nil
+end
+
+local function is_safe_math(text)
+  return not (names_a_denied_primitive(text) or reaches_for_the_kernel(text) or spells_a_character(text))
+end
+
+function RawBlock(element)
+  if is_tex(element.format) then
+    return {}
+  end
+end
+
+function RawInline(element)
+  if is_tex(element.format) then
+    return {}
+  end
+end
+
+function Math(element)
+  if not is_safe_math(element.text) then
+    return {}
+  end
+end

--- a/filters/strip_raw_tex.lua
+++ b/filters/strip_raw_tex.lua
@@ -47,6 +47,12 @@ for _, name in ipairs({
   "input", "endinput", "include", "includegraphics", "openin", "closein",
   "read", "readline", "openout", "closeout", "write", "immediate", "special",
   "font", "XeTeXpdffile", "XeTeXpicfile", "shellescape", "batchmode",
+  -- A name matches as a whole run of letters, so the pdfTeX spellings are
+  -- listed rather than reached by their stem. This engine answers "undefined
+  -- control sequence" to all of them today, which is checked in the tests, so
+  -- the list is what keeps that from being a matter of which engine builds it.
+  "pdffiledump", "pdffilesize", "pdffilemoddate", "pdfmdfivesum",
+  "pdfshellescape", "pdfximage", "pdfrefximage", "pdfprimitive",
   "usepackage", "RequirePackage", "InputIfFileExists", "IfFileExists",
   "subfile", "import", "lstinputlisting", "verbatiminput",
   -- a name is built, aliased, or a character is read as another

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ test = [
     "pytest-cov==7.1.0",
     "pytest-timeout==2.4.0",
     "httpx==0.28.1",
+    "pypdf==6.16.0",  # reads the text of a produced PDF in the container tests
     "coverage==7.15.4",
 ]
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,14 +1,17 @@
 import io
 import logging
 import time
+import zipfile
 from pathlib import Path
 from typing import NamedTuple
 
 import docker
+import pytest
 import requests
 from docker.models.containers import Container
 from docx import Document
 from docx.shared import RGBColor
+from pypdf import PdfReader
 
 from tests.test_pptx_post_process import find_presentation_information
 
@@ -502,3 +505,188 @@ def test_convert_invalid_target_format(test_parameters: TestParameters) -> None:
         data="test content",
     )
     assert response.status_code == 400
+
+
+SOURCE_HTML_WITH_LOCAL_FILE_REFERENCES = """
+            <html>
+                <body>
+                    <p>A document naming resources of the container it is converted in.</p>
+                    <img src="/etc/hostname"/>
+                    <img src="file:///etc/hostname"/>
+                    <img src="/etc/passwd"/>
+                </body>
+            </html>
+            """
+
+
+def test_a_document_cannot_read_files_of_the_container(test_parameters: TestParameters) -> None:
+    """The sandbox keeps a document from naming a path of this container.
+
+    Without it, pandoc reads the file and embeds it in the result: an exfiltration
+    channel out of every deployment reachable by a caller.
+    """
+    response = __send_request(
+        base_url=test_parameters.base_url,
+        request_session=test_parameters.request_session,
+        source_format="html",
+        target_format="docx",
+        data=SOURCE_HTML_WITH_LOCAL_FILE_REFERENCES,
+    )
+    assert response.status_code == 200
+
+    with zipfile.ZipFile(io.BytesIO(response.content)) as docx:
+        embedded = [name for name in docx.namelist() if name.startswith("word/media/")]
+        assert embedded == [], f"the document pulled files of the container into the result: {embedded}"
+        document_xml = docx.read("word/document.xml").decode("utf-8")
+
+    assert "root:x:0:0" not in document_xml
+
+
+SOURCE_MARKDOWN_WITH_RAW_TEX = """Hello
+
+\\input{/etc/hostname}
+"""
+
+
+def test_a_document_cannot_reach_the_pdf_engine_with_raw_tex(test_parameters: TestParameters) -> None:
+    """The PDF is produced by tectonic, which runs outside the pandoc sandbox.
+
+    Raw TeX of the document is therefore dropped before it gets there, or
+    ``\\input{/etc/hostname}`` would put a file of the container into the PDF.
+    The document with the raw TeX has to render exactly like the one without it.
+    """
+
+    def text_of(markdown: str) -> str:
+        response = __send_request(
+            base_url=test_parameters.base_url,
+            request_session=test_parameters.request_session,
+            source_format="markdown",
+            target_format="pdf",
+            data=markdown,
+        )
+        assert response.status_code == 200
+        reader = PdfReader(io.BytesIO(response.content))
+        return "".join(page.extract_text() for page in reader.pages)
+
+    with_raw_tex = text_of(SOURCE_MARKDOWN_WITH_RAW_TEX)
+    without_raw_tex = text_of("Hello\n")
+
+    assert "Hello" in without_raw_tex
+    assert with_raw_tex == without_raw_tex
+
+
+SOURCE_MARKDOWN_WITH_TEX_IN_MATH = """Hello
+
+$\\input{/etc/hostname}$
+"""
+
+SOURCE_MARKDOWN_WITH_A_LOCAL_IMAGE = """Hello
+
+![](/opt/pandoc/.build_timestamp)
+"""
+
+
+def _pdf_text_and_images(test_parameters: TestParameters, markdown: str) -> tuple[str, int]:
+    """Convert a markdown source to PDF and report what the result carries."""
+    response = __send_request(
+        base_url=test_parameters.base_url,
+        request_session=test_parameters.request_session,
+        source_format="markdown",
+        target_format="pdf",
+        data=markdown,
+    )
+    assert response.status_code == 200
+    reader = PdfReader(io.BytesIO(response.content))
+    text = "".join(page.extract_text() for page in reader.pages)
+    return text, sum(_image_count(page) for page in reader.pages)
+
+
+def _image_count(page: object) -> int:
+    """Count the images of a page by its resources, which needs no image library."""
+    resources = page.get("/Resources")  # type: ignore[attr-defined]
+    if resources is None:
+        return 0
+    xobjects = resources.get_object().get("/XObject")
+    if xobjects is None:
+        return 0
+    return sum(1 for entry in xobjects.get_object().values() if entry.get_object().get("/Subtype") == "/Image")
+
+
+def test_math_cannot_carry_tex_to_the_pdf_engine(test_parameters: TestParameters) -> None:
+    """The writer emits math verbatim, so the same primitive inside $...$ takes the same route."""
+    with_tex, _ = _pdf_text_and_images(test_parameters, SOURCE_MARKDOWN_WITH_TEX_IN_MATH)
+    plain, _ = _pdf_text_and_images(test_parameters, "Hello\n")
+
+    assert with_tex == plain
+
+
+def test_a_document_cannot_put_a_file_of_the_container_into_a_pdf_as_an_image(test_parameters: TestParameters) -> None:
+    """An image path becomes \\includegraphics, which the engine outside the sandbox resolves."""
+    _, images = _pdf_text_and_images(test_parameters, SOURCE_MARKDOWN_WITH_A_LOCAL_IMAGE)
+
+    assert images == 0
+
+
+SOURCE_MARKDOWN_WITH_MIXED_CASE_RAW_TEX = """Hello
+
+```{=LaTeX}
+\\input{/etc/hostname}
+```
+"""
+
+SOURCE_MARKDOWN_WITH_AN_EMBEDDED_IMAGE = "Hello\n\n![](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII=)\n"
+
+
+def test_the_raw_tex_check_is_case_insensitive(test_parameters: TestParameters) -> None:
+    """Pandoc folds the case of a raw format, so `{=LaTeX}` takes the same route as `{=latex}`."""
+    with_raw_tex, _ = _pdf_text_and_images(test_parameters, SOURCE_MARKDOWN_WITH_MIXED_CASE_RAW_TEX)
+    plain, _ = _pdf_text_and_images(test_parameters, "Hello\n")
+
+    assert with_raw_tex == plain
+
+
+def test_an_image_carried_by_the_document_reaches_the_pdf(test_parameters: TestParameters) -> None:
+    """The positive side of the rule: what travels inside the document is kept."""
+    _, images = _pdf_text_and_images(test_parameters, SOURCE_MARKDOWN_WITH_AN_EMBEDDED_IMAGE)
+
+    assert images == 1
+
+
+MATH_WHICH_REACHES_FOR_A_FILE = {
+    "carets": "$^^5cinput{/etc/hostname}$",
+    "wide carets": "$^^^^005cinput{/etc/hostname}$",
+    "kernel name": "$\\makeatletter\\@@input{/etc/hostname}$",
+    "other kernel name": "$\\makeatletter\\@input{/etc/hostname}$",
+    "alias by def": "$\\def\\x{\\input}\\x{/etc/hostname}$",
+    "alias by let": "$\\let\\x\\input \\x{/etc/hostname}$",
+    "name built with csname": "$\\csname input\\endcsname{/etc/hostname}$",
+    "name built with scantokens": "$\\scantokens{\\string\\i nput{/etc/hostname}}$",
+    "a file read as a font": "$\\font\\x=/etc/hostname \\x$",
+    "a file embedded by the engine": '$\\XeTeXpdffile"/etc/hostname"$',
+}
+
+ORDINARY_MATH = {
+    "a power": "$E = mc^2$",
+    "a fraction, a greek letter and a sum": "$\\frac{a}{b} + \\alpha \\sum_{i=1}^{n} x_i$",
+    "a root and an integral": "$\\sqrt{x} \\int_0^\\infty e^{-t}\\,dt$",
+    "a matrix": "$\\begin{pmatrix} 1 & 0 \\\\ 0 & 1 \\end{pmatrix}$",
+    "text inside math": "$x \\text{ for all } x$",
+}
+
+
+@pytest.mark.parametrize("math", MATH_WHICH_REACHES_FOR_A_FILE.values(), ids=MATH_WHICH_REACHES_FOR_A_FILE.keys())
+def test_math_cannot_reach_a_file_however_it_spells_it(test_parameters: TestParameters, math: str) -> None:
+    """A formula may not name a primitive, build a name, or carry the `@` of the kernel."""
+    reaching, _ = _pdf_text_and_images(test_parameters, f"Hello\n\n{math}\n")
+    plain, _ = _pdf_text_and_images(test_parameters, "Hello\n")
+
+    assert reaching == plain
+
+
+@pytest.mark.parametrize("math", ORDINARY_MATH.values(), ids=ORDINARY_MATH.keys())
+def test_ordinary_math_still_reaches_the_pdf(test_parameters: TestParameters, math: str) -> None:
+    """The positive side of the rule: a formula which reaches for nothing renders as before."""
+    rendered, _ = _pdf_text_and_images(test_parameters, f"Hello\n\n{math}\n")
+    plain, _ = _pdf_text_and_images(test_parameters, "Hello\n")
+
+    assert rendered != plain

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,7 +1,9 @@
+import base64
 import io
 import logging
 import time
 import zipfile
+from collections.abc import Callable
 from pathlib import Path
 from typing import NamedTuple
 
@@ -10,6 +12,8 @@ import pytest
 import requests
 from docker.models.containers import Container
 from docx import Document
+from docx.document import Document as DocumentObject
+from docx.enum.style import WD_STYLE_TYPE
 from docx.shared import RGBColor
 from pypdf import PdfReader
 
@@ -663,6 +667,9 @@ MATH_WHICH_REACHES_FOR_A_FILE = {
     "name built with scantokens": "$\\scantokens{\\string\\i nput{/etc/hostname}}$",
     "a file read as a font": "$\\font\\x=/etc/hostname \\x$",
     "a file embedded by the engine": '$\\XeTeXpdffile"/etc/hostname"$',
+    # This engine answers "undefined control sequence" to the pdfTeX spellings,
+    # so the case holds that answer as much as it holds the rule.
+    "a pdftex file primitive": "$\\pdffiledump{0}{40}{/etc/hostname}$",
 }
 
 ORDINARY_MATH = {
@@ -690,3 +697,63 @@ def test_ordinary_math_still_reaches_the_pdf(test_parameters: TestParameters, ma
     plain, _ = _pdf_text_and_images(test_parameters, "Hello\n")
 
     assert rendered != plain
+
+
+A_PIXEL = base64.b64decode("iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII=")
+
+STYLE_NAMES_WHICH_CARRY_TEX = {
+    "a foreground which is not a colour": "PandocColor__FG_AAAAAA}{\\input{/etc/hostname}",
+    "a background which is not a colour": "PandocColor__BG_AAAAAA}{\\input{/etc/hostname}",
+}
+
+
+def _docx(build: Callable[[DocumentObject], None]) -> bytes:
+    """Build a DOCX in memory, which is how a caller of this service sends one."""
+    document = Document()
+    build(document)
+    written = io.BytesIO()
+    document.save(written)
+    return written.getvalue()
+
+
+def _pdf_of_docx(test_parameters: TestParameters, blob: bytes) -> tuple[str, int]:
+    """Convert a DOCX to PDF and report what the result carries."""
+    response = __send_request(
+        base_url=test_parameters.base_url,
+        request_session=test_parameters.request_session,
+        source_format="docx",
+        target_format="pdf",
+        data=("source.docx", blob, "application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+    )
+    assert response.status_code == 200
+    reader = PdfReader(io.BytesIO(response.content))
+    text = "".join(page.extract_text() for page in reader.pages)
+    return text, sum(_image_count(page) for page in reader.pages)
+
+
+@pytest.mark.parametrize("style_name", STYLE_NAMES_WHICH_CARRY_TEX.values(), ids=STYLE_NAMES_WHICH_CARRY_TEX.keys())
+def test_a_style_name_of_a_docx_cannot_carry_tex_to_the_pdf_engine(test_parameters: TestParameters, style_name: str) -> None:
+    """The colour filters emit raw LaTeX after the strip filter, so what they build has to be a colour."""
+
+    def with_the_style(document: DocumentObject) -> None:
+        style = document.styles.add_style(style_name, WD_STYLE_TYPE.CHARACTER)
+        run = document.add_paragraph().add_run("styled text")
+        run.style = style
+
+    text, _ = _pdf_of_docx(test_parameters, _docx(with_the_style))
+
+    assert "styled text" in text
+    assert test_parameters.container.id[:12] not in text, "the host name of the container reached the PDF"
+
+
+def test_an_image_of_a_docx_reaches_the_pdf(test_parameters: TestParameters) -> None:
+    """The positive side of the image rule: pandoc extracts it itself, so the media bag holds it."""
+
+    def with_an_image(document: DocumentObject) -> None:
+        document.add_paragraph("with an image")
+        document.add_picture(io.BytesIO(A_PIXEL))
+
+    text, images = _pdf_of_docx(test_parameters, _docx(with_an_image))
+
+    assert "with an image" in text
+    assert images == 1

--- a/tests/test_docx_colors_to_latex_filter.py
+++ b/tests/test_docx_colors_to_latex_filter.py
@@ -189,6 +189,24 @@ def test_non_matching_custom_style_is_left_alone(test_parameters: TestParameters
     assert "hello" in flat
 
 
+def test_a_style_name_which_is_not_a_colour_is_dropped(test_parameters: TestParameters):
+    """A DOCX may carry a style of this namespace with TeX in its name, and the
+    value reaches raw LaTeX which this filter emits after the strip filter has
+    run. Only six hex digits are written out.
+    """
+    flat = _md_to_latex(test_parameters.container, '[hello]{custom-style="PandocColor__FG_AAAAAA}{\\input{/etc/hostname}"}\n')
+    assert "\\input" not in flat
+    assert "\\textcolor" not in flat
+    assert "hello" in flat
+
+
+def test_a_background_which_is_not_a_colour_is_dropped(test_parameters: TestParameters):
+    flat = _md_to_latex(test_parameters.container, '[hello]{custom-style="PandocColor__BG_AAAAAA}{\\input{/etc/hostname}"}\n')
+    assert "\\input" not in flat
+    assert "\\colorbox" not in flat
+    assert "hello" in flat
+
+
 # ---------------------------------------------------------------------------
 # Highlight on bold/italic/underlined text — all boxed, uniform band height
 # ---------------------------------------------------------------------------

--- a/tests/test_pandoc_controller.py
+++ b/tests/test_pandoc_controller.py
@@ -616,7 +616,7 @@ def test_run_pandoc_conversion_with_string_input():
             assert result == b"Converted content"
 
             # Verify subprocess.run was called with correct args
-            expected_cmd = ["/usr/local/bin/pandoc", "-f", "markdown", "-t", "html", "-o", "output.html", "source.md"]
+            expected_cmd = ["/usr/local/bin/pandoc", "-f", "markdown", "-t", "html", "-o", "output.html", "source.md", "--sandbox"]
             mock_subprocess.assert_called_once_with(expected_cmd, check=True, shell=False, stdin=subprocess.PIPE)
 
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,122 @@
+"""Tests for the pandoc sandbox, which keeps a document from naming its own resources."""
+
+import pytest
+
+from app.pandoc_controller import FILTERS, _build_pandoc_command, is_sandbox_enabled
+
+
+def build(**overrides: object) -> list[str]:
+    """Build a conversion command with the arguments a plain HTML to DOCX run uses."""
+    arguments: dict[str, object] = {
+        "source_format": "html",
+        "target_format": "docx",
+        "source_path": "/tmp/source.html",
+        "output_path": "/tmp/output.docx",
+        "validated_options": [],
+        "apply_docx_latex_filters": False,
+    }
+    arguments.update(overrides)
+    return _build_pandoc_command(**arguments)  # type: ignore[arg-type]
+
+
+def test_sandbox_is_on_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PANDOC_SANDBOX", raising=False)
+
+    assert is_sandbox_enabled() is True
+    assert "--sandbox" in build()
+
+
+@pytest.mark.parametrize("value", ["true", "1", "yes", "on", "TRUE"])
+def test_sandbox_stays_on_for_truthy_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("PANDOC_SANDBOX", value)
+
+    assert "--sandbox" in build()
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", "off"])
+def test_sandbox_can_be_turned_off(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    """An operator who needs a document to load its own resources has to say so."""
+    monkeypatch.setenv("PANDOC_SANDBOX", value)
+
+    assert is_sandbox_enabled() is False
+    assert "--sandbox" not in build()
+
+
+@pytest.mark.parametrize(
+    ("source_format", "target_format"),
+    [("html", "docx"), ("html", "pdf"), ("docx", "pdf"), ("markdown", "html"), ("html", "pptx")],
+)
+def test_every_conversion_is_sandboxed(monkeypatch: pytest.MonkeyPatch, source_format: str, target_format: str) -> None:
+    monkeypatch.delenv("PANDOC_SANDBOX", raising=False)
+
+    assert "--sandbox" in build(source_format=source_format, target_format=target_format)
+
+
+def test_sandbox_leaves_the_other_arguments_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The flag is added, nothing else about the invocation changes."""
+    monkeypatch.setenv("PANDOC_SANDBOX", "false")
+    without = build(validated_options=["--toc"])
+    monkeypatch.setenv("PANDOC_SANDBOX", "true")
+    with_sandbox = build(validated_options=["--toc"])
+
+    assert [argument for argument in with_sandbox if argument != "--sandbox"] == without
+
+
+@pytest.mark.parametrize("value", ["enabled", " on ", "of", "", "  ", "yes please"])
+def test_a_value_which_is_not_understood_keeps_the_sandbox(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    """A typo must not open the service, which is what a plain truthy check would do."""
+    monkeypatch.setenv("PANDOC_SANDBOX", value)
+
+    assert is_sandbox_enabled() is True
+    assert "--sandbox" in build()
+
+
+@pytest.mark.parametrize("target_format", ["pdf", "latex"])
+def test_raw_tex_of_the_document_is_dropped_on_the_tex_paths(monkeypatch: pytest.MonkeyPatch, target_format: str) -> None:
+    """tectonic runs outside the sandbox and reads what the TeX names, so the TeX goes first."""
+    monkeypatch.delenv("PANDOC_SANDBOX", raising=False)
+    command = build(target_format=target_format)
+    strip = f"--lua-filter={FILTERS['strip_raw_tex']}"
+
+    assert strip in command
+    other_filters = [index for index, argument in enumerate(command) if argument.startswith("--lua-filter=") and argument != strip]
+    assert all(command.index(strip) < index for index in other_filters), "the raw TeX of the document is dropped before the filters which emit their own"
+
+
+@pytest.mark.parametrize("target_format", ["docx", "html", "pptx", "odt"])
+def test_the_other_targets_keep_their_raw_blocks(monkeypatch: pytest.MonkeyPatch, target_format: str) -> None:
+    monkeypatch.delenv("PANDOC_SANDBOX", raising=False)
+
+    assert f"--lua-filter={FILTERS['strip_raw_tex']}" not in build(target_format=target_format)
+
+
+def test_the_filter_is_not_added_without_the_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PANDOC_SANDBOX", "false")
+
+    assert f"--lua-filter={FILTERS['strip_raw_tex']}" not in build(target_format="pdf")
+
+
+@pytest.mark.parametrize("source_format", ["markdown", "html", "latex", "docx", "epub", "fb2"])
+def test_images_named_by_the_document_are_dropped_on_the_tex_paths(monkeypatch: pytest.MonkeyPatch, source_format: str) -> None:
+    """An image becomes \\includegraphics, and the engine resolving it reads a file of the container.
+
+    The filter asks the media bag rather than the source format, so an EPUB whose
+    XHTML names an address is covered like a markdown source is.
+    """
+    monkeypatch.delenv("PANDOC_SANDBOX", raising=False)
+
+    assert f"--lua-filter={FILTERS['strip_document_images']}" in build(source_format=source_format, target_format="pdf")
+
+
+def test_images_are_kept_on_the_other_targets(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PANDOC_SANDBOX", raising=False)
+
+    assert f"--lua-filter={FILTERS['strip_document_images']}" not in build(source_format="markdown", target_format="docx")
+
+
+def test_no_filter_is_added_without_the_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PANDOC_SANDBOX", "false")
+    command = build(target_format="pdf")
+
+    assert f"--lua-filter={FILTERS['strip_document_images']}" not in command
+    assert f"--lua-filter={FILTERS['strip_raw_tex']}" not in command

--- a/uv.lock
+++ b/uv.lock
@@ -584,6 +584,7 @@ test = [
     { name = "coverage" },
     { name = "docker" },
     { name = "httpx" },
+    { name = "pypdf" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -621,6 +622,7 @@ test = [
     { name = "coverage", specifier = "==7.15.4" },
     { name = "docker", specifier = "==7.2.0" },
     { name = "httpx", specifier = "==0.28.1" },
+    { name = "pypdf", specifier = "==6.16.0" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-asyncio", specifier = "==1.4.0" },
     { name = "pytest-cov", specifier = "==7.1.0" },
@@ -811,6 +813,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pypdf"
+version = "6.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/7f/5bc369dedae6750e23fc9ce82f6396258f92ed80ae0137732738a6d4ffce/pypdf-6.16.0.tar.gz", hash = "sha256:dfc5b0afeb5e02e9ee1dce71c09071f062d1a4030d2925f03a5daee0ee975ed8", size = 7002332, upload-time = "2026-08-13T14:54:41.586Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/83/2b04a77f8de3c6d295e2687228b21152cb65a406511373ed06fd757634af/pypdf-6.16.0-py3-none-any.whl", hash = "sha256:8c47581faa1cba7006ac269da30075c929c251cc4ffbafb2bcbe260306631118", size = 382160, upload-time = "2026-08-13T14:54:39.734Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Proposed changes

Closes #215. Supersedes #226, which carried the same work as two commits; this is the same change set as one, on top of the current main, so the review reads the result rather than the path to it.

A document names its own resources, and the writers which embed media fetched them. The issue carries the proof: a request reached my own server, its body landed in the returned DOCX as `word/media/rId9.txt`, and `<img src="/etc/passwd">` put the content of that file into the document.

**Pandoc runs sandboxed**, by default. `PANDOC_SANDBOX=false` restores the old reach for a deployment which needs it, and only an understood value turns it off: a typo such as `enabled` keeps the sandbox and says so in the log, because the other way round a misspelled variable would open the service quietly.

**The PDF target needed more.** A PDF is produced by handing the generated LaTeX to tectonic, which runs outside that sandbox and resolves what the TeX names. These routes reached it, each verified against this image before it was closed:

| Route | Verified | What is done |
|---|---|---|
| raw TeX, `\input{/tmp/leak}` | the file content rendered into the PDF | dropped before the LaTeX writer, case-insensitively, so `{=LaTeX}` is covered |
| the same primitive inside math, `$\input{...}$` | the content rendered, in math italics | that formula is held to the rule below |
| the primitive spelled with carets, `$^^5cinput{...}$`, or behind the kernel, `$\makeatletter\@@input{...}$` | the whole of `/etc/passwd` rendered, in math italics | the same rule, which is why it is a rule and not a list |
| an image named by address | the file was embedded as an image of the PDF | dropped unless the image travels inside the document |

The image rule asks pandoc's media bag rather than the source format, so an EPUB whose XHTML names an address is covered like a markdown source, while an image pandoc extracted from a DOCX still reaches the PDF. `--untrusted` was tried first and does not stop these reads.

What the DOCX filters of this service emit afterwards is untouched, so the colors, lists and tables of a DOCX export are unaffected. Verified inside the sandbox as well: the lua filters, `--reference-doc` templates, the tectonic engine and `data:` URI images all keep working.

**Math is the one thing the writer emits verbatim**, so it is held to a rule rather than to a list of the spellings which have been thought of. A scan for a literal `\input` was not enough twice over: TeX reads `^^5c` as a backslash, and the LaTeX kernel keeps `\@@input` behind `\makeatletter`, which reached tectonic and put the file into the PDF. A formula is dropped when it

1. names a primitive which reads, writes or runs something: `\input`, `\openin`, `\write`, `\font`, `\usepackage`, `\XeTeXpdffile` and the rest,
2. builds a name, aliases one, or reads a character as another: `\csname`, `\expandafter`, `\scantokens`, `\string`, `\def`, `\let`, `\catcode`, and the `^^` notation,
3. carries `@`, which is a letter only under `\makeatletter`.

Rule 2 is what makes rule 1 complete: a formula which cannot make a name cannot reach a primitive the list does not hold. Tectonic's own `--untrusted` does not help here, which I checked in the container: it reads `/etc/passwd` exactly as the default run does.

Ten spellings were verified dropped against a container built from this branch: both caret widths, `\@@input`, `\@input`, alias by `\def` and by `\let`, a name built with `\csname` and with `\scantokens`, a file read as a font, and `\XeTeXpdffile`. Five ordinary formulas render as before: a power, a fraction with a greek letter and a sum, a root and an integral, a matrix, and text inside math. The rule costs the commutative diagrams of amsmath, which spell their arrows `@>>>`.

Container tests hold the result end to end: a document naming files of the container, raw TeX in both cases, the ten spellings above, an image named by path, and the positive cases, the five formulas and an image carried as a `data:` URI.

The sibling change for the WeasyPrint service is SchweizerischeBundesbahnen/weasyprint-service#359, where the mechanism differs: WeasyPrint takes an injectable fetcher, pandoc does not.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation


