### PR TITLE
feat: reject an unauthenticated request before the body read

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ bash tests/shell/test_pandoc_service.sh
 - Input validation with 200MB request size limit
 - Format validation for source/target combinations
 - Optional TLS on both servers (`app/tls.py`): `TLS_CERT_FILE`, `TLS_KEY_FILE`, `TLS_KEY_PASSWORD`, `TLS_CLIENT_CA_FILE`, `TLS_CLIENT_AUTH` (none/optional/required) for the API, the same five with a `METRICS_TLS_` prefix for the metrics server, configured independently. Unset means plain HTTP (default); an incomplete configuration fails at startup rather than falling back, and the material is loaded before either server listens (`load_tls_options`), so a mismatched key or a wrong password also stops the start. The container healthcheck (`healthcheck.sh`) follows the configured scheme.
-- Optional API key on the conversion and template endpoints (`app/auth.py`): set `API_KEY` (comma-separated list allowed) and clients send `X-API-Key` or `Authorization: Bearer`. Unset means disabled, which is the default. `/health`, `/version`, `/static` and `/api/docs` stay open so the healthcheck keeps working.
+- Optional API key on the conversion and template endpoints (`app/auth.py`): set `API_KEY` (comma-separated list allowed) and clients send `X-API-Key` or `Authorization: Bearer`. Unset means disabled, which is the default. `/health`, `/version`, `/static` and `/api/docs` stay open so the healthcheck keeps working. The key is checked twice: the `check_api_key` middleware rejects a protected path before `check_request_size` buffers the body, and the route dependency stays for the OpenAPI schema and for a route the middleware misses. `app/auth.py` holds the protected paths (`is_protected_path`), so the two cannot drift apart.
 
 ### Conversion Pipeline
 1. Request validation (format, size, encoding)

--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ curl -X POST -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application
 
 A missing or invalid key answers `401 Unauthorized` in plain text, with the header `WWW-Authenticate: Bearer`. The key value is never written to the log.
 
+The check runs in a middleware, ahead of the request size check. An unauthenticated upload is therefore rejected before its body is buffered, so it costs no memory.
+
 ### Using as a Base Image
 
 To extend or customize the service, use it as a base image in the Dockerfile:

--- a/app/auth.py
+++ b/app/auth.py
@@ -9,6 +9,11 @@ Clients send the key in one of two headers:
 
 - ``X-API-Key: <key>``
 - ``Authorization: Bearer <key>``
+
+The key is checked twice. ``is_request_authorized`` serves the middleware,
+which rejects a request before its body is buffered. ``require_api_key`` is the
+route dependency, which documents both schemes in the OpenAPI schema and covers
+a route the middleware misses.
 """
 
 from __future__ import annotations
@@ -16,17 +21,27 @@ from __future__ import annotations
 import logging
 import os
 import secrets
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 logger = logging.getLogger(__name__)
 
 API_KEY_ENV_VAR = "API_KEY"
 API_KEY_HEADER_NAME = "X-API-Key"
+AUTHORIZATION_HEADER_NAME = "Authorization"
+BEARER_SCHEME = "bearer"
 
 UNAUTHORIZED_MESSAGE = "Invalid or missing API key"
+
+# The paths the key protects. The middleware and the route dependency read this
+# one definition, so the two cannot drift apart.
+PROTECTED_PATHS = frozenset({"/docx-template", "/pptx-template"})
+PROTECTED_PATH_PREFIXES = ("/convert/",)
 
 # auto_error=False keeps both schemes optional, so a missing header reaches
 # require_api_key instead of failing inside the security dependency.
@@ -98,6 +113,90 @@ def _matches_any(candidate: str, api_keys: tuple[str, ...]) -> bool:
     return matched
 
 
+def is_protected_path(path: str) -> bool:
+    """
+    Check whether a request path needs an API key.
+
+    A trailing slash is ignored, so the redirect variant of a path is treated
+    like the path itself.
+
+    Args:
+        path: Path of the incoming request.
+
+    Returns:
+        True if the path belongs to a protected endpoint.
+    """
+    return path.rstrip("/") in PROTECTED_PATHS or path.startswith(PROTECTED_PATH_PREFIXES)
+
+
+def _extract_credentials(headers: Mapping[str, str]) -> list[str]:
+    """
+    Collect the API keys a request presents.
+
+    The headers are read directly, which is what the middleware needs: it runs
+    before routing, so the security dependencies are not available there.
+
+    Args:
+        headers: Headers of the incoming request.
+
+    Returns:
+        Non-empty candidate keys, from the X-API-Key header and from a bearer
+        token in the Authorization header.
+    """
+    candidates = [headers.get(API_KEY_HEADER_NAME)]
+    authorization = headers.get(AUTHORIZATION_HEADER_NAME)
+    if authorization:
+        scheme, _, credentials = authorization.partition(" ")
+        if scheme.lower() == BEARER_SCHEME:
+            candidates.append(credentials.strip())
+    return [candidate for candidate in candidates if candidate]
+
+
+def _is_authorized(presented: list[str], api_keys: tuple[str, ...], path: str) -> bool:
+    """
+    Match the presented keys against the configured ones and log a rejection.
+
+    Both schemes are advertised as alternatives, so either credential admits
+    the request. A stale header next to a valid bearer token must not reject.
+
+    Args:
+        presented: Candidate keys the request carries.
+        api_keys: Configured keys.
+        path: Path of the request, logged on a rejection.
+
+    Returns:
+        True if one of the candidates matches a configured key.
+    """
+    matched = False
+    for candidate in presented:
+        if _matches_any(candidate, api_keys):
+            matched = True
+    if not matched:
+        # Never log the presented value, only the reason and the target path.
+        logger.warning("Rejected unauthenticated request to %s: %s", path, "invalid API key" if presented else "missing API key")
+    return matched
+
+
+def is_request_authorized(request: Request) -> bool:
+    """
+    Check a request before its body is read.
+
+    The middleware calls this ahead of the size check, so an unauthenticated
+    request costs no memory.
+
+    Args:
+        request: Incoming request.
+
+    Returns:
+        True if authentication is disabled, the path is open, or the request
+        carries a valid key.
+    """
+    api_keys = get_api_keys()
+    if not api_keys or not is_protected_path(request.url.path):
+        return True
+    return _is_authorized(_extract_credentials(request.headers), api_keys, request.url.path)
+
+
 def require_api_key(
     request: Request,
     header_key: Annotated[str | None, Depends(_api_key_header)] = None,
@@ -121,16 +220,6 @@ def require_api_key(
     if not api_keys:
         return
 
-    # Both schemes are advertised as alternatives, so either credential admits
-    # the request. A stale header next to a valid bearer token must not reject.
     presented = [candidate for candidate in (header_key, bearer.credentials if bearer else None) if candidate]
-    matched = False
-    for candidate in presented:
-        if _matches_any(candidate, api_keys):
-            matched = True
-    if matched:
-        return
-
-    # Never log the presented value, only the reason and the target path.
-    logger.warning("Rejected unauthenticated request to %s: %s", request.url.path, "invalid API key" if presented else "missing API key")
-    raise ApiKeyError
+    if not _is_authorized(presented, api_keys, request.url.path):
+        raise ApiKeyError

--- a/app/pandoc_controller.py
+++ b/app/pandoc_controller.py
@@ -21,7 +21,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 from prometheus_fastapi_instrumentator import Instrumentator
 
-from app.auth import ApiKeyError, get_api_keys, require_api_key
+from app.auth import ApiKeyError, get_api_keys, is_request_authorized, require_api_key
 from app.schema import VersionSchema
 from app.tls import API_TLS_PREFIX, METRICS_TLS_PREFIX, get_scheme, get_tls_options, load_tls_options
 
@@ -308,6 +308,22 @@ async def check_request_size(request: Request, call_next: Callable[[Request], Aw
     return await call_next(request)
 
 
+def api_key_error_response(exc: ApiKeyError) -> PlainTextResponse:
+    """Answer a rejected API key in plain text, like every other error of this service."""
+    return PlainTextResponse(content=exc.detail, status_code=exc.status_code, headers=exc.headers)
+
+
+# Registered after the size check, so it wraps it and runs first: an
+# unauthenticated request is rejected before check_request_size buffers its
+# body, and therefore costs no memory.
+@app.middleware("http")
+async def check_api_key(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+    if not is_request_authorized(request):
+        return api_key_error_response(ApiKeyError())
+
+    return await call_next(request)
+
+
 # Replace standard request validation error handler to adhere to the PlainText format
 @app.exception_handler(RequestValidationError)
 async def handle_validation_error(request: Request, exc: RequestValidationError) -> PlainTextResponse:  # noqa: ARG001
@@ -318,10 +334,10 @@ async def handle_validation_error(request: Request, exc: RequestValidationError)
     )
 
 
-# Answer a rejected API key in plain text, like every other error of this service
+# The route dependency stays in place for a route the middleware does not cover
 @app.exception_handler(ApiKeyError)
 async def handle_api_key_error(request: Request, exc: ApiKeyError) -> PlainTextResponse:  # noqa: ARG001
-    return PlainTextResponse(content=exc.detail, status_code=exc.status_code, headers=exc.headers)
+    return api_key_error_response(exc)
 
 
 def get_pandoc_version() -> str | None:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -7,13 +7,15 @@ from fastapi import Depends, FastAPI
 from starlette.responses import Response
 from starlette.testclient import TestClient
 
-from app.auth import API_KEY_ENV_VAR, get_api_keys, is_auth_enabled, require_api_key
+from app import pandoc_controller
+from app.auth import API_KEY_ENV_VAR, get_api_keys, is_auth_enabled, is_protected_path, require_api_key
 from app.pandoc_controller import app
 
 SIMPLE_HTML = "<html><body><h1>Hello</h1></body></html>"
+CONVERT_HTML_TO_DOCX = "/convert/html/to/docx"
 
 PROTECTED_ENDPOINTS = [
-    ("post", "/convert/html/to/docx"),
+    ("post", CONVERT_HTML_TO_DOCX),
     ("post", "/convert/html/to/docx-with-template"),
     ("post", "/convert/html/to/pptx-with-template"),
     ("get", "/docx-template"),
@@ -168,8 +170,8 @@ def test_conversion_accepts_valid_key(monkeypatch: pytest.MonkeyPatch) -> None:
         patch("app.pandoc_controller.postprocess_and_build_response", return_value=Response(b"DOCX content")),
         TestClient(app) as test_client,
     ):
-        assert test_client.post("/convert/html/to/docx", content=SIMPLE_HTML, headers={"X-API-Key": "secret"}).status_code == 200
-        assert test_client.post("/convert/html/to/docx", content=SIMPLE_HTML, headers={"Authorization": "Bearer secret"}).status_code == 200
+        assert test_client.post(CONVERT_HTML_TO_DOCX, content=SIMPLE_HTML, headers={"X-API-Key": "secret"}).status_code == 200
+        assert test_client.post(CONVERT_HTML_TO_DOCX, content=SIMPLE_HTML, headers={"Authorization": "Bearer secret"}).status_code == 200
 
 
 def test_conversion_open_without_key(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -179,4 +181,59 @@ def test_conversion_open_without_key(monkeypatch: pytest.MonkeyPatch) -> None:
         patch("app.pandoc_controller.postprocess_and_build_response", return_value=Response(b"DOCX content")),
         TestClient(app) as test_client,
     ):
-        assert test_client.post("/convert/html/to/docx", content=SIMPLE_HTML).status_code == 200
+        assert test_client.post(CONVERT_HTML_TO_DOCX, content=SIMPLE_HTML).status_code == 200
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/convert/html/to/docx", True),
+        ("/convert/html/to/docx-with-template", True),
+        ("/convert/html/to/pptx-with-template", True),
+        ("/convert/html/to/unknown", True),
+        ("/docx-template", True),
+        ("/pptx-template", True),
+        ("/docx-template/", True),
+        ("/health", False),
+        ("/version", False),
+        ("/static/openapi.json", False),
+        ("/api/docs", False),
+        ("/", False),
+        ("/converted", False),
+    ],
+)
+def test_is_protected_path(path: str, expected: bool) -> None:
+    assert is_protected_path(path) is expected
+
+
+def test_unauthenticated_oversized_body_is_rejected_before_the_size_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The key is vetted first, so an anonymous upload never reaches the body buffer."""
+    monkeypatch.setenv(API_KEY_ENV_VAR, "secret")
+    monkeypatch.setattr(pandoc_controller, "data_limit", 10)
+    with TestClient(app) as test_client:
+        response = test_client.post(CONVERT_HTML_TO_DOCX, content=b"x" * 100)
+        assert response.status_code == 401
+        assert response.headers["WWW-Authenticate"] == "Bearer"
+
+
+def test_authenticated_oversized_body_still_hits_the_size_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(API_KEY_ENV_VAR, "secret")
+    monkeypatch.setattr(pandoc_controller, "data_limit", 10)
+    with TestClient(app) as test_client:
+        response = test_client.post(CONVERT_HTML_TO_DOCX, content=b"x" * 100, headers={"X-API-Key": "secret"})
+        assert response.status_code == 413
+
+
+def test_open_path_keeps_the_size_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An open endpoint is not touched by the key check, only by the size check."""
+    monkeypatch.setenv(API_KEY_ENV_VAR, "secret")
+    monkeypatch.setattr(pandoc_controller, "data_limit", 10)
+    with TestClient(app) as test_client:
+        assert test_client.post("/version", content=b"x" * 100).status_code == 413
+
+
+def test_unknown_protected_path_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The middleware answers before routing, so an unrouted convert path also needs the key."""
+    monkeypatch.setenv(API_KEY_ENV_VAR, "secret")
+    with TestClient(app) as test_client:
+        assert test_client.post("/convert/html/to/unknown", content=SIMPLE_HTML).status_code == 401


### PR DESCRIPTION
Closes #219.

## Problem

The API key is a route dependency, so it runs after routing. The size-limit middleware reads the whole body first, so an anonymous request costs up to `REQUEST_BODY_LIMIT_MB` of memory before the 401.

## Change

- `check_api_key` middleware, registered after `check_request_size` so it wraps it and runs first. A protected path without a valid key answers 401 before the body is buffered.
- `app/auth.py` holds the protected paths (`is_protected_path`): `/convert/...`, `/docx-template`, `/pptx-template`. The middleware and the dependency read the same definition.
- The route dependency stays, so the OpenAPI schema keeps documenting both schemes and a route added later stays protected.
- The rejection stays plain text with `WWW-Authenticate: Bearer`. The matching and logging logic is shared, so the middleware and the dependency answer alike.

## Tests

New cases in `tests/test_auth.py`: the path table, an oversized anonymous body answering 401 instead of 413, an authenticated oversized body still answering 413, and an open path keeping the size limit.